### PR TITLE
Plan: Block Editor Docs Health Monitor — PoC design

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,138 +1,155 @@
-# WP Docs Health Monitor — PoC Plan
+# WP Docs Health Monitor — Plan
 
-> **Reading order:** start here for the overview. Technical details → [docs/architecture.md](./docs/architecture.md). Tasks (what to build) → [docs/backlog.md](./docs/backlog.md). Schedule (when to build it) → [docs/timeline.md](./docs/timeline.md).
+> **Reading order:** start here for the overview. Components and issues → [docs/backlog.md](./docs/backlog.md). Schedule → [docs/timeline.md](./docs/timeline.md). Technical details → [docs/architecture.md](./docs/architecture.md).
+
+---
+
+## Contents
+
+- [Context](#context)
+- [Constraints](#constraints)
+- [Key Components](#key-components)
+  - [1. Project Foundation](#1-project-foundation)
+  - [2. Doc Ingestion](#2-doc-ingestion-docsource)
+  - [3. Code Ingestion](#3-code-ingestion-codesource)
+  - [4. Doc–Code Mapping](#4-doccode-mapping-doccodemapper)
+  - [5. Drift Validator](#5-drift-validator)
+  - [6. Dashboard + CLI](#6-dashboard--cli)
+  - [7. GitHub Pages Publish](#7-github-pages-publish)
+- [Component Dependency Map](#component-dependency-map)
+- [Phase 1 — PoC](#phase-1--poc)
+- [Phase 2 — Scale to Full Block Editor Handbook](#phase-2--scale-to-full-block-editor-handbook)
+- [Post-Phase 2](#post-phase-2-not-committed)
+- [Open Questions](#open-questions)
+
+---
 
 ## Context
 
 **End goal:** Keep WordPress-hosted documentation sites (developer.wordpress.org, WooCommerce docs, internal A8C docs, etc.) accurate and up-to-date against the code they describe. Docs on those sites come from two kinds of sources:
 
-1. **Markdown in a source repo** that gets synced to a WordPress site (e.g. Gutenberg's `docs/` → developer.wordpress.org Block Editor Handbook CPTs).
-2. **Custom posts edited directly in WordPress** — no git, authors write inside wp-admin (common for WooCommerce, internal A8C docs, and self-managed handbooks).
+1. **Markdown in a source repo** synced to a WordPress site (e.g. Gutenberg's `docs/` → developer.wordpress.org Block Editor Handbook).
+2. **Custom posts edited directly in WordPress** — no git, authors write inside wp-admin.
 
-Both paths drift from the code silently. No one today has a prioritized punch list of what's wrong on those WordPress sites.
+Both paths drift from the code silently. No one today has a prioritized punch list of what's wrong on those sites.
 
-This project ships an automated tool that:
-- Pulls docs from either source (markdown repo OR a WordPress REST API).
-- Pulls the related source code.
-- Uses Claude to compare them and produce evidence-backed issues with health scores.
-- Renders a static dashboard doc authors can act on.
-
-The blog post at https://radicalupdates.wordpress.com/2026/04/15/block-editor-docs-health-monitor/ sets the north star (weekly runs, $0.50/week after change-detection caching, CI/CD for docs). The project should eventually feed fixes back into either source type — a PR for markdown, a WordPress post update for direct-edit sites.
+This project ships an automated tool that pulls docs and code, uses Claude to compare them, and renders a static dashboard doc authors can act on.
 
 ## Constraints
 
-- **Week 1 PoC deadline:** ~2026-04-27 (one week from kickoff). Aggressive scope discipline.
-- Small validatable first iteration (~10 docs) but **architecture designed to scale to ~200 docs/site**.
-- **"Docs might be OK" is a valid outcome** — the tool must confidently report *healthy* when nothing is wrong, not just find issues. Recall (did we miss drift?) matters as much as precision (is what we found real?).
-- Two developers working in parallel — cleanly separable, independently shippable issues.
-- Vertical split: Track A owns the analysis pipeline, Track B owns CLI + dashboard + config. Either dev can own either track — both using Claude Code.
-- **Public GitHub repo + GitHub Pages** for the dashboard. Dashboard is the product — overall health %, per-doc detail pages with evidence and proposed actions, informational (no gamification).
-- Quality first, cost secondary. Flag if costs go off rails (rough guardrail: < $5 per full 10-doc PoC run).
+- Aggressive scope discipline — small, validatable first iteration (~10 docs) with architecture designed to scale to ~200 docs/site.
+- **"Docs might be OK" is a valid outcome** — the tool must confidently report *healthy* when nothing is wrong. Recall matters as much as precision.
+- Two developers working in parallel on cleanly separable tracks: **Track A** (analysis pipeline) and **Track B** (CLI + dashboard + config).
+- Public GitHub repo + GitHub Pages for the dashboard. The dashboard is the product — overall health %, per-doc detail pages with evidence and proposed actions, informational (no gamification).
+- Quality first, cost secondary. Rough guardrail: < $5 per full run at scale.
 
-## Targets
+## Key Components
 
-**Phase 1 (Week 1, PoC):** ~10 docs from the Gutenberg Block API Reference (https://developer.wordpress.org/block-editor/reference-guides/block-api/) — e.g. `block-metadata`, `block-registration`, `block-attributes`, `block-supports`, `block-variations`, `block-context`, `block-deprecation`, `block-transforms`, `block-patterns`, `block-bindings`. Tight mappings to `packages/blocks/src/api/*` and `schemas/json/block.json`. Code source: **gutenberg only**. Manual mapping. Proves the pipeline.
+Six building blocks, each a discrete issue or group of issues:
 
-**Phase 2 (Weeks 2–4, month-end target):** Scale to the **full Block Editor Handbook** — ~150 editorial docs (filter out auto-generated package READMEs). Build the `symbol-search` mapper so we don't hand-curate 150 entries. Harden the dashboard for scale. Ship a **GitHub Action with a weekly cron** that runs the pipeline and auto-deploys the dashboard to GitHub Pages — the cron is what makes "CI/CD for docs" real, not a manual habit.
+### 1. Project Foundation
+Establishes the shared contract that lets both tracks work in parallel from day one — shared type contracts, zod schemas, CLI entry stub, and a mock fixture that validates all schemas. Without this, both tracks would be guessing at interfaces and stepping on each other.
 
-**Post-month (not committed):** `wordpress-rest` DocSource, second handbook (e.g. Themes Handbook — assuming it's actually WP-edited and not markdown-sourced), `fs-walk` adapter, source-type awareness in the dashboard, `a8c-context` MCP adapter. Architecturally supported since Week 1, but deliberately deferred so month-end stays achievable.
+**Connects to:** all other components.
 
-## Architecture at a Glance
+### 2. Doc Ingestion (`DocSource`)
+Answers "what docs exist and what do they say?" — pulling documentation from a source into a normalised `Doc[]` and abstracting away where they live. In Phase 1 docs come from a Gutenberg-style `manifest.json`; later they may come from a WordPress REST API. Everything downstream receives the same normalised `Doc` regardless of origin.
 
-Pluggable adapters around a stateless pipeline:
+**Connects to:** Mapper, Validator.
+
+### 3. Code Ingestion (`CodeSource`)
+Answers "what does the code actually say right now?" — fetching and caching source files so the Validator has exact, current file contents to compare against. Abstracting this out means the pipeline can later support multiple repos or local paths without touching the Validator. Phase 1: shallow-clone via git.
+
+**Connects to:** Mapper, Validator.
+
+### 4. Doc–Code Mapping (`DocCodeMapper`)
+Tells the Validator *which* code files are relevant to each doc — the bridge between the documentation world and the source world. Without this, the Validator would have no idea where to look. Phase 1 uses a hand-curated slug-keyed JSON file with tiered relevance (`primary`, `secondary`, `context`); Phase 2 automates this with symbol extraction and AST search so it scales beyond what a human can maintain.
+
+**Connects to:** Validator.
+
+### 5. Drift Validator
+The core analysis step: determines whether each doc accurately describes the code it maps to, and produces evidence-backed findings a doc author can act on. Claude reads doc + code together, identifies specific claims that are wrong or outdated, and scores each finding by severity and confidence. It also surfaces what *is* correct — so the output is an honest health report, not just a bug list. Issues with unsupported or low-confidence findings are filtered out before results are written.
+
+**Depends on:** Doc Ingestion, Code Ingestion, Mapping.  
+**Connects to:** results.json, which feeds the Dashboard.
+
+### 6. Dashboard + CLI
+Makes findings useful to doc authors, not just developers. The CLI runs the pipeline on demand and writes `results.json`; the dashboard turns those results into a browsable static site — overall health at a glance, per-folder rollups, and per-doc detail pages with quoted evidence and proposed fixes. The dashboard is the product: it's what a doc author opens to decide what to work on next. Track B builds this against the mock fixture from Foundation and never waits for the pipeline.
+
+**Depends on:** Project Foundation (mock fixture). Swaps to real results once the Validator lands.  
+**Connects to:** GitHub Pages publish.
+
+### 7. GitHub Pages Publish
+Makes the dashboard publicly reachable and persistent. A single command pushes the generated site to the `gh-pages` branch while preserving prior run data for future historical views. Phase 2 automates this step via a GitHub Action on a weekly cron.
+
+**Depends on:** Dashboard.
+
+---
+
+## Component Dependency Map
 
 ```
-         ┌──────────────────────────────────────────┐
-         │  config.yml (project, sources, mapping)   │
-         └────────────────────┬──────────────────────┘
-                              ▼
-  ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-  │  DocSource  │     │ CodeSource  │     │DocCodeMapper│
-  │  (adapter)  │     │  (adapter)  │     │  (adapter)  │
-  └──────┬──────┘     └──────┬──────┘     └──────┬──────┘
-         │                   │                   │
-         ▼                   ▼                   ▼
-    docs[]              code files          doc→code[] pairs
-                              │
-                              ▼
-                    ┌──────────────────┐
-                    │    Validator     │  (Claude, two-pass,
-                    │    (adapter)     │   prompt-cached)
-                    └────────┬─────────┘
-                             ▼
-                       issues[] + scores
-                             │
-                             ▼
-                      results.json
-                             │
-              ┌──────────────┴──────────────┐
-              ▼                             ▼
-      Dashboard Generator             CLI/Action
-      (static HTML)                   (orchestration)
+Foundation
+  ├→ Doc Ingestion ──┐
+  ├→ Code Ingestion ─┤
+  ├→ Mapping ────────┴→ Validator → results.json ─→ Dashboard → Publish
+  └→ Dashboard (mock)────────────────────────────→ Dashboard
 ```
 
-| Interface        | Phase 1 (PoC, Week 1)     | Phase 2 (committed, Weeks 2–4) | Post-month / Later stubs              |
-|------------------|-------------------|--------------------------|--------------------------|
-| `DocSource`      | `manifest-url` (consumes Gutenberg-style `manifest.json`) | (reuse `manifest-url`) | `wordpress-rest` (D1), `fs-walk` (D4), `a8c-context` (D5), `sitemap-crawler` |
-| `CodeSource`     | `git-clone`       | (reuse)                  | `multi-repo`, `local-path` |
-| `DocCodeMapper`  | `manual-map` (slug-keyed JSON, tiered) + LLM-bootstrap helper | `symbol-search` (M1) | `hybrid`, `embedding-retrieval` |
-| `Validator`      | `claude`          | (reuse)                  | (only one needed)         |
+Track B (Dashboard) builds against the mock from Foundation and never waits for Track A (pipeline components).
 
-Unimplemented Later-stub adapters throw `NotImplementedError` — documents the extension surface without adding dead code.
+---
 
-Full technical details (schemas, repo layout, mapping format, tech stack) → [docs/architecture.md](./docs/architecture.md).
+## Phase 1 — PoC
 
-Issue-level plan with owners, deps, and acceptance criteria → [docs/backlog.md](./docs/backlog.md).
+**Scope:** ~10 docs from the Gutenberg Block API Reference, analyzed end-to-end, with a live public dashboard.
 
-## Phase 2 — Scale-up to Full Block Editor Handbook (Weeks 2–4)
+**In scope:**
+- All six components above, with Phase 1 adapters (`manifest-url`, `git-clone`, `manual-map`, `claude` validator).
+- A Phase 0 validation gate: run the validator on 3 docs (one known-drifted, one known-clean, one uncertain) and measure precision ≥80%, recall ≥70%, zero false positives on the clean doc before proceeding to the full run.
+- A manual mapping file seeded for the ~10 Block API Reference slugs.
 
-Committed. Breaks into issues at Week-2 kickoff; coarse milestones here:
+**Out of scope for Phase 1:**
+- GitHub Action / weekly cron — deferred to Phase 2.
+- `symbol-search` mapper — Phase 1 uses manual mapping.
+- Historical dashboard UI — data groundwork ships in Phase 1; UI needs multiple runs.
+- `wordpress-rest`, `fs-walk`, `a8c-context` DocSources — interfaces defined; implementations deferred.
+- Auto-generated package READMEs — low drift signal, excluded.
 
-- **M1** `symbol-search` Mapper — extract symbols from each doc (function names, types, hooks, attribute names, code-block imports); AST-grep Gutenberg via `ast-grep`/`tree-sitter`; rank by specificity × centrality × recency; output tiered `MappingSchema`. Validated against Week-1 manual mappings (≥70% agreement on `primary`).
-- **M2** Editorial-only filter in `manifest-url` — exclude `packages/*/README.md` and `packages/components/src/*/README.md`. Filters ~424 → ~150 docs.
-- **M3** Pipeline at scale — raise concurrency, add per-run cost meter with a hard stop at $5 (configurable), checkpoint results after each doc so a crash doesn't restart the whole run.
-- **M4** Dashboard at scale — tree collapse, search/filter by status, page loads <1s with 150 docs.
-- **M5** Full-handbook run + publish — one production-shaped run on all ~150 docs, manual spot-check of ~20 issues, published to `https://juanma-wp.github.io/wp-docs-health-monitor/`.
-- **M6** Runbook — documented procedure for manual one-off runs (backup path when the Action is down or under development).
-- **M7** GitHub Action with weekly cron — `.github/workflows/analyze-docs.yml` with `workflow_dispatch` for manual dispatch and `schedule: cron: '0 6 * * 1'` (Mondays 06:00 UTC) for the weekly run. Uses an `ANTHROPIC_API_KEY` repo secret, uploads `results.json` as an artifact, and auto-deploys the dashboard to GitHub Pages via the `actions/deploy-pages` flow. One green scheduled run is the acceptance bar.
-- **M8** Historical dashboard — each run archived as `data/runs/<runId>/results.json` on the `gh-pages` branch. Dashboard shows a trend line of overall health, "new this week" / "persistent for N runs" badges on issues (using stable `Issue.fingerprint` hashes), and a per-doc sparkline. Data-model groundwork ships with S-track in Week 1; UI lands in Phase 2 once there are 2–3 runs to draw on.
+---
 
-## Post-month (not committed, deliberately deferred)
+## Phase 2 — Scale to Full Block Editor Handbook
 
-Architecture supports these; we defer to keep month-end achievable. Promote to committed once the month-end demo lands.
+**Scope:** ~150 editorial Block Editor Handbook docs, weekly automated runs, historical dashboard.
 
-- **D1** `wordpress-rest` DocSource: pagination, HTML→markdown normalization, Application Password auth. Produces a manifest-shaped list from a live WP site.
-- **D2** Second handbook PoC: **Themes Handbook** (if actually WP-edited and not markdown-sourced — verify first) or a WooCommerce docs page, through `wordpress-rest`.
-- **D3** Source-type awareness in dashboard: label docs "markdown" / "wordpress", deep-link to WP edit URL for WP-sourced docs.
-- **D4** `fs-walk` DocSource for markdown repos without a manifest.
-- **D5** `a8c-context` DocSource variant (context-a8c MCP for A8C-internal sites).
+**Key additions over Phase 1:**
+- **`symbol-search` Mapper** — replaces manual mapping at scale. Extracts symbols from each doc, finds their definitions in the Gutenberg AST, tiers results. Validated against Phase 1 manual mappings.
+- **Editorial filter** — excludes auto-generated package READMEs from the manifest (~424 → ~150 docs).
+- **Pipeline hardening** — higher concurrency, per-run cost cap, checkpointing so a crash resumes rather than restarts.
+- **Dashboard at scale** — tree collapse, search/filter, page loads <1s with 150 docs.
+- **GitHub Action with weekly cron** — automated Monday runs, deploys to GitHub Pages, enforces cost cap. Manual `workflow_dispatch` also supported.
+- **Historical UI** — trend line of overall health across runs, "new this week" / "persistent N runs" badges on issues using stable fingerprint hashes.
 
-## Stretch — nice to have
+---
 
-- **S3** Change Detector: diffs last-analyzed commit SHA vs current, queues only changed docs + docs whose mapped code changed. Biggest cost lever per the blog post.
-- **S7** Slug-rename lint: warn when `mapping.json` keys aren't in the current manifest.
-- **S8** Round-trip: open a GitHub PR on the markdown source (or draft a WP post update via REST) for issues above a confidence threshold.
+## Post-Phase 2 (not committed)
 
-*(S5 promoted to committed Phase 2 as M1 `symbol-search` mapper. S6 trend tracking now covered by committed M8 historical dashboard.)*
+Architecture supports these; deferred until the Phase 2 demo lands.
 
-## Out of Scope for PoC (Week 1)
+- **`wordpress-rest` DocSource** — pull docs from a live WordPress site via REST API with Application Password auth.
+- **Second handbook** — Themes Handbook (if WP-edited) or WooCommerce docs through `wordpress-rest`.
+- **Source-type awareness** — label docs "markdown" / "wordpress" in the dashboard; deep-link to WP edit URL for WP-sourced docs.
+- **`fs-walk` DocSource** — markdown repos without a manifest.
+- **`a8c-context` DocSource** — context-a8c MCP for A8C-internal sites.
+- **Fix round-trip** — open a GitHub PR (markdown source) or draft a WP post update (REST) for issues above a confidence threshold.
+- **Change detector** — diff last-analyzed SHA vs current, queue only changed docs. Biggest cost lever.
 
-- GitHub Action workflow and weekly cron — Week 1 out of scope; lands in Phase 2 (M7).
-- `symbol-search` mapper — Week 1 uses manual mapping; `symbol-search` lands in Phase 2 (M1).
-- Historical dashboard UI — Week 1 ships the data-model groundwork; UI lands in Phase 2 (M8).
-- `wordpress-rest` / `fs-walk` / `a8c-context` DocSources — interfaces defined; implementations post-month.
-- `hybrid` / `embedding-retrieval` mappers — interface-compatible; implementations post-month.
-- Auto-generated package READMEs (`packages/*/README.md`) — most are docgen output, low drift signal.
-- Auto-PRs with fixes, screenshots/image link-checking, multi-handbook coverage.
-- Fine-tuning — off-the-shelf Claude Sonnet 4.6.
-- PHP / wordpress-develop code source — gutenberg repo only in Week 1.
-- Slug-rename detection, gamification.
+---
 
-## Open Questions (non-blocking)
+## Open Questions
 
-- **Known-clean controls in the 10 docs:** which 1–2 of the chosen Block API docs are known to be accurate? Include them on purpose so recall measurement has a baseline.
-- **Editorial-only filter rules:** are all `packages/*/README.md` truly auto-generated docgen output? Confirm before M2 excludes them wholesale — a false exclusion hides real drift.
-- **Themes Handbook source model:** verify whether it's markdown-sourced or actually WP-edited. Answer gates whether D3 becomes a meaningful `wordpress-rest` demo or just another markdown handbook.
-- **Fix round-trip (S8):** auto-open PRs / draft WP post updates, or stay strictly read-only? Auto-PRs change the trust bar significantly.
-- **Markdown↔WP drift:** when both a markdown source AND a WP-edited post exist for the same doc, they can drift from *each other*. Worth flagging as a real failure mode for later.
-- **Bifrost P2 / Radical Speed Month framing:** does the month-end demo need to hit a specific forum or write-up beyond the generic "publish + share link" bar?
+- **Known-clean controls:** which 1–2 of the chosen Block API docs are known-accurate? Include them explicitly so recall measurement has a baseline.
+- **Editorial-only filter rules:** are all `packages/*/README.md` truly auto-generated? Confirm before Phase 2 excludes them wholesale — a false exclusion hides real drift.
+- **Themes Handbook source model:** verify whether it's markdown-sourced or WP-edited. Answer gates whether D3 becomes a meaningful `wordpress-rest` demo.
+- **Fix round-trip (stretch):** auto-open PRs / draft WP post updates, or stay strictly read-only? Auto-PRs change the trust bar significantly.
+- **Markdown↔WP drift:** when both a markdown source AND a WP-edited post exist for the same doc, they can drift from *each other*. Worth flagging as a failure mode for later.

--- a/PLAN.md
+++ b/PLAN.md
@@ -67,12 +67,51 @@ Pluggable adapters around a stateless pipeline:
 |------------------|-------------------|--------------------------|--------------------------|
 | `DocSource`      | `markdown-git`    | `wordpress-rest`         | `sitemap-crawler`, `local-markdown`, `a8c-context` |
 | `CodeSource`     | `git-clone`       | (reuse)                  | `multi-repo`, `local-path` |
-| `DocCodeMapper`  | `manual-map` (YAML) | (reuse)                | `symbol-search`, `embedding-retrieval` |
+| `DocCodeMapper`  | `manual-map` (tiered YAML) + LLM-bootstrap helper | (reuse) | `symbol-search`, `embedding-retrieval`, `hybrid` |
 | `Validator`      | `claude`          | (reuse)                  | (only one needed)         |
 
 The registry lives in `packages/core/src/adapters/index.ts`. Unimplemented Later-stub adapters throw `NotImplementedError` — this documents the extension surface without adding dead code.
 
 **`wordpress-rest` DocSource** (Phase 2) fetches via `GET /wp-json/wp/v2/<post_type>?per_page=100` with pagination, unwraps rendered HTML back to a markdown-equivalent structure (via `turndown` or `node-html-parser` + a light converter), and returns the same `Doc[]` shape as `markdown-git` so every downstream stage is source-agnostic. Auth via Application Passwords for private sites; for A8C-internal sites, delegate to the `context-a8c` MCP (a separate adapter variant).
+
+## Doc ↔ Code Mapping
+
+The relationship is **many-to-many**: one doc typically references multiple source files (e.g. `block-metadata.md` touches `registration.js`, `parser.js`, `process-block-type.js`, `schemas/json/block.json`, and PHP side in WP core), and one source file is referenced by multiple docs.
+
+### Tiered mapping schema
+
+To handle this without blowing the token budget, mappings are **tiered**:
+
+```yaml
+# mappings/block-api.yml
+- doc: reference-guides/block-api/block-metadata.md
+  code:
+    primary:      # always sent to the validator — source of truth for this doc
+      - packages/blocks/src/api/registration.js
+      - schemas/json/block.json
+    secondary:    # usually sent — supporting context that catches most real drift
+      - packages/blocks/src/api/parser.js
+      - packages/blocks/src/api/process-block-type.js
+    context:      # dropped first when the budget is tight; re-fetched on demand in Pass 2
+      - packages/block-editor/src/components/block-edit/index.js
+```
+
+The validator starts with `primary + secondary`, adds `context` if budget allows, and in Pass 2 can targeted-fetch additional files by path (retrieval-on-demand rather than pre-loading everything). That shape generalizes to thousands of docs later.
+
+### LLM-assisted bootstrap
+
+Hand-writing mappings doesn't scale past ~50 docs. We keep the YAML as source of truth but add a one-shot dev-time helper: `scripts/bootstrap-mapping.ts <doc-path>` asks Claude *"given this doc and this file tree, which files are `primary`/`secondary`/`context`?"* and writes a YAML candidate. A human reviews and trims before committing. Cuts manual mapping work from minutes-per-doc to seconds-per-doc review.
+
+This is **not a runtime adapter** — it's a CLI helper the doc maintainer runs once per doc. The `manual-map` adapter stays simple and deterministic at analysis time.
+
+### Scaling path beyond PoC
+
+1. **Phase 1 (PoC):** `manual-map` tiered YAML + bootstrap script. 5–8 docs, done in <1 hour.
+2. **Phase 2+:** `symbol-search` adapter — extract symbols from doc (functions, hooks, attribute names, code-block imports), AST-grep the codebase, rank by proximity/recency. Fully automatic but noisy on generic names.
+3. **Phase 3:** `hybrid` adapter — `symbol-search` candidates + YAML include/exclude overrides. The long-term shape.
+4. **(Optional) `embedding-retrieval`:** semantic similarity when symbol matching isn't enough. Heavier infra; defer unless needed.
+
+All four share the same `DocCodeMapper` interface, so swapping is an adapter-config change, not a rewrite.
 
 ## Tech Stack
 
@@ -127,7 +166,9 @@ wp-docs-health-monitor/
 ├── config/
 │   └── gutenberg-block-api.yml    # PoC config
 ├── mappings/
-│   └── block-api.yml              # manual doc→code map (Dev A)
+│   └── block-api.yml              # tiered doc→code map (Dev A, seeded by bootstrap script)
+├── scripts/
+│   └── bootstrap-mapping.ts       # LLM-assisted helper: doc → YAML candidate (Dev A)
 ├── .github/workflows/
 │   └── analyze-docs.yml           # Dev B (stretch)
 ├── examples/
@@ -176,10 +217,25 @@ export const DocResultSchema = z.object({
     externalLinks: z.number(),
     lastModified: z.string().datetime().optional()
   }),
-  relatedCode: z.array(z.string()),
+  relatedCode: z.array(z.object({
+    path: z.string(),
+    tier: z.enum(["primary", "secondary", "context"]),
+    includedInAnalysis: z.boolean()  // false if dropped to fit token budget
+  })),
   issues: z.array(IssueSchema),
   positives: z.array(z.string())
 });
+
+// Shape returned by any DocCodeMapper adapter
+export const MappingEntrySchema = z.object({
+  doc: z.string(),
+  code: z.object({
+    primary:   z.array(z.string()).default([]),
+    secondary: z.array(z.string()).default([]),
+    context:   z.array(z.string()).default([])
+  })
+});
+export type MappingEntry = z.infer<typeof MappingEntrySchema>;
 
 export const RunResultsSchema = z.object({
   project: z.string(),
@@ -217,19 +273,15 @@ Numbering prefix: A = pipeline (Dev A), B = presentation (Dev B), S = shared/str
 - **A1** Adapter interfaces + registry (`doc-source`, `code-source`, `mapper`, `validator`). Unimplemented adapters throw `NotImplementedError`.
 - **A2** `markdown-git` DocSource: clones a repo shallowly, reads a section's `.md` files, parses frontmatter + code blocks via `gray-matter` + `remark`. Returns `Doc[]` with `{path, url, content, codeExamples, metrics}`.
 - **A3** `git-clone` CodeSource: shallow-clones a repo, exposes `readFile(relPath)` and `listDir(relPath)`. Handles caching between runs via commit SHA.
-- **A4** `manual-map` Mapper: loads `mappings/block-api.yml`, resolves doc path → list of code file paths.
-- **A5** Manual mapping file: write `mappings/block-api.yml` for the 5–8 chosen docs. Format:
-  ```yaml
-  - doc: reference-guides/block-api/block-metadata.md
-    code:
-      - packages/blocks/src/api/registration.js
-      - packages/blocks/src/api/parser.js
-  ```
+- **A4** `manual-map` Mapper: loads `mappings/*.yml`, validates against `MappingEntrySchema`, resolves doc path → tiered code paths (`primary`/`secondary`/`context`). See "Doc ↔ Code Mapping" section for the schema.
+- **A4b** `bootstrap-mapping` helper: `scripts/bootstrap-mapping.ts <doc-path>` — one-shot Claude call that, given the doc content and the repo file tree, proposes a tiered YAML entry for human review. **Not a runtime adapter** — a dev-time helper to seed the YAML. Keeps `manual-map` deterministic at analysis time.
+- **A5** Seed `mappings/block-api.yml` for the 5–8 chosen docs. Use A4b to propose, then a human trims. Target: ≤3 primary, ≤5 secondary, ≤8 context per doc.
 - **A6** Claude Validator:
   - System prompt (cached): rules for identifying genuine drift, forbidding hallucination, requiring quoted evidence.
   - Tool-use schema matches `IssueSchema`.
+  - **Tier- and budget-aware context assembly.** Start with `primary + secondary` files from the mapping. Add `context` files in order until the 50k input-token budget is hit; record which files were dropped in `DocResult.relatedCode[].includedInAnalysis`.
   - Pass 1 (cached code context): emit candidate issues.
-  - Pass 2 (per-issue): for each candidate, re-fetch the exact code lines referenced and ask the model to confirm/reject. Discard confidence < 0.7.
+  - Pass 2 (per-issue): for each candidate, retrieve-on-demand — re-fetch the exact code lines referenced (even from `context` files that were dropped in Pass 1). The validator exposes a `fetch_code(path, startLine?, endLine?)` tool Claude can call. Discard any issue with confidence < 0.7.
   - Budget: 50k input tokens/doc max, most of it cached.
 - **A7** Pipeline orchestrator (`runPipeline`): wires the adapters, emits `RunResults`. Concurrency: analyze docs in parallel with `p-limit` (default 3).
 - **A8** Health scorer: formula + thresholds for `healthScore` and `status`. Keep it simple (e.g. `100 - (critical*15 + major*7 + minor*2)`, clamp 0..100).

--- a/PLAN.md
+++ b/PLAN.md
@@ -18,14 +18,24 @@ This project ships an automated tool that:
 The blog post at https://radicalupdates.wordpress.com/2026/04/15/block-editor-docs-health-monitor/ sets the north star (weekly runs, $0.50/week after change-detection caching, CI/CD for docs). The project should eventually feed fixes back into either source type — a PR for markdown, a WordPress post update for direct-edit sites.
 
 **Constraints agreed with the user:**
-- Small validatable PoC (5–8 docs, markdown-sourced) but **architecture designed for scalability** to different codebases and to WordPress-sourced docs.
-- Two developers working in parallel — needs cleanly separable, independently shippable issues.
-- Vertical split: Dev A owns the analysis pipeline, Dev B owns CLI/dashboard/Action/config.
-- Avoid the premature-abstraction trap: define adapter interfaces broadly, implement narrowly. PoC implements `markdown-git` only; `wordpress-rest` is a committed Phase 2 deliverable (not "maybe later").
+- **Week 1 PoC deadline:** ~2026-04-27 (one week from kickoff). Aggressive scope discipline.
+- Small validatable first iteration (~10 docs) but **architecture designed to scale to ~200 docs/site**.
+- **"Docs might be OK" is a valid outcome** — the tool must confidently report *healthy* when nothing is wrong, not just find issues. Recall (did we miss drift?) matters as much as precision (is what we found real?).
+- Two developers working in parallel — cleanly separable, independently shippable issues.
+- Vertical split: Dev A owns the analysis pipeline, Dev B owns CLI + dashboard + config.
+- Avoid the premature-abstraction trap: define adapter interfaces broadly, implement narrowly. PoC implements `manifest-url` DocSource only; `wordpress-rest` is a committed Phase 2 deliverable.
+- **Public GitHub repo + GitHub Pages** for the dashboard. Dashboard is the product — overall health %, per-doc detail pages with evidence and proposed actions, informational (no gamification).
+- Quality first, cost secondary. Flag if costs go off rails (rough guardrail: < $5 per full 10-doc PoC run).
 
-**Target for first demo (Phase 1):** Gutenberg `docs/reference-guides/block-api/` via `markdown-git`. Pick 5–8 docs (e.g. `block-metadata.md`, `block-registration.md`, `block-attributes.md`, `block-supports.md`, `block-variations.md`, `block-context.md`, `block-deprecation.md`). Tight mappings to `packages/blocks/src/api/*`, known to drift.
+**Week 1 cut list** (to make the deadline realistic with both devs):
+- ❌ GitHub Action — deferred to Phase 2. Manual CLI run → manual commit of `out/` to `gh-pages` for Week 1.
+- ❌ pnpm workspaces / monorepo — single flat package.
+- ✅ **Kept:** two-pass validation (with Day-3 decision point if it proves too fragile), LLM-bootstrap script, Tailwind-CDN dashboard.
+- 🔄 **Day-3 decision point on Pass 2:** if precision on 3 docs ≥80%, keep Pass 2; if <80%, ship Pass 1 only with strict `confidence ≥ 0.8` and still-demoable dashboard.
 
-**Target for Phase 2:** A WordPress-sourced site fetched via REST API — either developer.wordpress.org (same Block Editor Handbook content, but pulled from the published site instead of the markdown source) or a WooCommerce docs page. This proves the abstraction and is the actual shape most downstream users will want.
+**Target for first demo (Phase 1):** ~10 docs from the Gutenberg Block API Reference (https://developer.wordpress.org/block-editor/reference-guides/block-api/) — e.g. `block-metadata`, `block-registration`, `block-attributes`, `block-supports`, `block-variations`, `block-context`, `block-deprecation`, `block-transforms`, `block-patterns`, `block-bindings`. Tight mappings to `packages/blocks/src/api/*` and `schemas/json/block.json`. Code source: **gutenberg only** (no wordpress-develop/PHP core in Week 1).
+
+**Target for Phase 2:** A WordPress-sourced site fetched via REST API — either developer.wordpress.org (Block Editor Handbook from the published site instead of the markdown source) or a WooCommerce docs page. Proves the abstraction and is the shape downstream users will want.
 
 ## Architecture Overview
 
@@ -65,61 +75,95 @@ Pluggable adapters around a stateless pipeline:
 
 | Interface        | Phase 1 (PoC)     | Phase 2 (committed)      | Later stubs              |
 |------------------|-------------------|--------------------------|--------------------------|
-| `DocSource`      | `markdown-git`    | `wordpress-rest`         | `sitemap-crawler`, `local-markdown`, `a8c-context` |
+| `DocSource`      | `manifest-url` (consumes Gutenberg-style `manifest.json`) | `wordpress-rest`, `fs-walk` (generate manifest for markdown sites without one) | `sitemap-crawler`, `a8c-context` |
 | `CodeSource`     | `git-clone`       | (reuse)                  | `multi-repo`, `local-path` |
-| `DocCodeMapper`  | `manual-map` (tiered YAML) + LLM-bootstrap helper | (reuse) | `symbol-search`, `embedding-retrieval`, `hybrid` |
+| `DocCodeMapper`  | `manual-map` (slug-keyed JSON, tiered) + LLM-bootstrap helper | (reuse) | `symbol-search`, `embedding-retrieval`, `hybrid` |
 | `Validator`      | `claude`          | (reuse)                  | (only one needed)         |
 
-The registry lives in `packages/core/src/adapters/index.ts`. Unimplemented Later-stub adapters throw `NotImplementedError` — this documents the extension surface without adding dead code.
+The registry lives in `src/adapters/index.ts`. Unimplemented Later-stub adapters throw `NotImplementedError` — documents the extension surface without adding dead code.
 
-**`wordpress-rest` DocSource** (Phase 2) fetches via `GET /wp-json/wp/v2/<post_type>?per_page=100` with pagination, unwraps rendered HTML back to a markdown-equivalent structure (via `turndown` or `node-html-parser` + a light converter), and returns the same `Doc[]` shape as `markdown-git` so every downstream stage is source-agnostic. Auth via Application Passwords for private sites; for A8C-internal sites, delegate to the `context-a8c` MCP (a separate adapter variant).
+**`wordpress-rest` DocSource** (Phase 2) fetches via `GET /wp-json/wp/v2/<post_type>?per_page=100` with pagination, unwraps rendered HTML back to markdown-equivalent structure, and **produces a manifest-shaped list** so every downstream stage is source-agnostic. Auth via Application Passwords for private sites; A8C-internal sites delegate to the `context-a8c` MCP (a separate adapter variant).
 
-## Doc ↔ Code Mapping
+**`fs-walk` DocSource** (Phase 2) walks a markdown directory to **generate** a manifest for sites that don't publish one. Output conforms to the same schema.
 
-The relationship is **many-to-many**: one doc typically references multiple source files (e.g. `block-metadata.md` touches `registration.js`, `parser.js`, `process-block-type.js`, `schemas/json/block.json`, and PHP side in WP core), and one source file is referenced by multiple docs.
+## Doc Index & Mapping Format
 
-### Tiered mapping schema
+Two files per site. Decoupled concerns: *what docs exist* vs *what code each one relates to*.
 
-To handle this without blowing the token budget, mappings are **tiered**:
+### File 1 — `manifest.json` (doc index)
 
-```yaml
-# mappings/block-api.yml
-- doc: reference-guides/block-api/block-metadata.md
-  code:
-    primary:      # always sent to the validator — source of truth for this doc
-      - packages/blocks/src/api/registration.js
-      - schemas/json/block.json
-    secondary:    # usually sent — supporting context that catches most real drift
-      - packages/blocks/src/api/parser.js
-      - packages/blocks/src/api/process-block-type.js
-    context:      # dropped first when the budget is tight; re-fetched on demand in Pass 2
-      - packages/block-editor/src/components/block-edit/index.js
+Canonical format = **Gutenberg's `manifest.json`** (https://github.com/WordPress/gutenberg/blob/trunk/docs/manifest.json). Each entry:
+
+```json
+{
+  "title": "Block Metadata",
+  "slug": "block-metadata",
+  "markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/docs/reference-guides/block-api/block-metadata.md",
+  "parent": "block-api"
+}
 ```
 
-The validator starts with `primary + secondary`, adds `context` if budget allows, and in Pass 2 can targeted-fetch additional files by path (retrieval-on-demand rather than pre-loading everything). That shape generalizes to thousands of docs later.
+For Gutenberg, we **consume the existing manifest verbatim** — no work, no maintenance. Just fetch the URL and filter by `parent: "block-api"` for Week 1.
+
+For sites that don't publish a manifest (WooCommerce docs, internal A8C sites, any markdown repo), later phases **generate** one: `fs-walk` adapter for markdown repos, `wordpress-rest` adapter for WP-sourced sites. Output conforms to the same shape.
+
+### File 2 — `mapping.json` (doc → code)
+
+Slug-keyed JSON with tiered code lists. **Slug is the primary key**, not file path — more stable when docs get reorganized.
+
+```json
+// mappings/gutenberg-block-api.json
+{
+  "block-metadata": {
+    "primary":   ["packages/blocks/src/api/registration.js", "schemas/json/block.json"],
+    "secondary": ["packages/blocks/src/api/parser.js", "packages/blocks/src/api/process-block-type.js"],
+    "context":   ["packages/block-editor/src/components/block-edit/index.js"]
+  },
+  "block-registration": {
+    "primary":   ["packages/blocks/src/api/registration.js"],
+    "secondary": [],
+    "context":   []
+  }
+}
+```
+
+**Tiers are token-budget hints for the validator:**
+- `primary` — always sent. Source of truth for this doc.
+- `secondary` — usually sent. Supporting context that catches most real drift.
+- `context` — dropped first when budget is tight; retrieved on demand in Pass 2.
+
+### Why two separate files
+
+- `manifest.json` is **site metadata** (could be upstreamed, machine-generated, maintained by doc owners).
+- `mapping.json` is **tool-specific knowledge** (maintained by us or by contributors using the tool).
+- Separation means we can drop a new site in by adding one `mapping.json` — the manifest is whatever the site already has (or generated once).
 
 ### LLM-assisted bootstrap
 
-Hand-writing mappings doesn't scale past ~50 docs. We keep the YAML as source of truth but add a one-shot dev-time helper: `scripts/bootstrap-mapping.ts <doc-path>` asks Claude *"given this doc and this file tree, which files are `primary`/`secondary`/`context`?"* and writes a YAML candidate. A human reviews and trims before committing. Cuts manual mapping work from minutes-per-doc to seconds-per-doc review.
+Hand-writing mappings doesn't scale past ~50 docs. A one-shot dev-time helper — `scripts/bootstrap-mapping.ts <slug>` — asks Claude *"given this doc and this file tree, which files are `primary`/`secondary`/`context`?"* and writes a candidate JSON block. A human reviews and trims before committing.
 
-This is **not a runtime adapter** — it's a CLI helper the doc maintainer runs once per doc. The `manual-map` adapter stays simple and deterministic at analysis time.
+Not a runtime adapter — a CLI helper you run once per doc. The `manual-map` adapter stays deterministic at analysis time.
 
 ### Scaling path beyond PoC
 
-1. **Phase 1 (PoC):** `manual-map` tiered YAML + bootstrap script. 5–8 docs, done in <1 hour.
-2. **Phase 2+:** `symbol-search` adapter — extract symbols from doc (functions, hooks, attribute names, code-block imports), AST-grep the codebase, rank by proximity/recency. Fully automatic but noisy on generic names.
-3. **Phase 3:** `hybrid` adapter — `symbol-search` candidates + YAML include/exclude overrides. The long-term shape.
-4. **(Optional) `embedding-retrieval`:** semantic similarity when symbol matching isn't enough. Heavier infra; defer unless needed.
+1. **Phase 1 (PoC):** `manual-map` slug-keyed JSON + bootstrap script. ~10 docs, <1 hour with the helper.
+2. **Phase 2+:** `symbol-search` mapper — extract symbols from doc (functions, hooks, attribute names, code-block imports), AST-grep the codebase via `ast-grep`/`tree-sitter`, rank by proximity and specificity. Auto-generates a candidate mapping.
+3. **Phase 3:** `hybrid` mapper — `symbol-search` candidates + a JSON overrides layer (`include` / `exclude` / `pin`) for manual corrections. Long-term shape.
+4. **(Optional) `embedding-retrieval`:** semantic similarity when symbol matching isn't enough. Heavier infra; only if needed.
 
-All four share the same `DocCodeMapper` interface, so swapping is an adapter-config change, not a rewrite.
+All four share the same `DocCodeMapper` interface — swapping is an adapter-config change, not a rewrite. The PoC JSON format is forward-compatible: it becomes the "override" layer in the hybrid adapter with an `overrides:` key added.
+
+### Known limitation (deferred)
+
+**Slug renames break the mapping silently.** If the manifest renames `block-metadata` → `block-json-metadata`, our `mapping.json` key is stale and the validator reports "no mapping found". Low probability in practice. Mitigation when we hit it: a lint step at run-start warning about mapping keys not present in the manifest. Deferred — not implemented in Week 1.
 
 ## Tech Stack
 
 - **Node.js 20 + TypeScript (strict).** Matches Gutenberg ecosystem, first-class Anthropic SDK, natural fit for `setup-node` in Actions.
 - **Anthropic SDK (`@anthropic-ai/sdk`)** with **prompt caching** for the system prompt + shared code context, and **tool use with JSON schema** for structured issue output. Two-pass validation: (1) find candidate issues with quoted evidence, (2) verify each with targeted code re-read. Model: **`claude-sonnet-4-6`** (cost/accuracy sweet spot; upgrade to `claude-opus-4-7` only if Sonnet misses real issues during Phase 0).
 - **`simple-git`** for repo clones. **`gray-matter` + `remark`** for markdown parsing. **`zod`** for runtime schema validation on config + results.
-- **Static HTML dashboard** — no framework. Single `index.html` + per-doc detail pages generated via templates (e.g. `eta` or plain template literals). Tailwind via CDN for styling.
-- **pnpm** workspace (optional) — not required for PoC but cheap to set up if later split into `@docs-health/core` + `@docs-health/dashboard` packages.
+- **Static HTML dashboard** — no framework. `index.html` + per-doc detail pages generated via templates (`eta` or plain template literals). Tailwind via CDN for styling, no build step.
+- **Single flat npm package** for Week 1. No monorepo, no pnpm workspaces — kept simple to fit the one-week timeline.
 
 When implementing, use **context7 MCP** for up-to-date Anthropic SDK docs (prompt caching, tool use, streaming) — matches your global CLAUDE.md rule.
 
@@ -127,62 +171,86 @@ When implementing, use **context7 MCP** for up-to-date Anthropic SDK docs (promp
 
 ```
 wp-docs-health-monitor/
-├── packages/
-│   ├── core/                      # Dev A's territory
-│   │   ├── src/
-│   │   │   ├── adapters/
-│   │   │   │   ├── index.ts        # registry
-│   │   │   │   ├── doc-source/
-│   │   │   │   │   ├── types.ts
-│   │   │   │   │   └── markdown-git.ts
-│   │   │   │   ├── code-source/
-│   │   │   │   │   ├── types.ts
-│   │   │   │   │   └── git-clone.ts
-│   │   │   │   ├── mapper/
-│   │   │   │   │   ├── types.ts
-│   │   │   │   │   └── manual-map.ts
-│   │   │   │   └── validator/
-│   │   │   │       ├── types.ts
-│   │   │   │       └── claude.ts
-│   │   │   ├── pipeline.ts         # orchestrates adapters
-│   │   │   ├── health-scorer.ts
-│   │   │   └── types/
-│   │   │       └── results.ts      # SHARED CONTRACT (zod schema)
-│   │   └── package.json
-│   └── dashboard/                 # Dev B's territory
-│       ├── src/
-│       │   ├── generate.ts         # JSON → static HTML
-│       │   ├── templates/
-│       │   │   ├── index.html.eta
-│       │   │   ├── doc-detail.html.eta
-│       │   │   └── folder.html.eta
-│       │   └── tree-builder.ts
-│       └── package.json
 ├── src/
-│   ├── cli.ts                     # Dev B — main entry
-│   └── config/
-│       ├── schema.ts              # zod schema for config.yml
-│       └── loader.ts
-├── config/
-│   └── gutenberg-block-api.yml    # PoC config
-├── mappings/
-│   └── block-api.yml              # tiered doc→code map (Dev A, seeded by bootstrap script)
+│   ├── adapters/                    # Dev A
+│   │   ├── index.ts                  # registry
+│   │   ├── doc-source/
+│   │   │   ├── types.ts
+│   │   │   └── manifest-url.ts       # PoC impl (consumes Gutenberg manifest.json)
+│   │   ├── code-source/
+│   │   │   ├── types.ts
+│   │   │   └── git-clone.ts
+│   │   ├── mapper/
+│   │   │   ├── types.ts
+│   │   │   └── manual-map.ts         # reads slug-keyed JSON
+│   │   └── validator/
+│   │       ├── types.ts
+│   │       └── claude.ts             # two-pass, prompt-cached, tool-use
+│   ├── pipeline.ts                  # Dev A — wires adapters, emits RunResults
+│   ├── health-scorer.ts             # Dev A
+│   ├── config/                      # Dev B
+│   │   ├── schema.ts
+│   │   └── loader.ts
+│   ├── dashboard/                   # Dev B
+│   │   ├── generate.ts               # RunResults → static HTML
+│   │   ├── templates/
+│   │   │   ├── index.html.eta
+│   │   │   ├── doc-detail.html.eta
+│   │   │   └── folder.html.eta
+│   │   └── tree-builder.ts
+│   ├── cli.ts                       # Dev B — main entry
+│   └── types/
+│       ├── results.ts                # SHARED CONTRACT (zod)
+│       └── mapping.ts                # MappingSchema + Manifest types
 ├── scripts/
-│   └── bootstrap-mapping.ts       # LLM-assisted helper: doc → YAML candidate (Dev A)
-├── .github/workflows/
-│   └── analyze-docs.yml           # Dev B (stretch)
+│   └── bootstrap-mapping.ts         # LLM-assisted helper: slug → JSON candidate (Dev A)
+├── config/
+│   └── gutenberg-block-api.yml      # PoC config
+├── mappings/
+│   └── gutenberg-block-api.json     # slug-keyed tiered map (Dev A)
 ├── examples/
-│   └── results.schema.json        # generated from zod, for Dev B to mock against
+│   ├── mock-results.json            # for dashboard dev without running pipeline (Dev B)
+│   └── results.schema.json          # generated from zod
+├── out/                             # gitignored — generated dashboard
+├── package.json                     # single flat package
+├── tsconfig.json
+├── PLAN.md
 └── README.md
 ```
+
+No `packages/` directory, no monorepo, no GitHub Action workflow in Week 1. All deferred to Phase 2.
 
 ## Shared Contract (Day 1, before branching)
 
 This is the single most important artifact. Both devs pair on it in a 1-hour kickoff, commit to `main`, then diverge.
 
 ```ts
-// packages/core/src/types/results.ts
+// src/types/results.ts
 import { z } from "zod";
+
+// ─── Manifest (doc index) ──────────────────────────────────────────────
+
+export const ManifestEntrySchema = z.object({
+  title: z.string(),
+  slug: z.string(),                       // primary key within a site
+  markdown_source: z.string().url(),      // URL to raw markdown (or local path)
+  parent: z.string().optional()           // parent slug for hierarchy
+});
+export type ManifestEntry = z.infer<typeof ManifestEntrySchema>;
+
+// ─── Mapping (slug → code files) ───────────────────────────────────────
+
+export const CodeTiersSchema = z.object({
+  primary:   z.array(z.string()).default([]),
+  secondary: z.array(z.string()).default([]),
+  context:   z.array(z.string()).default([])
+});
+
+// mapping.json is a Record<slug, CodeTiers>
+export const MappingSchema = z.record(z.string(), CodeTiersSchema);
+export type Mapping = z.infer<typeof MappingSchema>;
+
+// ─── Issues & results ──────────────────────────────────────────────────
 
 export const IssueSchema = z.object({
   id: z.string(),
@@ -204,10 +272,13 @@ export const IssueSchema = z.object({
 });
 
 export const DocResultSchema = z.object({
-  file: z.string(),
-  url: z.string().url().optional(),
+  slug: z.string(),                                        // key from manifest
+  title: z.string(),
+  parent: z.string().optional(),
+  sourceUrl: z.string().url(),                             // markdown_source
+  publishedUrl: z.string().url().optional(),               // rendered doc URL if known
   analyzedAt: z.string().datetime(),
-  commitSha: z.string(),       // enables change detection later
+  commitSha: z.string().optional(),                        // enables change detection later
   healthScore: z.number().min(0).max(100),
   status: z.enum(["healthy", "needs-attention", "critical"]),
   metrics: z.object({
@@ -220,22 +291,11 @@ export const DocResultSchema = z.object({
   relatedCode: z.array(z.object({
     path: z.string(),
     tier: z.enum(["primary", "secondary", "context"]),
-    includedInAnalysis: z.boolean()  // false if dropped to fit token budget
+    includedInAnalysis: z.boolean()                        // false if dropped to fit budget
   })),
   issues: z.array(IssueSchema),
   positives: z.array(z.string())
 });
-
-// Shape returned by any DocCodeMapper adapter
-export const MappingEntrySchema = z.object({
-  doc: z.string(),
-  code: z.object({
-    primary:   z.array(z.string()).default([]),
-    secondary: z.array(z.string()).default([]),
-    context:   z.array(z.string()).default([])
-  })
-});
-export type MappingEntry = z.infer<typeof MappingEntrySchema>;
 
 export const RunResultsSchema = z.object({
   project: z.string(),
@@ -261,100 +321,240 @@ Dev B generates `examples/results.schema.json` from this and mocks a fixture, so
 
 ## Issues for Parallel Work
 
-Numbering prefix: A = pipeline (Dev A), B = presentation (Dev B), S = shared/stretch.
+Each issue is sized to be **individually shippable** — one person, one PR, one merge. Sizes: **S** <1h, **M** 1–3h, **L** 3–6h (flag an L for potential split if it bloats during work).
 
-### Day 1 — Shared Kickoff (both devs)
-- **S0** Repo init, tsconfig, eslint, prettier, pnpm/npm setup.
-- **S1** Define and merge `RunResultsSchema` (zod) and `ConfigSchema`. Export generated JSON Schema to `examples/`.
-- **S2** Agree on CLI entry point signature: `runPipeline(config: Config): Promise<RunResults>`. Dev B calls this from `cli.ts`; Dev A provides the implementation.
+Every issue has:
+- **Owner** (Dev A / Dev B / Either) — suggested, swap freely
+- **Deps** — prerequisite issue IDs that must be merged first
+- **Done when** — acceptance check a reviewer uses
+
+Full issue backlog: **~30 issues, ~50 dev-hours total**. Fits two devs × ~5 days with buffer. Phase 2 / Stretch items are kept intentionally coarse — break them down later.
+
+### Day 1 — Shared Kickoff (both devs, half-day pair session)
+
+- **S0 — Bootstrap repo** · Either · S
+  - Deps: —
+  - Done when: `package.json`, `tsconfig.json` (strict), ESLint + Prettier, `.gitignore`, `src/index.ts` placeholder. `npm run typecheck` passes on an empty project.
+
+- **S1 — Manifest + mapping types** · Dev A · S
+  - Deps: S0
+  - Done when: `src/types/mapping.ts` exports `ManifestEntrySchema`, `CodeTiersSchema`, `MappingSchema` (zod). Types compile.
+
+- **S2 — Issue + result types** · Dev A · M
+  - Deps: S0
+  - Done when: `src/types/results.ts` exports `IssueSchema`, `DocResultSchema`, `RunResultsSchema` (zod). Matches the Shared Contract above exactly.
+
+- **S3 — Config schema** · Dev B · S
+  - Deps: S0
+  - Done when: `src/config/schema.ts` exports `ConfigSchema` with fields for project, docs source, code source, mapping path, output dir.
+
+- **S4 — Pipeline entry stub** · Either · S
+  - Deps: S2
+  - Done when: `src/pipeline.ts` exports `runPipeline(config: Config): Promise<RunResults>` returning an empty-but-valid `RunResults`. This is the interface Dev B codes against.
+
+- **S5 — Export JSON Schema** · Either · S
+  - Deps: S2
+  - Done when: `npm run gen:schema` writes `examples/results.schema.json` via `zod-to-json-schema`.
+
+- **S6 — Mock results fixture** · Either · M
+  - Deps: S2, S5
+  - Done when: `examples/mock-results.json` has ~4 fake docs (one healthy, one needs-attention, one critical, one with varied issue types) and passes `RunResultsSchema` validation. **Unblocks Dev B fully.**
 
 ### Dev A — Pipeline
 
-- **A1** Adapter interfaces + registry (`doc-source`, `code-source`, `mapper`, `validator`). Unimplemented adapters throw `NotImplementedError`.
-- **A2** `markdown-git` DocSource: clones a repo shallowly, reads a section's `.md` files, parses frontmatter + code blocks via `gray-matter` + `remark`. Returns `Doc[]` with `{path, url, content, codeExamples, metrics}`.
-- **A3** `git-clone` CodeSource: shallow-clones a repo, exposes `readFile(relPath)` and `listDir(relPath)`. Handles caching between runs via commit SHA.
-- **A4** `manual-map` Mapper: loads `mappings/*.yml`, validates against `MappingEntrySchema`, resolves doc path → tiered code paths (`primary`/`secondary`/`context`). See "Doc ↔ Code Mapping" section for the schema.
-- **A4b** `bootstrap-mapping` helper: `scripts/bootstrap-mapping.ts <doc-path>` — one-shot Claude call that, given the doc content and the repo file tree, proposes a tiered YAML entry for human review. **Not a runtime adapter** — a dev-time helper to seed the YAML. Keeps `manual-map` deterministic at analysis time.
-- **A5** Seed `mappings/block-api.yml` for the 5–8 chosen docs. Use A4b to propose, then a human trims. Target: ≤3 primary, ≤5 secondary, ≤8 context per doc.
-- **A6** Claude Validator:
-  - System prompt (cached): rules for identifying genuine drift, forbidding hallucination, requiring quoted evidence.
-  - Tool-use schema matches `IssueSchema`.
-  - **Tier- and budget-aware context assembly.** Start with `primary + secondary` files from the mapping. Add `context` files in order until the 50k input-token budget is hit; record which files were dropped in `DocResult.relatedCode[].includedInAnalysis`.
-  - Pass 1 (cached code context): emit candidate issues.
-  - Pass 2 (per-issue): for each candidate, retrieve-on-demand — re-fetch the exact code lines referenced (even from `context` files that were dropped in Pass 1). The validator exposes a `fetch_code(path, startLine?, endLine?)` tool Claude can call. Discard any issue with confidence < 0.7.
-  - Budget: 50k input tokens/doc max, most of it cached.
-- **A7** Pipeline orchestrator (`runPipeline`): wires the adapters, emits `RunResults`. Concurrency: analyze docs in parallel with `p-limit` (default 3).
-- **A8** Health scorer: formula + thresholds for `healthScore` and `status`. Keep it simple (e.g. `100 - (critical*15 + major*7 + minor*2)`, clamp 0..100).
-- **A9** Unit tests for the validator prompt using a known-drifted doc fixture — the quality gate before demo.
+- **A1 — Adapter registry** · Dev A · S
+  - Deps: S0
+  - Done when: `src/adapters/index.ts` exports a registry and `NotImplementedError`. Empty type files for `doc-source`, `code-source`, `mapper`, `validator`.
+
+- **A2a — DocSource interface** · Dev A · S
+  - Deps: A1, S1
+  - Done when: `src/adapters/doc-source/types.ts` defines `DocSource.list(config) → Doc[]` returning `{slug, title, parent, sourceUrl, content, codeExamples, metrics}`.
+
+- **A2b — `manifest-url`: fetch + validate** · Dev A · M
+  - Deps: A2a
+  - Done when: given a manifest URL, fetches JSON, validates each entry against `ManifestEntrySchema`, warns on invalid entries without crashing.
+
+- **A2c — `manifest-url`: filter + fetch markdown** · Dev A · M
+  - Deps: A2b
+  - Done when: filters entries by `parent` slug, fetches each `markdown_source` URL, handles 404/500 gracefully, returns `{entry, content}` pairs.
+
+- **A2d — `manifest-url`: parse markdown → Doc** · Dev A · M
+  - Deps: A2c
+  - Done when: frontmatter via `gray-matter`, code blocks/links counted via `remark`. Returns complete `Doc[]`. Unit test against a checked-in mini-manifest fixture.
+
+- **A3a — `git-clone` CodeSource** · Dev A · M
+  - Deps: A1
+  - Done when: `src/adapters/code-source/git-clone.ts` shallow-clones a repo, exposes `readFile(path, startLine?, endLine?)` and `listDir(path)`. Cleans up old clones.
+
+- **A3b — `git-clone`: SHA caching** · Dev A · S
+  - Deps: A3a
+  - Done when: if cache exists and HEAD SHA matches ref, skips clone. Reruns are <1s.
+
+- **A4 — `manual-map` Mapper** · Dev A · M
+  - Deps: A1, S1
+  - Done when: reads `mappings/<project>.json`, validates against `MappingSchema`, returns `CodeTiers` by slug. Throws helpful error when a requested slug is missing.
+
+- **A4c — `bootstrap-mapping` script** · Dev A · L
+  - Deps: A2d, A3a
+  - Done when: `npx tsx scripts/bootstrap-mapping.ts <slug>` prints a proposed `{slug: CodeTiers}` JSON snippet. Uses Claude with the doc content + repo file tree. Human reviews, pastes into `mappings/*.json`.
+
+- **A5 — Seed mapping for ~10 slugs** · Dev A · M
+  - Deps: A4c
+  - Done when: `mappings/gutenberg-block-api.json` has entries for ~10 Block API Reference slugs. Caps: ≤3 primary, ≤5 secondary, ≤8 context each. Committed.
+
+- **A6a — Validator: Validator interface** · Dev A · S
+  - Deps: A1, S2
+  - Done when: `src/adapters/validator/types.ts` defines `Validator.validate(doc, context) → Issue[]`.
+
+- **A6b — Validator: context assembler** · Dev A · M
+  - Deps: A3a, A4, S2
+  - Done when: `assembleContext(doc, mapping, budget) → {files, stats}`. Starts with primary+secondary, adds context until budget hit, records what was dropped.
+
+- **A6c — Validator: Pass 1 (system prompt + tool use)** · Dev A · L
+  - Deps: A6a, A6b
+  - Done when: Claude call with cached system prompt emits `Issue[]` via tool-use matching `IssueSchema`. Unit-tested against fixture doc+code.
+
+- **A6d — Validator: verbatim evidence check** · Dev A · S
+  - Deps: A6c
+  - Done when: issues whose `evidence.codeSays` isn't literally found in the referenced file are silently rejected. Counter logged.
+
+- **A6e — Validator: Pass 2 (`fetch_code` retrieve-on-demand)** · Dev A · L
+  - Deps: A6c, A3a
+  - Done when: for each candidate issue, Claude can call `fetch_code(path, startLine?, endLine?)` to verify. Issues with `confidence < 0.7` dropped. **This is the issue to cut at the Day-3 decision point if it's not stable.**
+
+- **A7 — Pipeline orchestrator** · Dev A · M
+  - Deps: A2d, A3a, A4, A6c (Pass 1 at minimum)
+  - Done when: `runPipeline(config)` wires DocSource → CodeSource → Mapper → Validator, analyzes docs with `p-limit(3)`, emits `RunResults` that validates against the schema.
+
+- **A8 — Health scorer** · Dev A · S
+  - Deps: S2
+  - Done when: `scoreDoc(issues) → {healthScore, status}` implemented. Formula and thresholds per the spec. Overall average computed in the orchestrator.
+
+- **A9a — Test fixture: drifted doc** · Dev A · M
+  - Deps: A6c
+  - Done when: `tests/fixtures/drifted/` has a hand-tampered doc+code pair. Validator reports ≥1 `critical` issue.
+
+- **A9b — Test fixture: clean doc** · Dev A · S
+  - Deps: A6c
+  - Done when: `tests/fixtures/clean/` has a known-accurate doc+code pair. Validator reports 0 issues (after confidence filter).
 
 ### Dev B — Presentation
 
-- **B1** Config loader: YAML → validated `Config` via zod.
-- **B2** CLI (`npm run analyze -- --config config/gutenberg-block-api.yml --output ./out`). Flags: `--config`, `--output`, `--only <glob>`, `--dry-run`.
-- **B3** Dashboard generator: reads `results.json`, produces:
-  - `out/index.html` — overall health, tree view of docs with per-folder aggregates.
-  - `out/doc/<slug>.html` — detail page with issues, evidence, suggestions.
-  - `out/folder/<path>.html` — folder summary.
-  - Tailwind via CDN, no build step.
-- **B4** Tree builder: given a flat list of doc paths, build the nested folder tree with aggregated health scores.
-- **B5** Mock fixture: checked-in `examples/mock-results.json` for dashboard dev without running the pipeline.
-- **B6** GitHub Action workflow (stretch for PoC): manual dispatch + weekly cron, uploads dashboard as artifact. Deploy to GitHub Pages after PoC is validated.
-- **B7** README with example commands + screenshots + cost expectations.
+- **B1 — Config loader** · Dev B · S
+  - Deps: S3
+  - Done when: `loadConfig(path)` reads YAML, validates via `ConfigSchema`, returns typed `Config`.
+
+- **B2a — CLI skeleton** · Dev B · S
+  - Deps: S0
+  - Done when: `src/cli.ts` with flags `--config`, `--output`, `--only <slug>`, `--dry-run`. `npm run analyze -- --help` prints usage.
+
+- **B2b — CLI wired to pipeline** · Dev B · S
+  - Deps: B2a, B1, S4
+  - Done when: `npm run analyze -- --config config/gutenberg-block-api.yml --output ./out` writes `out/results.json` + a log file. Works with stub `runPipeline` returning empty results.
+
+- **B3a — Dashboard: reader + generator entry** · Dev B · S
+  - Deps: S6
+  - Done when: `src/dashboard/generate.ts` reads + validates a `results.json`, exposes `generate(results, outDir)` that writes to disk.
+
+- **B3b — Dashboard: index.html** · Dev B · M
+  - Deps: B3a, B4
+  - Done when: `out/index.html` shows overall health %, totals (critical/major/minor), and the tree view grouped by parent slug with per-folder aggregated score. Tailwind CDN, one-file HTML.
+
+- **B3c — Dashboard: doc-detail.html** · Dev B · L
+  - Deps: B3a
+  - Done when: `out/doc/<slug>.html` shows title, health score, metrics, issues (severity, confidence, quoted evidence, proposed action), positives, related-code list, source URL link. Generated one per doc from `examples/mock-results.json`.
+
+- **B3d — Dashboard: folder.html** · Dev B · M
+  - Deps: B3a, B4
+  - Done when: `out/folder/<parent>.html` shows a section's rollup and its docs. Reached via links in `index.html`.
+
+- **B4 — Tree builder** · Dev B · M
+  - Deps: S2
+  - Done when: `buildTree(docs) → TreeNode[]` groups by parent slug, aggregates health (doc-count weighted). Handles ≥200 docs cleanly.
+
+- **B6 — `publish.sh`** · Dev B · S
+  - Deps: B3b, B3c, B3d
+  - Done when: `scripts/publish.sh` (or `npm run publish`) copies `out/` to a `gh-pages` worktree and pushes. GitHub Pages serves the result.
+
+- **B7 — README** · Dev B · M
+  - Deps: B2b (so examples are real)
+  - Done when: install steps, API key setup, CLI usage, sample output, cost expectation, dashboard screenshot. Enough for your partner's partner to reproduce.
+
+### Phase 0 Validation Gate (Day 3)
+
+- **V0 — Run on 3 docs, measure P/R** · Dev A + manual review · M
+  - Deps: A5, A7 (with at least Pass 1 wired)
+  - Done when: `docs/phase-0-results.md` (or PR comment) records precision, recall, clean-doc false positives. Day-3 decision documented: keep Pass 2, cut Pass 2, or abort.
 
 ### Phase 2 — After PoC is validated (committed)
 
-- **P2-1** `wordpress-rest` DocSource: pagination, HTML→markdown normalization, Application Password auth, meta/slug round-trip fields so fixes can later be written back. Demoed against one real WP docs site (dev.wordpress.org or a WooCommerce page).
-- **P2-2** Dashboard: show source type per doc ("markdown" / "wordpress") and deep-link to the edit URL in WP so authors can fix directly.
-- **P2-3** `a8c-context` DocSource variant: use the context-a8c MCP for A8C-internal sites (Fieldguide, P2s) that aren't publicly reachable.
+- **P2-1** GitHub Action workflow: manual dispatch + weekly cron, uploads `results.json` as artifact, auto-deploys dashboard to GitHub Pages.
+- **P2-2** `wordpress-rest` DocSource: pagination, HTML→markdown normalization, Application Password auth. Produces a manifest-shaped list from a live WP site. Demoed against developer.wordpress.org or a WooCommerce docs page.
+- **P2-3** `fs-walk` DocSource: generates a manifest for markdown repos that don't publish one (WooCommerce docs repo, etc.).
+- **P2-4** Dashboard: show source type per doc ("markdown" / "wordpress") and deep-link to the edit URL in WP so authors can fix directly.
+- **P2-5** `a8c-context` DocSource variant: use the context-a8c MCP for A8C-internal sites (Fieldguide, P2s) that aren't publicly reachable.
 
 ### Stretch — nice to have
 
 - **S3** Change Detector: diffs last-analyzed commit SHA vs current, queues only changed docs + docs whose mapped code changed. Biggest cost lever per the blog post.
-- **S5** `symbol-search` Mapper (heuristic doc→code resolution to reduce manual mapping work for new sections).
+- **S5** `symbol-search` Mapper (heuristic doc→code resolution to scale beyond hand-maintained mappings).
 - **S6** Trend tracking across runs (store history, show trend line in dashboard).
-- **S7** GitHub Pages deploy in the Action.
+- **S7** Slug-rename lint: warn when `mapping.json` keys aren't in the current manifest.
 - **S8** Round-trip: open a GitHub PR on the markdown source (or draft a WP post update via REST) for issues above a confidence threshold.
 
-## Phase 0 Validation (before PoC scale-up)
+## Phase 0 Validation (Day 3 — Decision Point)
 
-Day 2–3 of Dev A's work, gate everything else behind it:
+Gate everything else behind this check. It's also the go/no-go for two-pass validation.
 
-1. Pick 3 of the 5–8 docs.
-2. Manually read each doc + its mapped code. Write down what a human reviewer considers the top drift issues.
+1. Pick 3 of the ~10 docs — ideally **one known-drifted, one known-clean, one uncertain** so we can measure both precision and recall.
+2. Manually read each doc + its mapped code. Write down (a) the real drift issues a human reviewer would flag, and (b) that the clean doc is actually clean.
 3. Run the validator on those 3 docs.
-4. Measure precision: of issues reported, how many are real? Target ≥80%. Recall: of the human-found issues, how many did it surface? Target ≥70%.
-5. If precision is weak, iterate the system prompt before scaling. If it still fails, that's a go/no-go signal — better to learn at day 3 than day 14.
+4. **Measure:**
+   - **Precision** — of issues reported, how many are real? Target ≥80%.
+   - **Recall** — of the human-found issues, how many did the tool surface? Target ≥70%.
+   - **Clean-doc false positives** — on the clean doc, tool must report 0 issues (or all <0.7 confidence, which we filter). This is the single most important check: a tool that fabricates issues on good docs is worse than useless.
+5. **Day-3 decision:**
+   - **Go (precision ≥80% + clean doc shows 0 issues):** keep two-pass validation, proceed to full 10-doc run.
+   - **No-go (precision <80% OR clean doc shows false positives):** iterate the system prompt for up to half a day. If still failing, **cut Pass 2**, tighten `confidence ≥ 0.8`, rely on the runtime verbatim-evidence check, and ship the Pass-1-only version. Dashboard still demos.
+   - **Fail (still bad after cuts):** honest conversation about whether the PoC is viable — better to surface that at day 3 than day 7.
 
 ## Verification (end-to-end)
 
 1. `npm install`
 2. `export ANTHROPIC_API_KEY=...`
 3. `npm run analyze -- --config config/gutenberg-block-api.yml --output ./out`
-4. `open out/index.html` — verify tree view renders, scores look reasonable, clicking a doc shows evidence-backed issues with line numbers and suggestions.
+4. `open out/index.html` — verify overall health %, tree view renders all ~10 docs grouped under `block-api`, clicking a doc opens a detail page with issues, evidence, proposed actions, and a link to the source URL.
 5. Manual precision check on 10 random issues: confirm they're real drift, not hallucination.
-6. Cost check: ≤$1 for the full 5–8 doc run.
-7. (Stretch) Trigger the GitHub Action manually, verify artifact upload.
+6. Clean-doc check: at least one doc shows `healthy` status with 0 issues (or proves the tool can recognize health).
+7. Cost check: ≤$1 for the full 10-doc run. Flag if it exceeds $5.
+8. `npm run publish` (or `scripts/publish.sh`) pushes `out/` to the `gh-pages` branch; verify the dashboard loads at `https://juanma-wp.github.io/wp-docs-health-monitor/`.
 
 ## Risks and Mitigations
 
-- **AI hallucination / false positives** → two-pass validation + quoted evidence requirement + confidence threshold ≥0.7. Reject any issue whose `evidence.codeSays` can't be found verbatim in the referenced file (validate in code, not just the prompt).
-- **Premature abstraction** → adapter interfaces are stubs; only implemented adapters get code. Registry documents the extension surface without adding maintenance burden.
-- **Dev A / Dev B divergence** → Day-1 schema handshake + mock fixture; Dev B never has to wait on Dev A.
-- **Mapping accuracy for the 5–8 docs** → manual, curated, checked into git; mapping errors are quick to fix when a human spotted the issue.
-- **Timeline pressure** → GitHub Action, Pages deploy, change detector are all marked stretch. Core shippable demo is the CLI + local dashboard.
+- **AI hallucination / false positives** → two-pass validation + quoted evidence + `confidence ≥ 0.7` + **runtime verbatim check** (`evidence.codeSays` must literally appear in the referenced file). Clean-doc fixture in tests catches drift in the validator itself.
+- **Two-pass validation is complex and time-hungry** → Day-3 decision point with a Pass-1-only fallback that still demos.
+- **Premature abstraction** → adapter interfaces designed broadly, implemented narrowly. Registry documents extension surface without dead code.
+- **Dev A / Dev B divergence** → Day-1 schema handshake + mock fixture; Dev B never blocks on Dev A.
+- **Mapping accuracy for ~10 docs** → hand-curated via bootstrap script, checked into git. Mapping errors are trivial to fix.
+- **Slug renames breaking mappings silently** → deferred. A lint step (S7) handles it later when it bites.
+- **Timeline pressure (1 week)** → GitHub Action, `symbol-search` mapper, change detector all deferred to Phase 2. Core shippable demo is CLI + local dashboard + manual `gh-pages` push.
+- **Cost runaway** → 50k input-token cap per doc + prompt caching. Expected total per 10-doc run: ≤$1. Alert threshold: $5. Measured at the end of each run, logged to console.
 
-## Out of Scope for PoC
+## Out of Scope for PoC (Week 1)
 
+- GitHub Action workflow and weekly cron — deferred to Phase 2 (P2-1).
+- `wordpress-rest` / `fs-walk` / `a8c-context` DocSources — interfaces defined, implementations deferred.
+- `symbol-search`, `hybrid`, `embedding-retrieval` mappers — interface-compatible, implementations deferred.
 - Auto-generated package READMEs (`packages/*/README.md`) — most are docgen output, low drift signal.
-- WordPress REST / wpcom doc sources — interface defined, implementation deferred.
-- Auto-PRs with fixes, screenshots analysis, multi-handbook coverage.
+- Auto-PRs with fixes, screenshots/image link-checking, multi-handbook coverage.
 - Fine-tuning — off-the-shelf Claude Sonnet 4.6.
+- PHP / wordpress-develop code source — gutenberg repo only in Week 1.
+- Slug-rename detection, trend tracking, gamification.
 
 ## Open Questions (non-blocking)
 
-- Does the repo live in a personal GitHub or in a WordPress/Automattic org? (affects Action secrets and Pages URL — answer before B6.)
-- Licensing: MIT to match the WordPress ecosystem? (confirm before repo init.)
-- Should the 5–8 docs include any known-clean ones as controls? (recommended — two "healthy" and six "suspect" gives a better demo than all-suspect.)
-- **Phase 2 target site**: developer.wordpress.org (Block Editor Handbook pulled from the published site) vs a WooCommerce docs page vs an internal A8C docs P2. Each has different auth, different content shape, and different audience. Decide before P2-1 starts.
-- **Fix round-trip**: do we want to auto-open PRs / draft WP post updates (S8), or keep the tool strictly read-only and leave fixes to humans? Auto-PRs change the trust bar significantly.
-- **Markdown↔WP drift**: when both a markdown source AND a WP-edited post exist for the same doc, they can drift from each other. Out of scope for PoC, but worth flagging because it's a real failure mode.
+- **Known-clean controls in the 10 docs:** which 1–2 of the chosen Block API docs are known to be accurate? Include them on purpose so recall measurement has a baseline.
+- **Phase 2 target site:** developer.wordpress.org vs a WooCommerce docs page vs an A8C-internal P2. Decide before P2-2 starts — each has different auth, content shape, and audience.
+- **Fix round-trip (S8):** auto-open PRs / draft WP post updates, or stay strictly read-only? Auto-PRs change the trust bar significantly.
+- **Markdown↔WP drift:** when both a markdown source AND a WP-edited post exist for the same doc, they can drift from *each other*. Out of scope for PoC, worth flagging as a real failure mode for later.
+- **Bifrost P2 / Radical Speed Month framing:** does the Week-1 demo need to hit a specific forum or deadline beyond the generic 1-week bar?

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,5 +1,7 @@
 # WP Docs Health Monitor — PoC Plan
 
+> **Reading order:** start here. Technical details live in [docs/architecture.md](./docs/architecture.md). Issues to pick up live in [docs/backlog.md](./docs/backlog.md).
+
 ## Context
 
 **End goal:** Keep WordPress-hosted documentation sites (developer.wordpress.org, WooCommerce docs, internal A8C docs, etc.) accurate and up-to-date against the code they describe. Docs on those sites come from two kinds of sources:
@@ -17,27 +19,23 @@ This project ships an automated tool that:
 
 The blog post at https://radicalupdates.wordpress.com/2026/04/15/block-editor-docs-health-monitor/ sets the north star (weekly runs, $0.50/week after change-detection caching, CI/CD for docs). The project should eventually feed fixes back into either source type — a PR for markdown, a WordPress post update for direct-edit sites.
 
-**Constraints agreed with the user:**
+## Constraints
+
 - **Week 1 PoC deadline:** ~2026-04-27 (one week from kickoff). Aggressive scope discipline.
 - Small validatable first iteration (~10 docs) but **architecture designed to scale to ~200 docs/site**.
 - **"Docs might be OK" is a valid outcome** — the tool must confidently report *healthy* when nothing is wrong, not just find issues. Recall (did we miss drift?) matters as much as precision (is what we found real?).
 - Two developers working in parallel — cleanly separable, independently shippable issues.
 - Vertical split: Dev A owns the analysis pipeline, Dev B owns CLI + dashboard + config.
-- Avoid the premature-abstraction trap: define adapter interfaces broadly, implement narrowly. PoC implements `manifest-url` DocSource only; `wordpress-rest` is a committed Phase 2 deliverable.
 - **Public GitHub repo + GitHub Pages** for the dashboard. Dashboard is the product — overall health %, per-doc detail pages with evidence and proposed actions, informational (no gamification).
 - Quality first, cost secondary. Flag if costs go off rails (rough guardrail: < $5 per full 10-doc PoC run).
 
-**Week 1 cut list** (to make the deadline realistic with both devs):
-- ❌ GitHub Action — deferred to Phase 2. Manual CLI run → manual commit of `out/` to `gh-pages` for Week 1.
-- ❌ pnpm workspaces / monorepo — single flat package.
-- ✅ **Kept:** two-pass validation (with Day-3 decision point if it proves too fragile), LLM-bootstrap script, Tailwind-CDN dashboard.
-- 🔄 **Day-3 decision point on Pass 2:** if precision on 3 docs ≥80%, keep Pass 2; if <80%, ship Pass 1 only with strict `confidence ≥ 0.8` and still-demoable dashboard.
+## Targets
 
-**Target for first demo (Phase 1):** ~10 docs from the Gutenberg Block API Reference (https://developer.wordpress.org/block-editor/reference-guides/block-api/) — e.g. `block-metadata`, `block-registration`, `block-attributes`, `block-supports`, `block-variations`, `block-context`, `block-deprecation`, `block-transforms`, `block-patterns`, `block-bindings`. Tight mappings to `packages/blocks/src/api/*` and `schemas/json/block.json`. Code source: **gutenberg only** (no wordpress-develop/PHP core in Week 1).
+**Phase 1 (Week 1, demo target):** ~10 docs from the Gutenberg Block API Reference (https://developer.wordpress.org/block-editor/reference-guides/block-api/) — e.g. `block-metadata`, `block-registration`, `block-attributes`, `block-supports`, `block-variations`, `block-context`, `block-deprecation`, `block-transforms`, `block-patterns`, `block-bindings`. Tight mappings to `packages/blocks/src/api/*` and `schemas/json/block.json`. Code source: **gutenberg only** (no wordpress-develop/PHP core in Week 1).
 
-**Target for Phase 2:** A WordPress-sourced site fetched via REST API — either developer.wordpress.org (Block Editor Handbook from the published site instead of the markdown source) or a WooCommerce docs page. Proves the abstraction and is the shape downstream users will want.
+**Phase 2:** A WordPress-sourced site fetched via REST API — either developer.wordpress.org (Block Editor Handbook from the published site instead of the markdown source) or a WooCommerce docs page. Proves the abstraction and is the shape downstream users will want.
 
-## Architecture Overview
+## Architecture at a Glance
 
 Pluggable adapters around a stateless pipeline:
 
@@ -71,8 +69,6 @@ Pluggable adapters around a stateless pipeline:
       (static HTML)                   (orchestration)
 ```
 
-**Adapter interfaces designed, staged implementations:**
-
 | Interface        | Phase 1 (PoC)     | Phase 2 (committed)      | Later stubs              |
 |------------------|-------------------|--------------------------|--------------------------|
 | `DocSource`      | `manifest-url` (consumes Gutenberg-style `manifest.json`) | `wordpress-rest`, `fs-walk` (generate manifest for markdown sites without one) | `sitemap-crawler`, `a8c-context` |
@@ -80,413 +76,13 @@ Pluggable adapters around a stateless pipeline:
 | `DocCodeMapper`  | `manual-map` (slug-keyed JSON, tiered) + LLM-bootstrap helper | (reuse) | `symbol-search`, `embedding-retrieval`, `hybrid` |
 | `Validator`      | `claude`          | (reuse)                  | (only one needed)         |
 
-The registry lives in `src/adapters/index.ts`. Unimplemented Later-stub adapters throw `NotImplementedError` — documents the extension surface without adding dead code.
+Unimplemented Later-stub adapters throw `NotImplementedError` — documents the extension surface without adding dead code.
 
-**`wordpress-rest` DocSource** (Phase 2) fetches via `GET /wp-json/wp/v2/<post_type>?per_page=100` with pagination, unwraps rendered HTML back to markdown-equivalent structure, and **produces a manifest-shaped list** so every downstream stage is source-agnostic. Auth via Application Passwords for private sites; A8C-internal sites delegate to the `context-a8c` MCP (a separate adapter variant).
+Full technical details (schemas, repo layout, mapping format, tech stack) → [docs/architecture.md](./docs/architecture.md).
 
-**`fs-walk` DocSource** (Phase 2) walks a markdown directory to **generate** a manifest for sites that don't publish one. Output conforms to the same schema.
+Issue-level plan with owners, deps, and acceptance criteria → [docs/backlog.md](./docs/backlog.md).
 
-## Doc Index & Mapping Format
-
-Two files per site. Decoupled concerns: *what docs exist* vs *what code each one relates to*.
-
-### File 1 — `manifest.json` (doc index)
-
-Canonical format = **Gutenberg's `manifest.json`** (https://github.com/WordPress/gutenberg/blob/trunk/docs/manifest.json). Each entry:
-
-```json
-{
-  "title": "Block Metadata",
-  "slug": "block-metadata",
-  "markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/docs/reference-guides/block-api/block-metadata.md",
-  "parent": "block-api"
-}
-```
-
-For Gutenberg, we **consume the existing manifest verbatim** — no work, no maintenance. Just fetch the URL and filter by `parent: "block-api"` for Week 1.
-
-For sites that don't publish a manifest (WooCommerce docs, internal A8C sites, any markdown repo), later phases **generate** one: `fs-walk` adapter for markdown repos, `wordpress-rest` adapter for WP-sourced sites. Output conforms to the same shape.
-
-### File 2 — `mapping.json` (doc → code)
-
-Slug-keyed JSON with tiered code lists. **Slug is the primary key**, not file path — more stable when docs get reorganized.
-
-```json
-// mappings/gutenberg-block-api.json
-{
-  "block-metadata": {
-    "primary":   ["packages/blocks/src/api/registration.js", "schemas/json/block.json"],
-    "secondary": ["packages/blocks/src/api/parser.js", "packages/blocks/src/api/process-block-type.js"],
-    "context":   ["packages/block-editor/src/components/block-edit/index.js"]
-  },
-  "block-registration": {
-    "primary":   ["packages/blocks/src/api/registration.js"],
-    "secondary": [],
-    "context":   []
-  }
-}
-```
-
-**Tiers are token-budget hints for the validator:**
-- `primary` — always sent. Source of truth for this doc.
-- `secondary` — usually sent. Supporting context that catches most real drift.
-- `context` — dropped first when budget is tight; retrieved on demand in Pass 2.
-
-### Why two separate files
-
-- `manifest.json` is **site metadata** (could be upstreamed, machine-generated, maintained by doc owners).
-- `mapping.json` is **tool-specific knowledge** (maintained by us or by contributors using the tool).
-- Separation means we can drop a new site in by adding one `mapping.json` — the manifest is whatever the site already has (or generated once).
-
-### LLM-assisted bootstrap
-
-Hand-writing mappings doesn't scale past ~50 docs. A one-shot dev-time helper — `scripts/bootstrap-mapping.ts <slug>` — asks Claude *"given this doc and this file tree, which files are `primary`/`secondary`/`context`?"* and writes a candidate JSON block. A human reviews and trims before committing.
-
-Not a runtime adapter — a CLI helper you run once per doc. The `manual-map` adapter stays deterministic at analysis time.
-
-### Scaling path beyond PoC
-
-1. **Phase 1 (PoC):** `manual-map` slug-keyed JSON + bootstrap script. ~10 docs, <1 hour with the helper.
-2. **Phase 2+:** `symbol-search` mapper — extract symbols from doc (functions, hooks, attribute names, code-block imports), AST-grep the codebase via `ast-grep`/`tree-sitter`, rank by proximity and specificity. Auto-generates a candidate mapping.
-3. **Phase 3:** `hybrid` mapper — `symbol-search` candidates + a JSON overrides layer (`include` / `exclude` / `pin`) for manual corrections. Long-term shape.
-4. **(Optional) `embedding-retrieval`:** semantic similarity when symbol matching isn't enough. Heavier infra; only if needed.
-
-All four share the same `DocCodeMapper` interface — swapping is an adapter-config change, not a rewrite. The PoC JSON format is forward-compatible: it becomes the "override" layer in the hybrid adapter with an `overrides:` key added.
-
-### Known limitation (deferred)
-
-**Slug renames break the mapping silently.** If the manifest renames `block-metadata` → `block-json-metadata`, our `mapping.json` key is stale and the validator reports "no mapping found". Low probability in practice. Mitigation when we hit it: a lint step at run-start warning about mapping keys not present in the manifest. Deferred — not implemented in Week 1.
-
-## Tech Stack
-
-- **Node.js 20 + TypeScript (strict).** Matches Gutenberg ecosystem, first-class Anthropic SDK, natural fit for `setup-node` in Actions.
-- **Anthropic SDK (`@anthropic-ai/sdk`)** with **prompt caching** for the system prompt + shared code context, and **tool use with JSON schema** for structured issue output. Two-pass validation: (1) find candidate issues with quoted evidence, (2) verify each with targeted code re-read. Model: **`claude-sonnet-4-6`** (cost/accuracy sweet spot; upgrade to `claude-opus-4-7` only if Sonnet misses real issues during Phase 0).
-- **`simple-git`** for repo clones. **`gray-matter` + `remark`** for markdown parsing. **`zod`** for runtime schema validation on config + results.
-- **Static HTML dashboard** — no framework. `index.html` + per-doc detail pages generated via templates (`eta` or plain template literals). Tailwind via CDN for styling, no build step.
-- **Single flat npm package** for Week 1. No monorepo, no pnpm workspaces — kept simple to fit the one-week timeline.
-
-When implementing, use **context7 MCP** for up-to-date Anthropic SDK docs (prompt caching, tool use, streaming) — matches your global CLAUDE.md rule.
-
-## Repo Layout
-
-```
-wp-docs-health-monitor/
-├── src/
-│   ├── adapters/                    # Dev A
-│   │   ├── index.ts                  # registry
-│   │   ├── doc-source/
-│   │   │   ├── types.ts
-│   │   │   └── manifest-url.ts       # PoC impl (consumes Gutenberg manifest.json)
-│   │   ├── code-source/
-│   │   │   ├── types.ts
-│   │   │   └── git-clone.ts
-│   │   ├── mapper/
-│   │   │   ├── types.ts
-│   │   │   └── manual-map.ts         # reads slug-keyed JSON
-│   │   └── validator/
-│   │       ├── types.ts
-│   │       └── claude.ts             # two-pass, prompt-cached, tool-use
-│   ├── pipeline.ts                  # Dev A — wires adapters, emits RunResults
-│   ├── health-scorer.ts             # Dev A
-│   ├── config/                      # Dev B
-│   │   ├── schema.ts
-│   │   └── loader.ts
-│   ├── dashboard/                   # Dev B
-│   │   ├── generate.ts               # RunResults → static HTML
-│   │   ├── templates/
-│   │   │   ├── index.html.eta
-│   │   │   ├── doc-detail.html.eta
-│   │   │   └── folder.html.eta
-│   │   └── tree-builder.ts
-│   ├── cli.ts                       # Dev B — main entry
-│   └── types/
-│       ├── results.ts                # SHARED CONTRACT (zod)
-│       └── mapping.ts                # MappingSchema + Manifest types
-├── scripts/
-│   └── bootstrap-mapping.ts         # LLM-assisted helper: slug → JSON candidate (Dev A)
-├── config/
-│   └── gutenberg-block-api.yml      # PoC config
-├── mappings/
-│   └── gutenberg-block-api.json     # slug-keyed tiered map (Dev A)
-├── examples/
-│   ├── mock-results.json            # for dashboard dev without running pipeline (Dev B)
-│   └── results.schema.json          # generated from zod
-├── out/                             # gitignored — generated dashboard
-├── package.json                     # single flat package
-├── tsconfig.json
-├── PLAN.md
-└── README.md
-```
-
-No `packages/` directory, no monorepo, no GitHub Action workflow in Week 1. All deferred to Phase 2.
-
-## Shared Contract (Day 1, before branching)
-
-This is the single most important artifact. Both devs pair on it in a 1-hour kickoff, commit to `main`, then diverge.
-
-```ts
-// src/types/results.ts
-import { z } from "zod";
-
-// ─── Manifest (doc index) ──────────────────────────────────────────────
-
-export const ManifestEntrySchema = z.object({
-  title: z.string(),
-  slug: z.string(),                       // primary key within a site
-  markdown_source: z.string().url(),      // URL to raw markdown (or local path)
-  parent: z.string().optional()           // parent slug for hierarchy
-});
-export type ManifestEntry = z.infer<typeof ManifestEntrySchema>;
-
-// ─── Mapping (slug → code files) ───────────────────────────────────────
-
-export const CodeTiersSchema = z.object({
-  primary:   z.array(z.string()).default([]),
-  secondary: z.array(z.string()).default([]),
-  context:   z.array(z.string()).default([])
-});
-
-// mapping.json is a Record<slug, CodeTiers>
-export const MappingSchema = z.record(z.string(), CodeTiersSchema);
-export type Mapping = z.infer<typeof MappingSchema>;
-
-// ─── Issues & results ──────────────────────────────────────────────────
-
-export const IssueSchema = z.object({
-  id: z.string(),
-  severity: z.enum(["critical", "major", "minor"]),
-  type: z.enum([
-    "outdated-api", "missing-parameter", "incorrect-example",
-    "broken-link", "unclear-explanation", "deprecated-usage"
-  ]),
-  location: z.object({ line: z.number().int(), text: z.string() }),
-  issue: z.string(),
-  evidence: z.object({
-    docSays: z.string(),
-    codeSays: z.string(),
-    codeFile: z.string(),
-    codeLine: z.number().int().optional()
-  }),
-  suggestion: z.string(),
-  confidence: z.number().min(0).max(1)
-});
-
-export const DocResultSchema = z.object({
-  slug: z.string(),                                        // key from manifest
-  title: z.string(),
-  parent: z.string().optional(),
-  sourceUrl: z.string().url(),                             // markdown_source
-  publishedUrl: z.string().url().optional(),               // rendered doc URL if known
-  analyzedAt: z.string().datetime(),
-  commitSha: z.string().optional(),                        // enables change detection later
-  healthScore: z.number().min(0).max(100),
-  status: z.enum(["healthy", "needs-attention", "critical"]),
-  metrics: z.object({
-    wordCount: z.number(),
-    codeExamples: z.number(),
-    internalLinks: z.number(),
-    externalLinks: z.number(),
-    lastModified: z.string().datetime().optional()
-  }),
-  relatedCode: z.array(z.object({
-    path: z.string(),
-    tier: z.enum(["primary", "secondary", "context"]),
-    includedInAnalysis: z.boolean()                        // false if dropped to fit budget
-  })),
-  issues: z.array(IssueSchema),
-  positives: z.array(z.string())
-});
-
-export const RunResultsSchema = z.object({
-  project: z.string(),
-  runId: z.string(),
-  analyzedAt: z.string().datetime(),
-  scope: z.object({
-    source: z.string(),
-    docsCount: z.number()
-  }),
-  overallHealth: z.number().min(0).max(100),
-  totals: z.object({
-    critical: z.number(),
-    major: z.number(),
-    minor: z.number()
-  }),
-  docs: z.array(DocResultSchema)
-});
-
-export type RunResults = z.infer<typeof RunResultsSchema>;
-```
-
-Dev B generates `examples/results.schema.json` from this and mocks a fixture, so Dev B's dashboard work is unblocked immediately — doesn't have to wait for real pipeline output.
-
-## Issues for Parallel Work
-
-Each issue is sized to be **individually shippable** — one person, one PR, one merge. Sizes: **S** <1h, **M** 1–3h, **L** 3–6h (flag an L for potential split if it bloats during work).
-
-Every issue has:
-- **Owner** (Dev A / Dev B / Either) — suggested, swap freely
-- **Deps** — prerequisite issue IDs that must be merged first
-- **Done when** — acceptance check a reviewer uses
-
-Full issue backlog: **~30 issues, ~50 dev-hours total**. Fits two devs × ~5 days with buffer. Phase 2 / Stretch items are kept intentionally coarse — break them down later.
-
-### Day 1 — Shared Kickoff (both devs, half-day pair session)
-
-- **S0 — Bootstrap repo** · Either · S
-  - Deps: —
-  - Done when: `package.json`, `tsconfig.json` (strict), ESLint + Prettier, `.gitignore`, `src/index.ts` placeholder. `npm run typecheck` passes on an empty project.
-
-- **S1 — Manifest + mapping types** · Dev A · S
-  - Deps: S0
-  - Done when: `src/types/mapping.ts` exports `ManifestEntrySchema`, `CodeTiersSchema`, `MappingSchema` (zod). Types compile.
-
-- **S2 — Issue + result types** · Dev A · M
-  - Deps: S0
-  - Done when: `src/types/results.ts` exports `IssueSchema`, `DocResultSchema`, `RunResultsSchema` (zod). Matches the Shared Contract above exactly.
-
-- **S3 — Config schema** · Dev B · S
-  - Deps: S0
-  - Done when: `src/config/schema.ts` exports `ConfigSchema` with fields for project, docs source, code source, mapping path, output dir.
-
-- **S4 — Pipeline entry stub** · Either · S
-  - Deps: S2
-  - Done when: `src/pipeline.ts` exports `runPipeline(config: Config): Promise<RunResults>` returning an empty-but-valid `RunResults`. This is the interface Dev B codes against.
-
-- **S5 — Export JSON Schema** · Either · S
-  - Deps: S2
-  - Done when: `npm run gen:schema` writes `examples/results.schema.json` via `zod-to-json-schema`.
-
-- **S6 — Mock results fixture** · Either · M
-  - Deps: S2, S5
-  - Done when: `examples/mock-results.json` has ~4 fake docs (one healthy, one needs-attention, one critical, one with varied issue types) and passes `RunResultsSchema` validation. **Unblocks Dev B fully.**
-
-### Dev A — Pipeline
-
-- **A1 — Adapter registry** · Dev A · S
-  - Deps: S0
-  - Done when: `src/adapters/index.ts` exports a registry and `NotImplementedError`. Empty type files for `doc-source`, `code-source`, `mapper`, `validator`.
-
-- **A2a — DocSource interface** · Dev A · S
-  - Deps: A1, S1
-  - Done when: `src/adapters/doc-source/types.ts` defines `DocSource.list(config) → Doc[]` returning `{slug, title, parent, sourceUrl, content, codeExamples, metrics}`.
-
-- **A2b — `manifest-url`: fetch + validate** · Dev A · M
-  - Deps: A2a
-  - Done when: given a manifest URL, fetches JSON, validates each entry against `ManifestEntrySchema`, warns on invalid entries without crashing.
-
-- **A2c — `manifest-url`: filter + fetch markdown** · Dev A · M
-  - Deps: A2b
-  - Done when: filters entries by `parent` slug, fetches each `markdown_source` URL, handles 404/500 gracefully, returns `{entry, content}` pairs.
-
-- **A2d — `manifest-url`: parse markdown → Doc** · Dev A · M
-  - Deps: A2c
-  - Done when: frontmatter via `gray-matter`, code blocks/links counted via `remark`. Returns complete `Doc[]`. Unit test against a checked-in mini-manifest fixture.
-
-- **A3a — `git-clone` CodeSource** · Dev A · M
-  - Deps: A1
-  - Done when: `src/adapters/code-source/git-clone.ts` shallow-clones a repo, exposes `readFile(path, startLine?, endLine?)` and `listDir(path)`. Cleans up old clones.
-
-- **A3b — `git-clone`: SHA caching** · Dev A · S
-  - Deps: A3a
-  - Done when: if cache exists and HEAD SHA matches ref, skips clone. Reruns are <1s.
-
-- **A4 — `manual-map` Mapper** · Dev A · M
-  - Deps: A1, S1
-  - Done when: reads `mappings/<project>.json`, validates against `MappingSchema`, returns `CodeTiers` by slug. Throws helpful error when a requested slug is missing.
-
-- **A4c — `bootstrap-mapping` script** · Dev A · L
-  - Deps: A2d, A3a
-  - Done when: `npx tsx scripts/bootstrap-mapping.ts <slug>` prints a proposed `{slug: CodeTiers}` JSON snippet. Uses Claude with the doc content + repo file tree. Human reviews, pastes into `mappings/*.json`.
-
-- **A5 — Seed mapping for ~10 slugs** · Dev A · M
-  - Deps: A4c
-  - Done when: `mappings/gutenberg-block-api.json` has entries for ~10 Block API Reference slugs. Caps: ≤3 primary, ≤5 secondary, ≤8 context each. Committed.
-
-- **A6a — Validator: Validator interface** · Dev A · S
-  - Deps: A1, S2
-  - Done when: `src/adapters/validator/types.ts` defines `Validator.validate(doc, context) → Issue[]`.
-
-- **A6b — Validator: context assembler** · Dev A · M
-  - Deps: A3a, A4, S2
-  - Done when: `assembleContext(doc, mapping, budget) → {files, stats}`. Starts with primary+secondary, adds context until budget hit, records what was dropped.
-
-- **A6c — Validator: Pass 1 (system prompt + tool use)** · Dev A · L
-  - Deps: A6a, A6b
-  - Done when: Claude call with cached system prompt emits `Issue[]` via tool-use matching `IssueSchema`. Unit-tested against fixture doc+code.
-
-- **A6d — Validator: verbatim evidence check** · Dev A · S
-  - Deps: A6c
-  - Done when: issues whose `evidence.codeSays` isn't literally found in the referenced file are silently rejected. Counter logged.
-
-- **A6e — Validator: Pass 2 (`fetch_code` retrieve-on-demand)** · Dev A · L
-  - Deps: A6c, A3a
-  - Done when: for each candidate issue, Claude can call `fetch_code(path, startLine?, endLine?)` to verify. Issues with `confidence < 0.7` dropped. **This is the issue to cut at the Day-3 decision point if it's not stable.**
-
-- **A7 — Pipeline orchestrator** · Dev A · M
-  - Deps: A2d, A3a, A4, A6c (Pass 1 at minimum)
-  - Done when: `runPipeline(config)` wires DocSource → CodeSource → Mapper → Validator, analyzes docs with `p-limit(3)`, emits `RunResults` that validates against the schema.
-
-- **A8 — Health scorer** · Dev A · S
-  - Deps: S2
-  - Done when: `scoreDoc(issues) → {healthScore, status}` implemented. Formula and thresholds per the spec. Overall average computed in the orchestrator.
-
-- **A9a — Test fixture: drifted doc** · Dev A · M
-  - Deps: A6c
-  - Done when: `tests/fixtures/drifted/` has a hand-tampered doc+code pair. Validator reports ≥1 `critical` issue.
-
-- **A9b — Test fixture: clean doc** · Dev A · S
-  - Deps: A6c
-  - Done when: `tests/fixtures/clean/` has a known-accurate doc+code pair. Validator reports 0 issues (after confidence filter).
-
-### Dev B — Presentation
-
-- **B1 — Config loader** · Dev B · S
-  - Deps: S3
-  - Done when: `loadConfig(path)` reads YAML, validates via `ConfigSchema`, returns typed `Config`.
-
-- **B2a — CLI skeleton** · Dev B · S
-  - Deps: S0
-  - Done when: `src/cli.ts` with flags `--config`, `--output`, `--only <slug>`, `--dry-run`. `npm run analyze -- --help` prints usage.
-
-- **B2b — CLI wired to pipeline** · Dev B · S
-  - Deps: B2a, B1, S4
-  - Done when: `npm run analyze -- --config config/gutenberg-block-api.yml --output ./out` writes `out/results.json` + a log file. Works with stub `runPipeline` returning empty results.
-
-- **B3a — Dashboard: reader + generator entry** · Dev B · S
-  - Deps: S6
-  - Done when: `src/dashboard/generate.ts` reads + validates a `results.json`, exposes `generate(results, outDir)` that writes to disk.
-
-- **B3b — Dashboard: index.html** · Dev B · M
-  - Deps: B3a, B4
-  - Done when: `out/index.html` shows overall health %, totals (critical/major/minor), and the tree view grouped by parent slug with per-folder aggregated score. Tailwind CDN, one-file HTML.
-
-- **B3c — Dashboard: doc-detail.html** · Dev B · L
-  - Deps: B3a
-  - Done when: `out/doc/<slug>.html` shows title, health score, metrics, issues (severity, confidence, quoted evidence, proposed action), positives, related-code list, source URL link. Generated one per doc from `examples/mock-results.json`.
-
-- **B3d — Dashboard: folder.html** · Dev B · M
-  - Deps: B3a, B4
-  - Done when: `out/folder/<parent>.html` shows a section's rollup and its docs. Reached via links in `index.html`.
-
-- **B4 — Tree builder** · Dev B · M
-  - Deps: S2
-  - Done when: `buildTree(docs) → TreeNode[]` groups by parent slug, aggregates health (doc-count weighted). Handles ≥200 docs cleanly.
-
-- **B6 — `publish.sh`** · Dev B · S
-  - Deps: B3b, B3c, B3d
-  - Done when: `scripts/publish.sh` (or `npm run publish`) copies `out/` to a `gh-pages` worktree and pushes. GitHub Pages serves the result.
-
-- **B7 — README** · Dev B · M
-  - Deps: B2b (so examples are real)
-  - Done when: install steps, API key setup, CLI usage, sample output, cost expectation, dashboard screenshot. Enough for your partner's partner to reproduce.
-
-### Phase 0 Validation Gate (Day 3)
-
-- **V0 — Run on 3 docs, measure P/R** · Dev A + manual review · M
-  - Deps: A5, A7 (with at least Pass 1 wired)
-  - Done when: `docs/phase-0-results.md` (or PR comment) records precision, recall, clean-doc false positives. Day-3 decision documented: keep Pass 2, cut Pass 2, or abort.
-
-### Phase 2 — After PoC is validated (committed)
+## Phase 2 — After PoC is validated (committed)
 
 - **P2-1** GitHub Action workflow: manual dispatch + weekly cron, uploads `results.json` as artifact, auto-deploys dashboard to GitHub Pages.
 - **P2-2** `wordpress-rest` DocSource: pagination, HTML→markdown normalization, Application Password auth. Produces a manifest-shaped list from a live WP site. Demoed against developer.wordpress.org or a WooCommerce docs page.
@@ -494,7 +90,7 @@ Full issue backlog: **~30 issues, ~50 dev-hours total**. Fits two devs × ~5 day
 - **P2-4** Dashboard: show source type per doc ("markdown" / "wordpress") and deep-link to the edit URL in WP so authors can fix directly.
 - **P2-5** `a8c-context` DocSource variant: use the context-a8c MCP for A8C-internal sites (Fieldguide, P2s) that aren't publicly reachable.
 
-### Stretch — nice to have
+## Stretch — nice to have
 
 - **S3** Change Detector: diffs last-analyzed commit SHA vs current, queues only changed docs + docs whose mapped code changed. Biggest cost lever per the blog post.
 - **S5** `symbol-search` Mapper (heuristic doc→code resolution to scale beyond hand-maintained mappings).
@@ -502,49 +98,11 @@ Full issue backlog: **~30 issues, ~50 dev-hours total**. Fits two devs × ~5 day
 - **S7** Slug-rename lint: warn when `mapping.json` keys aren't in the current manifest.
 - **S8** Round-trip: open a GitHub PR on the markdown source (or draft a WP post update via REST) for issues above a confidence threshold.
 
-## Phase 0 Validation (Day 3 — Decision Point)
-
-Gate everything else behind this check. It's also the go/no-go for two-pass validation.
-
-1. Pick 3 of the ~10 docs — ideally **one known-drifted, one known-clean, one uncertain** so we can measure both precision and recall.
-2. Manually read each doc + its mapped code. Write down (a) the real drift issues a human reviewer would flag, and (b) that the clean doc is actually clean.
-3. Run the validator on those 3 docs.
-4. **Measure:**
-   - **Precision** — of issues reported, how many are real? Target ≥80%.
-   - **Recall** — of the human-found issues, how many did the tool surface? Target ≥70%.
-   - **Clean-doc false positives** — on the clean doc, tool must report 0 issues (or all <0.7 confidence, which we filter). This is the single most important check: a tool that fabricates issues on good docs is worse than useless.
-5. **Day-3 decision:**
-   - **Go (precision ≥80% + clean doc shows 0 issues):** keep two-pass validation, proceed to full 10-doc run.
-   - **No-go (precision <80% OR clean doc shows false positives):** iterate the system prompt for up to half a day. If still failing, **cut Pass 2**, tighten `confidence ≥ 0.8`, rely on the runtime verbatim-evidence check, and ship the Pass-1-only version. Dashboard still demos.
-   - **Fail (still bad after cuts):** honest conversation about whether the PoC is viable — better to surface that at day 3 than day 7.
-
-## Verification (end-to-end)
-
-1. `npm install`
-2. `export ANTHROPIC_API_KEY=...`
-3. `npm run analyze -- --config config/gutenberg-block-api.yml --output ./out`
-4. `open out/index.html` — verify overall health %, tree view renders all ~10 docs grouped under `block-api`, clicking a doc opens a detail page with issues, evidence, proposed actions, and a link to the source URL.
-5. Manual precision check on 10 random issues: confirm they're real drift, not hallucination.
-6. Clean-doc check: at least one doc shows `healthy` status with 0 issues (or proves the tool can recognize health).
-7. Cost check: ≤$1 for the full 10-doc run. Flag if it exceeds $5.
-8. `npm run publish` (or `scripts/publish.sh`) pushes `out/` to the `gh-pages` branch; verify the dashboard loads at `https://juanma-wp.github.io/wp-docs-health-monitor/`.
-
-## Risks and Mitigations
-
-- **AI hallucination / false positives** → two-pass validation + quoted evidence + `confidence ≥ 0.7` + **runtime verbatim check** (`evidence.codeSays` must literally appear in the referenced file). Clean-doc fixture in tests catches drift in the validator itself.
-- **Two-pass validation is complex and time-hungry** → Day-3 decision point with a Pass-1-only fallback that still demos.
-- **Premature abstraction** → adapter interfaces designed broadly, implemented narrowly. Registry documents extension surface without dead code.
-- **Dev A / Dev B divergence** → Day-1 schema handshake + mock fixture; Dev B never blocks on Dev A.
-- **Mapping accuracy for ~10 docs** → hand-curated via bootstrap script, checked into git. Mapping errors are trivial to fix.
-- **Slug renames breaking mappings silently** → deferred. A lint step (S7) handles it later when it bites.
-- **Timeline pressure (1 week)** → GitHub Action, `symbol-search` mapper, change detector all deferred to Phase 2. Core shippable demo is CLI + local dashboard + manual `gh-pages` push.
-- **Cost runaway** → 50k input-token cap per doc + prompt caching. Expected total per 10-doc run: ≤$1. Alert threshold: $5. Measured at the end of each run, logged to console.
-
 ## Out of Scope for PoC (Week 1)
 
 - GitHub Action workflow and weekly cron — deferred to Phase 2 (P2-1).
 - `wordpress-rest` / `fs-walk` / `a8c-context` DocSources — interfaces defined, implementations deferred.
-- `symbol-search`, `hybrid`, `embedding-retrieval` mappers — interface-compatible, implementations deferred.
+- `symbol-search` / `hybrid` / `embedding-retrieval` mappers — interface-compatible, implementations deferred.
 - Auto-generated package READMEs (`packages/*/README.md`) — most are docgen output, low drift signal.
 - Auto-PRs with fixes, screenshots/image link-checking, multi-handbook coverage.
 - Fine-tuning — off-the-shelf Claude Sonnet 4.6.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,308 @@
+# WP Docs Health Monitor — PoC Plan
+
+## Context
+
+**End goal:** Keep WordPress-hosted documentation sites (developer.wordpress.org, WooCommerce docs, internal A8C docs, etc.) accurate and up-to-date against the code they describe. Docs on those sites come from two kinds of sources:
+
+1. **Markdown in a source repo** that gets synced to a WordPress site (e.g. Gutenberg's `docs/` → developer.wordpress.org Block Editor Handbook CPTs).
+2. **Custom posts edited directly in WordPress** — no git, authors write inside wp-admin (common for WooCommerce, internal A8C docs, and self-managed handbooks).
+
+Both paths drift from the code silently. No one today has a prioritized punch list of what's wrong on those WordPress sites.
+
+This project ships an automated tool that:
+- Pulls docs from either source (markdown repo OR a WordPress REST API).
+- Pulls the related source code.
+- Uses Claude to compare them and produce evidence-backed issues with health scores.
+- Renders a static dashboard doc authors can act on.
+
+The blog post at https://radicalupdates.wordpress.com/2026/04/15/block-editor-docs-health-monitor/ sets the north star (weekly runs, $0.50/week after change-detection caching, CI/CD for docs). The project should eventually feed fixes back into either source type — a PR for markdown, a WordPress post update for direct-edit sites.
+
+**Constraints agreed with the user:**
+- Small validatable PoC (5–8 docs, markdown-sourced) but **architecture designed for scalability** to different codebases and to WordPress-sourced docs.
+- Two developers working in parallel — needs cleanly separable, independently shippable issues.
+- Vertical split: Dev A owns the analysis pipeline, Dev B owns CLI/dashboard/Action/config.
+- Avoid the premature-abstraction trap: define adapter interfaces broadly, implement narrowly. PoC implements `markdown-git` only; `wordpress-rest` is a committed Phase 2 deliverable (not "maybe later").
+
+**Target for first demo (Phase 1):** Gutenberg `docs/reference-guides/block-api/` via `markdown-git`. Pick 5–8 docs (e.g. `block-metadata.md`, `block-registration.md`, `block-attributes.md`, `block-supports.md`, `block-variations.md`, `block-context.md`, `block-deprecation.md`). Tight mappings to `packages/blocks/src/api/*`, known to drift.
+
+**Target for Phase 2:** A WordPress-sourced site fetched via REST API — either developer.wordpress.org (same Block Editor Handbook content, but pulled from the published site instead of the markdown source) or a WooCommerce docs page. This proves the abstraction and is the actual shape most downstream users will want.
+
+## Architecture Overview
+
+Pluggable adapters around a stateless pipeline:
+
+```
+         ┌──────────────────────────────────────────┐
+         │  config.yml (project, sources, mapping)   │
+         └────────────────────┬──────────────────────┘
+                              ▼
+  ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+  │  DocSource  │     │ CodeSource  │     │DocCodeMapper│
+  │  (adapter)  │     │  (adapter)  │     │  (adapter)  │
+  └──────┬──────┘     └──────┬──────┘     └──────┬──────┘
+         │                   │                   │
+         ▼                   ▼                   ▼
+    docs[]              code files          doc→code[] pairs
+                              │
+                              ▼
+                    ┌──────────────────┐
+                    │    Validator     │  (Claude, two-pass,
+                    │    (adapter)     │   prompt-cached)
+                    └────────┬─────────┘
+                             ▼
+                       issues[] + scores
+                             │
+                             ▼
+                      results.json
+                             │
+              ┌──────────────┴──────────────┐
+              ▼                             ▼
+      Dashboard Generator             CLI/Action
+      (static HTML)                   (orchestration)
+```
+
+**Adapter interfaces designed, staged implementations:**
+
+| Interface        | Phase 1 (PoC)     | Phase 2 (committed)      | Later stubs              |
+|------------------|-------------------|--------------------------|--------------------------|
+| `DocSource`      | `markdown-git`    | `wordpress-rest`         | `sitemap-crawler`, `local-markdown`, `a8c-context` |
+| `CodeSource`     | `git-clone`       | (reuse)                  | `multi-repo`, `local-path` |
+| `DocCodeMapper`  | `manual-map` (YAML) | (reuse)                | `symbol-search`, `embedding-retrieval` |
+| `Validator`      | `claude`          | (reuse)                  | (only one needed)         |
+
+The registry lives in `packages/core/src/adapters/index.ts`. Unimplemented Later-stub adapters throw `NotImplementedError` — this documents the extension surface without adding dead code.
+
+**`wordpress-rest` DocSource** (Phase 2) fetches via `GET /wp-json/wp/v2/<post_type>?per_page=100` with pagination, unwraps rendered HTML back to a markdown-equivalent structure (via `turndown` or `node-html-parser` + a light converter), and returns the same `Doc[]` shape as `markdown-git` so every downstream stage is source-agnostic. Auth via Application Passwords for private sites; for A8C-internal sites, delegate to the `context-a8c` MCP (a separate adapter variant).
+
+## Tech Stack
+
+- **Node.js 20 + TypeScript (strict).** Matches Gutenberg ecosystem, first-class Anthropic SDK, natural fit for `setup-node` in Actions.
+- **Anthropic SDK (`@anthropic-ai/sdk`)** with **prompt caching** for the system prompt + shared code context, and **tool use with JSON schema** for structured issue output. Two-pass validation: (1) find candidate issues with quoted evidence, (2) verify each with targeted code re-read. Model: **`claude-sonnet-4-6`** (cost/accuracy sweet spot; upgrade to `claude-opus-4-7` only if Sonnet misses real issues during Phase 0).
+- **`simple-git`** for repo clones. **`gray-matter` + `remark`** for markdown parsing. **`zod`** for runtime schema validation on config + results.
+- **Static HTML dashboard** — no framework. Single `index.html` + per-doc detail pages generated via templates (e.g. `eta` or plain template literals). Tailwind via CDN for styling.
+- **pnpm** workspace (optional) — not required for PoC but cheap to set up if later split into `@docs-health/core` + `@docs-health/dashboard` packages.
+
+When implementing, use **context7 MCP** for up-to-date Anthropic SDK docs (prompt caching, tool use, streaming) — matches your global CLAUDE.md rule.
+
+## Repo Layout
+
+```
+wp-docs-health-monitor/
+├── packages/
+│   ├── core/                      # Dev A's territory
+│   │   ├── src/
+│   │   │   ├── adapters/
+│   │   │   │   ├── index.ts        # registry
+│   │   │   │   ├── doc-source/
+│   │   │   │   │   ├── types.ts
+│   │   │   │   │   └── markdown-git.ts
+│   │   │   │   ├── code-source/
+│   │   │   │   │   ├── types.ts
+│   │   │   │   │   └── git-clone.ts
+│   │   │   │   ├── mapper/
+│   │   │   │   │   ├── types.ts
+│   │   │   │   │   └── manual-map.ts
+│   │   │   │   └── validator/
+│   │   │   │       ├── types.ts
+│   │   │   │       └── claude.ts
+│   │   │   ├── pipeline.ts         # orchestrates adapters
+│   │   │   ├── health-scorer.ts
+│   │   │   └── types/
+│   │   │       └── results.ts      # SHARED CONTRACT (zod schema)
+│   │   └── package.json
+│   └── dashboard/                 # Dev B's territory
+│       ├── src/
+│       │   ├── generate.ts         # JSON → static HTML
+│       │   ├── templates/
+│       │   │   ├── index.html.eta
+│       │   │   ├── doc-detail.html.eta
+│       │   │   └── folder.html.eta
+│       │   └── tree-builder.ts
+│       └── package.json
+├── src/
+│   ├── cli.ts                     # Dev B — main entry
+│   └── config/
+│       ├── schema.ts              # zod schema for config.yml
+│       └── loader.ts
+├── config/
+│   └── gutenberg-block-api.yml    # PoC config
+├── mappings/
+│   └── block-api.yml              # manual doc→code map (Dev A)
+├── .github/workflows/
+│   └── analyze-docs.yml           # Dev B (stretch)
+├── examples/
+│   └── results.schema.json        # generated from zod, for Dev B to mock against
+└── README.md
+```
+
+## Shared Contract (Day 1, before branching)
+
+This is the single most important artifact. Both devs pair on it in a 1-hour kickoff, commit to `main`, then diverge.
+
+```ts
+// packages/core/src/types/results.ts
+import { z } from "zod";
+
+export const IssueSchema = z.object({
+  id: z.string(),
+  severity: z.enum(["critical", "major", "minor"]),
+  type: z.enum([
+    "outdated-api", "missing-parameter", "incorrect-example",
+    "broken-link", "unclear-explanation", "deprecated-usage"
+  ]),
+  location: z.object({ line: z.number().int(), text: z.string() }),
+  issue: z.string(),
+  evidence: z.object({
+    docSays: z.string(),
+    codeSays: z.string(),
+    codeFile: z.string(),
+    codeLine: z.number().int().optional()
+  }),
+  suggestion: z.string(),
+  confidence: z.number().min(0).max(1)
+});
+
+export const DocResultSchema = z.object({
+  file: z.string(),
+  url: z.string().url().optional(),
+  analyzedAt: z.string().datetime(),
+  commitSha: z.string(),       // enables change detection later
+  healthScore: z.number().min(0).max(100),
+  status: z.enum(["healthy", "needs-attention", "critical"]),
+  metrics: z.object({
+    wordCount: z.number(),
+    codeExamples: z.number(),
+    internalLinks: z.number(),
+    externalLinks: z.number(),
+    lastModified: z.string().datetime().optional()
+  }),
+  relatedCode: z.array(z.string()),
+  issues: z.array(IssueSchema),
+  positives: z.array(z.string())
+});
+
+export const RunResultsSchema = z.object({
+  project: z.string(),
+  runId: z.string(),
+  analyzedAt: z.string().datetime(),
+  scope: z.object({
+    source: z.string(),
+    docsCount: z.number()
+  }),
+  overallHealth: z.number().min(0).max(100),
+  totals: z.object({
+    critical: z.number(),
+    major: z.number(),
+    minor: z.number()
+  }),
+  docs: z.array(DocResultSchema)
+});
+
+export type RunResults = z.infer<typeof RunResultsSchema>;
+```
+
+Dev B generates `examples/results.schema.json` from this and mocks a fixture, so Dev B's dashboard work is unblocked immediately — doesn't have to wait for real pipeline output.
+
+## Issues for Parallel Work
+
+Numbering prefix: A = pipeline (Dev A), B = presentation (Dev B), S = shared/stretch.
+
+### Day 1 — Shared Kickoff (both devs)
+- **S0** Repo init, tsconfig, eslint, prettier, pnpm/npm setup.
+- **S1** Define and merge `RunResultsSchema` (zod) and `ConfigSchema`. Export generated JSON Schema to `examples/`.
+- **S2** Agree on CLI entry point signature: `runPipeline(config: Config): Promise<RunResults>`. Dev B calls this from `cli.ts`; Dev A provides the implementation.
+
+### Dev A — Pipeline
+
+- **A1** Adapter interfaces + registry (`doc-source`, `code-source`, `mapper`, `validator`). Unimplemented adapters throw `NotImplementedError`.
+- **A2** `markdown-git` DocSource: clones a repo shallowly, reads a section's `.md` files, parses frontmatter + code blocks via `gray-matter` + `remark`. Returns `Doc[]` with `{path, url, content, codeExamples, metrics}`.
+- **A3** `git-clone` CodeSource: shallow-clones a repo, exposes `readFile(relPath)` and `listDir(relPath)`. Handles caching between runs via commit SHA.
+- **A4** `manual-map` Mapper: loads `mappings/block-api.yml`, resolves doc path → list of code file paths.
+- **A5** Manual mapping file: write `mappings/block-api.yml` for the 5–8 chosen docs. Format:
+  ```yaml
+  - doc: reference-guides/block-api/block-metadata.md
+    code:
+      - packages/blocks/src/api/registration.js
+      - packages/blocks/src/api/parser.js
+  ```
+- **A6** Claude Validator:
+  - System prompt (cached): rules for identifying genuine drift, forbidding hallucination, requiring quoted evidence.
+  - Tool-use schema matches `IssueSchema`.
+  - Pass 1 (cached code context): emit candidate issues.
+  - Pass 2 (per-issue): for each candidate, re-fetch the exact code lines referenced and ask the model to confirm/reject. Discard confidence < 0.7.
+  - Budget: 50k input tokens/doc max, most of it cached.
+- **A7** Pipeline orchestrator (`runPipeline`): wires the adapters, emits `RunResults`. Concurrency: analyze docs in parallel with `p-limit` (default 3).
+- **A8** Health scorer: formula + thresholds for `healthScore` and `status`. Keep it simple (e.g. `100 - (critical*15 + major*7 + minor*2)`, clamp 0..100).
+- **A9** Unit tests for the validator prompt using a known-drifted doc fixture — the quality gate before demo.
+
+### Dev B — Presentation
+
+- **B1** Config loader: YAML → validated `Config` via zod.
+- **B2** CLI (`npm run analyze -- --config config/gutenberg-block-api.yml --output ./out`). Flags: `--config`, `--output`, `--only <glob>`, `--dry-run`.
+- **B3** Dashboard generator: reads `results.json`, produces:
+  - `out/index.html` — overall health, tree view of docs with per-folder aggregates.
+  - `out/doc/<slug>.html` — detail page with issues, evidence, suggestions.
+  - `out/folder/<path>.html` — folder summary.
+  - Tailwind via CDN, no build step.
+- **B4** Tree builder: given a flat list of doc paths, build the nested folder tree with aggregated health scores.
+- **B5** Mock fixture: checked-in `examples/mock-results.json` for dashboard dev without running the pipeline.
+- **B6** GitHub Action workflow (stretch for PoC): manual dispatch + weekly cron, uploads dashboard as artifact. Deploy to GitHub Pages after PoC is validated.
+- **B7** README with example commands + screenshots + cost expectations.
+
+### Phase 2 — After PoC is validated (committed)
+
+- **P2-1** `wordpress-rest` DocSource: pagination, HTML→markdown normalization, Application Password auth, meta/slug round-trip fields so fixes can later be written back. Demoed against one real WP docs site (dev.wordpress.org or a WooCommerce page).
+- **P2-2** Dashboard: show source type per doc ("markdown" / "wordpress") and deep-link to the edit URL in WP so authors can fix directly.
+- **P2-3** `a8c-context` DocSource variant: use the context-a8c MCP for A8C-internal sites (Fieldguide, P2s) that aren't publicly reachable.
+
+### Stretch — nice to have
+
+- **S3** Change Detector: diffs last-analyzed commit SHA vs current, queues only changed docs + docs whose mapped code changed. Biggest cost lever per the blog post.
+- **S5** `symbol-search` Mapper (heuristic doc→code resolution to reduce manual mapping work for new sections).
+- **S6** Trend tracking across runs (store history, show trend line in dashboard).
+- **S7** GitHub Pages deploy in the Action.
+- **S8** Round-trip: open a GitHub PR on the markdown source (or draft a WP post update via REST) for issues above a confidence threshold.
+
+## Phase 0 Validation (before PoC scale-up)
+
+Day 2–3 of Dev A's work, gate everything else behind it:
+
+1. Pick 3 of the 5–8 docs.
+2. Manually read each doc + its mapped code. Write down what a human reviewer considers the top drift issues.
+3. Run the validator on those 3 docs.
+4. Measure precision: of issues reported, how many are real? Target ≥80%. Recall: of the human-found issues, how many did it surface? Target ≥70%.
+5. If precision is weak, iterate the system prompt before scaling. If it still fails, that's a go/no-go signal — better to learn at day 3 than day 14.
+
+## Verification (end-to-end)
+
+1. `npm install`
+2. `export ANTHROPIC_API_KEY=...`
+3. `npm run analyze -- --config config/gutenberg-block-api.yml --output ./out`
+4. `open out/index.html` — verify tree view renders, scores look reasonable, clicking a doc shows evidence-backed issues with line numbers and suggestions.
+5. Manual precision check on 10 random issues: confirm they're real drift, not hallucination.
+6. Cost check: ≤$1 for the full 5–8 doc run.
+7. (Stretch) Trigger the GitHub Action manually, verify artifact upload.
+
+## Risks and Mitigations
+
+- **AI hallucination / false positives** → two-pass validation + quoted evidence requirement + confidence threshold ≥0.7. Reject any issue whose `evidence.codeSays` can't be found verbatim in the referenced file (validate in code, not just the prompt).
+- **Premature abstraction** → adapter interfaces are stubs; only implemented adapters get code. Registry documents the extension surface without adding maintenance burden.
+- **Dev A / Dev B divergence** → Day-1 schema handshake + mock fixture; Dev B never has to wait on Dev A.
+- **Mapping accuracy for the 5–8 docs** → manual, curated, checked into git; mapping errors are quick to fix when a human spotted the issue.
+- **Timeline pressure** → GitHub Action, Pages deploy, change detector are all marked stretch. Core shippable demo is the CLI + local dashboard.
+
+## Out of Scope for PoC
+
+- Auto-generated package READMEs (`packages/*/README.md`) — most are docgen output, low drift signal.
+- WordPress REST / wpcom doc sources — interface defined, implementation deferred.
+- Auto-PRs with fixes, screenshots analysis, multi-handbook coverage.
+- Fine-tuning — off-the-shelf Claude Sonnet 4.6.
+
+## Open Questions (non-blocking)
+
+- Does the repo live in a personal GitHub or in a WordPress/Automattic org? (affects Action secrets and Pages URL — answer before B6.)
+- Licensing: MIT to match the WordPress ecosystem? (confirm before repo init.)
+- Should the 5–8 docs include any known-clean ones as controls? (recommended — two "healthy" and six "suspect" gives a better demo than all-suspect.)
+- **Phase 2 target site**: developer.wordpress.org (Block Editor Handbook pulled from the published site) vs a WooCommerce docs page vs an internal A8C docs P2. Each has different auth, different content shape, and different audience. Decide before P2-1 starts.
+- **Fix round-trip**: do we want to auto-open PRs / draft WP post updates (S8), or keep the tool strictly read-only and leave fixes to humans? Auto-PRs change the trust bar significantly.
+- **Markdown↔WP drift**: when both a markdown source AND a WP-edited post exist for the same doc, they can drift from each other. Out of scope for PoC, but worth flagging because it's a real failure mode.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # WP Docs Health Monitor — PoC Plan
 
-> **Reading order:** start here. Technical details live in [docs/architecture.md](./docs/architecture.md). Issues to pick up live in [docs/backlog.md](./docs/backlog.md).
+> **Reading order:** start here for the overview. Technical details → [docs/architecture.md](./docs/architecture.md). Tasks (what to build) → [docs/backlog.md](./docs/backlog.md). Schedule (when to build it) → [docs/timeline.md](./docs/timeline.md).
 
 ## Context
 
@@ -35,7 +35,7 @@ The blog post at https://radicalupdates.wordpress.com/2026/04/15/block-editor-do
 
 **Phase 2 (Weeks 2–4, month-end target):** Scale to the **full Block Editor Handbook** — ~150 editorial docs (filter out auto-generated package READMEs). Build the `symbol-search` mapper so we don't hand-curate 150 entries. Harden the dashboard for scale. Ship a **GitHub Action with a weekly cron** that runs the pipeline and auto-deploys the dashboard to GitHub Pages — the cron is what makes "CI/CD for docs" real, not a manual habit.
 
-**Post-month (not committed):** `wordpress-rest` DocSource, second handbook (e.g. Themes Handbook — assuming it's actually WP-edited and not markdown-sourced), GitHub Action automation, trend tracking. Architecturally supported since Week 1, but deliberately deferred so month-end stays achievable.
+**Post-month (not committed):** `wordpress-rest` DocSource, second handbook (e.g. Themes Handbook — assuming it's actually WP-edited and not markdown-sourced), `fs-walk` adapter, source-type awareness in the dashboard, `a8c-context` MCP adapter. Architecturally supported since Week 1, but deliberately deferred so month-end stays achievable.
 
 ## Architecture at a Glance
 
@@ -71,11 +71,11 @@ Pluggable adapters around a stateless pipeline:
       (static HTML)                   (orchestration)
 ```
 
-| Interface        | Phase 1 (PoC)     | Phase 2 (committed)      | Later stubs              |
+| Interface        | Phase 1 (PoC, Week 1)     | Phase 2 (committed, Weeks 2–4) | Post-month / Later stubs              |
 |------------------|-------------------|--------------------------|--------------------------|
-| `DocSource`      | `manifest-url` (consumes Gutenberg-style `manifest.json`) | `wordpress-rest`, `fs-walk` (generate manifest for markdown sites without one) | `sitemap-crawler`, `a8c-context` |
+| `DocSource`      | `manifest-url` (consumes Gutenberg-style `manifest.json`) | (reuse `manifest-url`) | `wordpress-rest` (D1), `fs-walk` (D4), `a8c-context` (D5), `sitemap-crawler` |
 | `CodeSource`     | `git-clone`       | (reuse)                  | `multi-repo`, `local-path` |
-| `DocCodeMapper`  | `manual-map` (slug-keyed JSON, tiered) + LLM-bootstrap helper | (reuse) | `symbol-search`, `embedding-retrieval`, `hybrid` |
+| `DocCodeMapper`  | `manual-map` (slug-keyed JSON, tiered) + LLM-bootstrap helper | `symbol-search` (M1) | `hybrid`, `embedding-retrieval` |
 | `Validator`      | `claude`          | (reuse)                  | (only one needed)         |
 
 Unimplemented Later-stub adapters throw `NotImplementedError` — documents the extension surface without adding dead code.
@@ -110,20 +110,23 @@ Architecture supports these; we defer to keep month-end achievable. Promote to c
 ## Stretch — nice to have
 
 - **S3** Change Detector: diffs last-analyzed commit SHA vs current, queues only changed docs + docs whose mapped code changed. Biggest cost lever per the blog post.
-- **S6** Trend tracking across runs (store history, show trend line in dashboard).
 - **S7** Slug-rename lint: warn when `mapping.json` keys aren't in the current manifest.
 - **S8** Round-trip: open a GitHub PR on the markdown source (or draft a WP post update via REST) for issues above a confidence threshold.
 
+*(S5 promoted to committed Phase 2 as M1 `symbol-search` mapper. S6 trend tracking now covered by committed M8 historical dashboard.)*
+
 ## Out of Scope for PoC (Week 1)
 
-- GitHub Action workflow and weekly cron — deferred to Phase 2 (P2-1).
-- `wordpress-rest` / `fs-walk` / `a8c-context` DocSources — interfaces defined, implementations deferred.
-- `symbol-search` / `hybrid` / `embedding-retrieval` mappers — interface-compatible, implementations deferred.
+- GitHub Action workflow and weekly cron — Week 1 out of scope; lands in Phase 2 (M7).
+- `symbol-search` mapper — Week 1 uses manual mapping; `symbol-search` lands in Phase 2 (M1).
+- Historical dashboard UI — Week 1 ships the data-model groundwork; UI lands in Phase 2 (M8).
+- `wordpress-rest` / `fs-walk` / `a8c-context` DocSources — interfaces defined; implementations post-month.
+- `hybrid` / `embedding-retrieval` mappers — interface-compatible; implementations post-month.
 - Auto-generated package READMEs (`packages/*/README.md`) — most are docgen output, low drift signal.
 - Auto-PRs with fixes, screenshots/image link-checking, multi-handbook coverage.
 - Fine-tuning — off-the-shelf Claude Sonnet 4.6.
 - PHP / wordpress-develop code source — gutenberg repo only in Week 1.
-- Slug-rename detection, trend tracking, gamification.
+- Slug-rename detection, gamification.
 
 ## Open Questions (non-blocking)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -148,6 +148,7 @@ Architecture supports these; deferred until the Phase 2 demo lands.
 
 ## Open Questions
 
+- **Release pinning:** `CodeSource` currently defaults to `trunk`, which contains unreleased code no end user runs. See [docs/release-pinning.md](./docs/release-pinning.md) for the proposed fix (pin to the latest stable Gutenberg release tag) and the Phase 2 deferral rationale.
 - **Known-clean controls:** which 1–2 of the chosen Block API docs are known-accurate? Include them explicitly so recall measurement has a baseline.
 - **Editorial-only filter rules:** are all `packages/*/README.md` truly auto-generated? Confirm before Phase 2 excludes them wholesale — a false exclusion hides real drift.
 - **Themes Handbook source model:** verify whether it's markdown-sourced or WP-edited. Answer gates whether D3 becomes a meaningful `wordpress-rest` demo.

--- a/PLAN.md
+++ b/PLAN.md
@@ -25,15 +25,17 @@ The blog post at https://radicalupdates.wordpress.com/2026/04/15/block-editor-do
 - Small validatable first iteration (~10 docs) but **architecture designed to scale to ~200 docs/site**.
 - **"Docs might be OK" is a valid outcome** — the tool must confidently report *healthy* when nothing is wrong, not just find issues. Recall (did we miss drift?) matters as much as precision (is what we found real?).
 - Two developers working in parallel — cleanly separable, independently shippable issues.
-- Vertical split: Dev A owns the analysis pipeline, Dev B owns CLI + dashboard + config.
+- Vertical split: Track A owns the analysis pipeline, Track B owns CLI + dashboard + config. Either dev can own either track — both using Claude Code.
 - **Public GitHub repo + GitHub Pages** for the dashboard. Dashboard is the product — overall health %, per-doc detail pages with evidence and proposed actions, informational (no gamification).
 - Quality first, cost secondary. Flag if costs go off rails (rough guardrail: < $5 per full 10-doc PoC run).
 
 ## Targets
 
-**Phase 1 (Week 1, demo target):** ~10 docs from the Gutenberg Block API Reference (https://developer.wordpress.org/block-editor/reference-guides/block-api/) — e.g. `block-metadata`, `block-registration`, `block-attributes`, `block-supports`, `block-variations`, `block-context`, `block-deprecation`, `block-transforms`, `block-patterns`, `block-bindings`. Tight mappings to `packages/blocks/src/api/*` and `schemas/json/block.json`. Code source: **gutenberg only** (no wordpress-develop/PHP core in Week 1).
+**Phase 1 (Week 1, PoC):** ~10 docs from the Gutenberg Block API Reference (https://developer.wordpress.org/block-editor/reference-guides/block-api/) — e.g. `block-metadata`, `block-registration`, `block-attributes`, `block-supports`, `block-variations`, `block-context`, `block-deprecation`, `block-transforms`, `block-patterns`, `block-bindings`. Tight mappings to `packages/blocks/src/api/*` and `schemas/json/block.json`. Code source: **gutenberg only**. Manual mapping. Proves the pipeline.
 
-**Phase 2:** A WordPress-sourced site fetched via REST API — either developer.wordpress.org (Block Editor Handbook from the published site instead of the markdown source) or a WooCommerce docs page. Proves the abstraction and is the shape downstream users will want.
+**Phase 2 (Weeks 2–4, month-end target):** Scale to the **full Block Editor Handbook** — ~150 editorial docs (filter out auto-generated package READMEs). Build the `symbol-search` mapper so we don't hand-curate 150 entries. Harden the dashboard for scale. Ship a **GitHub Action with a weekly cron** that runs the pipeline and auto-deploys the dashboard to GitHub Pages — the cron is what makes "CI/CD for docs" real, not a manual habit.
+
+**Post-month (not committed):** `wordpress-rest` DocSource, second handbook (e.g. Themes Handbook — assuming it's actually WP-edited and not markdown-sourced), GitHub Action automation, trend tracking. Architecturally supported since Week 1, but deliberately deferred so month-end stays achievable.
 
 ## Architecture at a Glance
 
@@ -82,18 +84,32 @@ Full technical details (schemas, repo layout, mapping format, tech stack) → [d
 
 Issue-level plan with owners, deps, and acceptance criteria → [docs/backlog.md](./docs/backlog.md).
 
-## Phase 2 — After PoC is validated (committed)
+## Phase 2 — Scale-up to Full Block Editor Handbook (Weeks 2–4)
 
-- **P2-1** GitHub Action workflow: manual dispatch + weekly cron, uploads `results.json` as artifact, auto-deploys dashboard to GitHub Pages.
-- **P2-2** `wordpress-rest` DocSource: pagination, HTML→markdown normalization, Application Password auth. Produces a manifest-shaped list from a live WP site. Demoed against developer.wordpress.org or a WooCommerce docs page.
-- **P2-3** `fs-walk` DocSource: generates a manifest for markdown repos that don't publish one (WooCommerce docs repo, etc.).
-- **P2-4** Dashboard: show source type per doc ("markdown" / "wordpress") and deep-link to the edit URL in WP so authors can fix directly.
-- **P2-5** `a8c-context` DocSource variant: use the context-a8c MCP for A8C-internal sites (Fieldguide, P2s) that aren't publicly reachable.
+Committed. Breaks into issues at Week-2 kickoff; coarse milestones here:
+
+- **M1** `symbol-search` Mapper — extract symbols from each doc (function names, types, hooks, attribute names, code-block imports); AST-grep Gutenberg via `ast-grep`/`tree-sitter`; rank by specificity × centrality × recency; output tiered `MappingSchema`. Validated against Week-1 manual mappings (≥70% agreement on `primary`).
+- **M2** Editorial-only filter in `manifest-url` — exclude `packages/*/README.md` and `packages/components/src/*/README.md`. Filters ~424 → ~150 docs.
+- **M3** Pipeline at scale — raise concurrency, add per-run cost meter with a hard stop at $5 (configurable), checkpoint results after each doc so a crash doesn't restart the whole run.
+- **M4** Dashboard at scale — tree collapse, search/filter by status, page loads <1s with 150 docs.
+- **M5** Full-handbook run + publish — one production-shaped run on all ~150 docs, manual spot-check of ~20 issues, published to `https://juanma-wp.github.io/wp-docs-health-monitor/`.
+- **M6** Runbook — documented procedure for manual one-off runs (backup path when the Action is down or under development).
+- **M7** GitHub Action with weekly cron — `.github/workflows/analyze-docs.yml` with `workflow_dispatch` for manual dispatch and `schedule: cron: '0 6 * * 1'` (Mondays 06:00 UTC) for the weekly run. Uses an `ANTHROPIC_API_KEY` repo secret, uploads `results.json` as an artifact, and auto-deploys the dashboard to GitHub Pages via the `actions/deploy-pages` flow. One green scheduled run is the acceptance bar.
+- **M8** Historical dashboard — each run archived as `data/runs/<runId>/results.json` on the `gh-pages` branch. Dashboard shows a trend line of overall health, "new this week" / "persistent for N runs" badges on issues (using stable `Issue.fingerprint` hashes), and a per-doc sparkline. Data-model groundwork ships with S-track in Week 1; UI lands in Phase 2 once there are 2–3 runs to draw on.
+
+## Post-month (not committed, deliberately deferred)
+
+Architecture supports these; we defer to keep month-end achievable. Promote to committed once the month-end demo lands.
+
+- **D1** `wordpress-rest` DocSource: pagination, HTML→markdown normalization, Application Password auth. Produces a manifest-shaped list from a live WP site.
+- **D2** Second handbook PoC: **Themes Handbook** (if actually WP-edited and not markdown-sourced — verify first) or a WooCommerce docs page, through `wordpress-rest`.
+- **D3** Source-type awareness in dashboard: label docs "markdown" / "wordpress", deep-link to WP edit URL for WP-sourced docs.
+- **D4** `fs-walk` DocSource for markdown repos without a manifest.
+- **D5** `a8c-context` DocSource variant (context-a8c MCP for A8C-internal sites).
 
 ## Stretch — nice to have
 
 - **S3** Change Detector: diffs last-analyzed commit SHA vs current, queues only changed docs + docs whose mapped code changed. Biggest cost lever per the blog post.
-- **S5** `symbol-search` Mapper (heuristic doc→code resolution to scale beyond hand-maintained mappings).
 - **S6** Trend tracking across runs (store history, show trend line in dashboard).
 - **S7** Slug-rename lint: warn when `mapping.json` keys aren't in the current manifest.
 - **S8** Round-trip: open a GitHub PR on the markdown source (or draft a WP post update via REST) for issues above a confidence threshold.
@@ -112,7 +128,8 @@ Issue-level plan with owners, deps, and acceptance criteria → [docs/backlog.md
 ## Open Questions (non-blocking)
 
 - **Known-clean controls in the 10 docs:** which 1–2 of the chosen Block API docs are known to be accurate? Include them on purpose so recall measurement has a baseline.
-- **Phase 2 target site:** developer.wordpress.org vs a WooCommerce docs page vs an A8C-internal P2. Decide before P2-2 starts — each has different auth, content shape, and audience.
+- **Editorial-only filter rules:** are all `packages/*/README.md` truly auto-generated docgen output? Confirm before M2 excludes them wholesale — a false exclusion hides real drift.
+- **Themes Handbook source model:** verify whether it's markdown-sourced or actually WP-edited. Answer gates whether D3 becomes a meaningful `wordpress-rest` demo or just another markdown handbook.
 - **Fix round-trip (S8):** auto-open PRs / draft WP post updates, or stay strictly read-only? Auto-PRs change the trust bar significantly.
-- **Markdown↔WP drift:** when both a markdown source AND a WP-edited post exist for the same doc, they can drift from *each other*. Out of scope for PoC, worth flagging as a real failure mode for later.
-- **Bifrost P2 / Radical Speed Month framing:** does the Week-1 demo need to hit a specific forum or deadline beyond the generic 1-week bar?
+- **Markdown↔WP drift:** when both a markdown source AND a WP-edited post exist for the same doc, they can drift from *each other*. Worth flagging as a real failure mode for later.
+- **Bifrost P2 / Radical Speed Month framing:** does the month-end demo need to hit a specific forum or write-up beyond the generic "publish + share link" bar?

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The tool compares docs (from markdown in a repo or from a WordPress REST API) ag
 
 - **[`PLAN.md`](./PLAN.md)** — overview, scope, architecture at a glance, out-of-scope, open questions.
 - **[`docs/architecture.md`](./docs/architecture.md)** — technical details: repo layout, schemas, mapping format, tech stack, risks.
-- **[`docs/backlog.md`](./docs/backlog.md)** — ~30 individually-shippable issues with owner, deps, and acceptance criteria. Week-1 timeline.
+- **[`docs/backlog.md`](./docs/backlog.md)** — what to build: 5 Week-1 issues + Phase 2 milestones, with owner, deps, and acceptance criteria.
+- **[`docs/timeline.md`](./docs/timeline.md)** — when to build it: milestones with target dates, gates, dependencies across the month.
 
 ## Why
 
@@ -23,7 +24,7 @@ The Block Editor Handbook alone has 150+ editorial docs that silently drift from
 3. **Static HTML dashboard** — one file per doc, color-coded health scores, linkable deep-URLs for fixing.
 4. **GitHub Action** for weekly cron + manual dispatch (stretch for the PoC).
 
-See [`PLAN.md`](./PLAN.md) for the design, [`docs/architecture.md`](./docs/architecture.md) for the schemas, and [`docs/backlog.md`](./docs/backlog.md) for the issue breakdown and verification plan.
+See [`PLAN.md`](./PLAN.md) for the design, [`docs/architecture.md`](./docs/architecture.md) for the schemas, [`docs/backlog.md`](./docs/backlog.md) for the issue breakdown, and [`docs/timeline.md`](./docs/timeline.md) for the schedule.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ The tool compares docs (from markdown in a repo or from a WordPress REST API) ag
 
 ## Status
 
-🌱 Early. The first design proposal lives in [`PLAN.md`](./PLAN.md) (proposed via PR — review, challenge, and refine there before any implementation starts).
+🌱 Early. Design proposed via PR — review, challenge, and refine before implementation starts.
+
+- **[`PLAN.md`](./PLAN.md)** — overview, scope, architecture at a glance, out-of-scope, open questions.
+- **[`docs/architecture.md`](./docs/architecture.md)** — technical details: repo layout, schemas, mapping format, tech stack, risks.
+- **[`docs/backlog.md`](./docs/backlog.md)** — ~30 individually-shippable issues with owner, deps, and acceptance criteria. Week-1 timeline.
 
 ## Why
 
@@ -19,7 +23,7 @@ The Block Editor Handbook alone has 150+ editorial docs that silently drift from
 3. **Static HTML dashboard** — one file per doc, color-coded health scores, linkable deep-URLs for fixing.
 4. **GitHub Action** for weekly cron + manual dispatch (stretch for the PoC).
 
-See [`PLAN.md`](./PLAN.md) for the full design, issue breakdown, and verification plan.
+See [`PLAN.md`](./PLAN.md) for the design, [`docs/architecture.md`](./docs/architecture.md) for the schemas, and [`docs/backlog.md`](./docs/backlog.md) for the issue breakdown and verification plan.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,351 +1,201 @@
 # Architecture
 
-Back to [PLAN.md](../PLAN.md) · For the issue backlog see [backlog.md](./backlog.md).
+Back to [PLAN.md](../PLAN.md) · Issues in [backlog.md](./backlog.md) · Schedule in [timeline.md](./timeline.md).
 
-Technical reference: how the pieces fit, the schemas they exchange, and the file layout. Changes as we learn; keep in sync with `src/types/*`.
-
----
-
-## Repo Layout
-
-```
-wp-docs-health-monitor/
-├── src/
-│   ├── adapters/                    # Track A
-│   │   ├── index.ts                  # registry
-│   │   ├── doc-source/
-│   │   │   ├── types.ts
-│   │   │   └── manifest-url.ts       # PoC impl (consumes Gutenberg manifest.json)
-│   │   ├── code-source/
-│   │   │   ├── types.ts
-│   │   │   └── git-clone.ts
-│   │   ├── mapper/
-│   │   │   ├── types.ts
-│   │   │   └── manual-map.ts         # reads slug-keyed JSON
-│   │   └── validator/
-│   │       ├── types.ts
-│   │       └── claude.ts             # two-pass, prompt-cached, tool-use
-│   ├── pipeline.ts                  # Track A — wires adapters, emits RunResults
-│   ├── health-scorer.ts             # Track A
-│   ├── config/                      # Track B
-│   │   ├── schema.ts
-│   │   └── loader.ts
-│   ├── dashboard/                   # Track B
-│   │   ├── generate.ts               # RunResults → static HTML
-│   │   ├── templates/
-│   │   │   ├── index.html.eta
-│   │   │   ├── doc-detail.html.eta
-│   │   │   └── folder.html.eta
-│   │   └── tree-builder.ts
-│   ├── cli.ts                       # Track B — main entry
-│   └── types/
-│       ├── results.ts                # SHARED CONTRACT (zod)
-│       └── mapping.ts                # MappingSchema + Manifest types
-├── scripts/
-│   └── bootstrap-mapping.ts         # LLM-assisted helper: slug → JSON candidate (Track A)
-├── config/
-│   └── gutenberg-block-api.yml      # PoC config
-├── mappings/
-│   └── gutenberg-block-api.json     # slug-keyed tiered map (Track A)
-├── examples/
-│   ├── mock-results.json            # for dashboard dev without running pipeline (Track B)
-│   └── results.schema.json          # generated from zod
-├── out/                             # gitignored — generated dashboard
-├── package.json                     # single flat package
-├── tsconfig.json
-├── PLAN.md
-├── README.md
-└── docs/
-    ├── architecture.md              # this file
-    └── backlog.md
-```
-
-No `packages/` directory, no monorepo, no GitHub Action workflow in Week 1. The Action ships in Phase 2 (M7); monorepo stays out unless genuinely needed later.
+Technical decisions, patterns, and the rationale behind them. Not a file map — for that, read the source. This document explains *why* the system is built the way it is and what to reach for when building each part.
 
 ---
 
-## Tech Stack
+## Contents
 
-- **Node.js 20 + TypeScript (strict).** Matches Gutenberg ecosystem, first-class Anthropic SDK, natural fit for `setup-node` in Actions later.
-- **Anthropic SDK (`@anthropic-ai/sdk`)** with **prompt caching** for the system prompt + shared code context, and **tool use with JSON schema** for structured issue output. Two-pass validation: (1) find candidate issues with quoted evidence, (2) verify each with targeted code re-read. Model: **`claude-sonnet-4-6`** (cost/accuracy sweet spot; upgrade to `claude-opus-4-7` only if Sonnet misses real issues during Phase 0).
-- **`simple-git`** for repo clones. **`gray-matter` + `remark`** for markdown parsing. **`zod`** for runtime schema validation on config + results.
-- **Static HTML dashboard** — no framework. `index.html` + per-doc detail pages via templates (`eta` or plain template literals). Tailwind via CDN, no build step.
-- **Single flat npm package** for Week 1. No monorepo, no pnpm workspaces.
-
-When implementing, use the **context7 MCP** for up-to-date Anthropic SDK docs (prompt caching, tool use, streaming).
-
----
-
-## Doc Index & Mapping Format
-
-Two files per site. Decoupled concerns: *what docs exist* vs *what code each one relates to*.
-
-### File 1 — `manifest.json` (doc index)
-
-Canonical format = **Gutenberg's `manifest.json`** (https://github.com/WordPress/gutenberg/blob/trunk/docs/manifest.json). Each entry:
-
-```json
-{
-  "title": "Block Metadata",
-  "slug": "block-metadata",
-  "markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/docs/reference-guides/block-api/block-metadata.md",
-  "parent": "block-api"
-}
-```
-
-For Gutenberg, we **consume the existing manifest verbatim** — no work, no maintenance. Just fetch the URL and filter by `parent: "block-api"` for Week 1.
-
-For sites that don't publish a manifest (WooCommerce docs, internal A8C sites, any markdown repo), later phases **generate** one: `fs-walk` adapter for markdown repos, `wordpress-rest` adapter for WP-sourced sites. Output conforms to the same shape.
-
-### File 2 — `mapping.json` (doc → code)
-
-Slug-keyed JSON with tiered code lists. **Slug is the primary key**, not file path — more stable when docs get reorganized.
-
-```json
-// mappings/gutenberg-block-api.json
-{
-  "block-metadata": {
-    "primary":   ["packages/blocks/src/api/registration.js", "schemas/json/block.json"],
-    "secondary": ["packages/blocks/src/api/parser.js", "packages/blocks/src/api/process-block-type.js"],
-    "context":   ["packages/block-editor/src/components/block-edit/index.js"]
-  },
-  "block-registration": {
-    "primary":   ["packages/blocks/src/api/registration.js"],
-    "secondary": [],
-    "context":   []
-  }
-}
-```
-
-**Tiers are token-budget hints for the validator:**
-- `primary` — always sent. Source of truth for this doc.
-- `secondary` — usually sent. Supporting context that catches most real drift.
-- `context` — dropped first when budget is tight; retrieved on demand in Pass 2.
-
-### Why two separate files
-
-- `manifest.json` is **site metadata** (could be upstreamed, machine-generated, maintained by doc owners).
-- `mapping.json` is **tool-specific knowledge** (maintained by us or by contributors using the tool).
-- Separation means we can drop a new site in by adding one `mapping.json` — the manifest is whatever the site already has (or generated once).
-
-### LLM-assisted bootstrap
-
-Hand-writing mappings doesn't scale past ~50 docs. A one-shot dev-time helper — `scripts/bootstrap-mapping.ts <slug>` — asks Claude *"given this doc and this file tree, which files are `primary`/`secondary`/`context`?"* and writes a candidate JSON block. A human reviews and trims before committing.
-
-Not a runtime adapter — a CLI helper you run once per doc. The `manual-map` adapter stays deterministic at analysis time.
-
-### Scaling path beyond PoC
-
-1. **Phase 1 (PoC):** `manual-map` slug-keyed JSON + bootstrap script. ~10 docs, <1 hour with the helper.
-2. **Phase 2+:** `symbol-search` mapper — extract symbols from doc (functions, hooks, attribute names, code-block imports), AST-grep the codebase via `ast-grep`/`tree-sitter`, rank by proximity and specificity. Auto-generates a candidate mapping.
-3. **Phase 3:** `hybrid` mapper — `symbol-search` candidates + a JSON overrides layer (`include` / `exclude` / `pin`) for manual corrections. Long-term shape.
-4. **(Optional) `embedding-retrieval`:** semantic similarity when symbol matching isn't enough. Heavier infra; only if needed.
-
-All four share the same `DocCodeMapper` interface — swapping is an adapter-config change, not a rewrite. The PoC JSON format is forward-compatible: it becomes the "override" layer in the hybrid adapter with an `overrides:` key added.
-
-### Known limitation (deferred)
-
-**Slug renames break the mapping silently.** If the manifest renames `block-metadata` → `block-json-metadata`, our `mapping.json` key is stale and the validator reports "no mapping found". Low probability in practice. Mitigation when we hit it: a lint step at run-start warning about mapping keys not present in the manifest. Deferred — not implemented in Week 1.
+- [Stack](#stack)
+- [Adapter Pattern](#adapter-pattern)
+- [Project Foundation — Shared Contract](#project-foundation--shared-contract)
+- [Doc Ingestion](#doc-ingestion-docsource)
+- [Code Ingestion](#code-ingestion-codesource)
+- [Doc–Code Mapping](#doccode-mapping-doccodemapper)
+- [Drift Validator](#drift-validator)
+  - [What counts as drift](#what-counts-as-drift)
+  - [What does not count as drift](#what-does-not-count-as-drift)
+- [Dashboard + CLI](#dashboard--cli)
+- [Results Storage & History](#results-storage--history)
+- [Risks and Mitigations](#risks-and-mitigations)
 
 ---
 
-## Shared Contract (Day 1, before branching)
+## Stack
 
-This is the single most important artifact. Both devs pair on it in a 1-hour kickoff, commit to `main`, then diverge.
+**Node.js 20 + TypeScript (strict).** Matches the Gutenberg ecosystem tooling, has first-class support from the Anthropic SDK, and fits naturally into a GitHub Action (`setup-node`). Strict TypeScript catches interface mismatches between adapters at compile time, which matters when two devs build against the same contract.
 
-```ts
-// src/types/results.ts
-import { z } from "zod";
+**Zod for runtime validation.** All data that crosses a boundary — config files, manifest JSON, Claude's tool-use output, `results.json` — is validated with Zod schemas. The same schemas generate the JSON Schema for documentation and the TypeScript types for the rest of the codebase. Single source of truth; no manual sync.
 
-// ─── Manifest (doc index) ──────────────────────────────────────────────
+**Anthropic SDK (`@anthropic-ai/sdk`).** Used with prompt caching (system prompt + shared code context cached across a run) and structured tool use (Claude emits typed `Issue[]` rather than free prose). Always fetch current SDK docs via the context7 MCP before writing Claude API code — caching and tool-use APIs change between model generations.
 
-export const ManifestEntrySchema = z.object({
-  title: z.string(),
-  slug: z.string(),                       // primary key within a site
-  markdown_source: z.string().url(),      // URL to raw markdown (or local path)
-  parent: z.string().optional()           // parent slug for hierarchy
-});
-export type ManifestEntry = z.infer<typeof ManifestEntrySchema>;
+**`simple-git`** for repo operations. **`gray-matter` + `remark`** for markdown parsing (frontmatter extraction + code block / link counting). **`p-limit`** for bounded concurrency across docs. **`eta`** or plain template literals for HTML generation — no frontend framework, no build step. Tailwind via CDN keeps the dashboard self-contained.
 
-// ─── Mapping (slug → code files) ───────────────────────────────────────
-
-export const CodeTiersSchema = z.object({
-  primary:   z.array(z.string()).default([]),
-  secondary: z.array(z.string()).default([]),
-  context:   z.array(z.string()).default([])
-});
-
-// mapping.json is a Record<slug, CodeTiers>
-export const MappingSchema = z.record(z.string(), CodeTiersSchema);
-export type Mapping = z.infer<typeof MappingSchema>;
-
-// ─── Issues & results ──────────────────────────────────────────────────
-
-export const IssueSchema = z.object({
-  id: z.string(),
-  fingerprint: z.string(),                 // hash(slug + type + codeFile + normalize(issue)) — stable across runs
-  severity: z.enum(["critical", "major", "minor"]),
-  type: z.enum([
-    "outdated-api", "missing-parameter", "incorrect-example",
-    "broken-code-reference",                // doc references a code path that no longer exists
-    "unclear-explanation", "deprecated-usage"
-  ]),
-  location: z.object({ line: z.number().int(), text: z.string() }),
-  issue: z.string(),
-  evidence: z.object({
-    docSays: z.string(),
-    codeSays: z.string(),
-    codeFile: z.string(),
-    codeLine: z.number().int().optional()
-  }),
-  suggestion: z.string(),
-  confidence: z.number().min(0).max(1)
-});
-
-export const DocResultSchema = z.object({
-  slug: z.string(),                                        // key from manifest
-  title: z.string(),
-  parent: z.string().optional(),
-  sourceUrl: z.string().url(),                             // markdown_source
-  publishedUrl: z.string().url().optional(),               // rendered doc URL if known
-  analyzedAt: z.string().datetime(),
-  commitSha: z.string().optional(),                        // enables change detection later
-  healthScore: z.number().min(0).max(100),
-  status: z.enum(["healthy", "needs-attention", "critical"]),
-  metrics: z.object({
-    wordCount: z.number(),
-    codeExamples: z.number(),
-    internalLinks: z.number(),
-    externalLinks: z.number(),
-    lastModified: z.string().datetime().optional()
-  }),
-  relatedCode: z.array(z.object({
-    path: z.string(),
-    tier: z.enum(["primary", "secondary", "context"]),
-    includedInAnalysis: z.boolean()                        // false if dropped to fit budget
-  })),
-  issues: z.array(IssueSchema),
-  positives: z.array(z.string()),
-  diagnostics: z.array(z.string()).default([])             // honesty signal: "2 mapped files not found", "budget exhausted, 3 context files skipped"
-});
-
-export const RunResultsSchema = z.object({
-  project: z.string(),
-  runId: z.string(),
-  analyzedAt: z.string().datetime(),
-  scope: z.object({
-    source: z.string(),
-    docsCount: z.number()
-  }),
-  overallHealth: z.number().min(0).max(100),
-  totals: z.object({
-    critical: z.number(),
-    major: z.number(),
-    minor: z.number()
-  }),
-  docs: z.array(DocResultSchema)
-});
-
-export type RunResults = z.infer<typeof RunResultsSchema>;
-```
-
-Track B generates `examples/results.schema.json` from this and mocks a fixture, so dashboard work is unblocked immediately — doesn't have to wait for real pipeline output.
+**Config format: JSON.** Config files (`config/*.json`) and mapping files (`mappings/*.json`) use JSON rather than YAML — consistent with the rest of the data layer, no extra parser dependency, and easier to validate with the same Zod schemas used everywhere else.
 
 ---
 
-## Validator Behavior (Prompt Rules)
+## Adapter Pattern
 
-Decisions from design review, encoded into the validator's system prompt + runtime wrappers. The prompt is cached; these rules are part of what's cached.
+Every component that touches an external system — doc sources, code sources, mappers, the validator — is behind an interface with a pluggable implementation. The pipeline wires adapters together at runtime from config; it doesn't import concrete implementations directly.
 
-### What counts as drift (report it)
+```
+config.json
+  └── adapter type string ("manifest-url", "git-clone", "manual-map", "claude")
+        └── registry resolves → concrete adapter instance
+              └── pipeline calls interface methods only
+```
+
+**Why:** isolates change. Adding a `wordpress-rest` DocSource doesn't touch the pipeline. Swapping the mapper from `manual-map` to `symbol-search` doesn't touch the validator. Unimplemented adapters throw `NotImplementedError` — they document the extension surface without adding dead code.
+
+**Registry pattern:** a central `adapters/index.ts` maps type strings to factory functions. This is the only place where concrete adapter modules are imported. Everything else depends on the interface types.
+
+---
+
+## Project Foundation — Shared Contract
+
+Before either track writes domain code, both agree on the shape of every data object the system passes around. These are the types that matter:
+
+- **`ManifestEntry`** — one doc as listed in the index (`slug`, `title`, `markdown_source`, `parent`).
+- **`CodeTiers`** — the code files mapped to a doc, split into `primary` / `secondary` / `context` tiers. Tiers are token-budget hints: primary is always sent; context is dropped first.
+- **`Issue`** — one drift finding: `severity`, `type`, `evidence` (what the doc says vs. what the code says, with exact file + verbatim quote), `suggestion`, `confidence`, and a stable `fingerprint` hash used to track the same issue across runs.
+- **`DocResult`** — the full analysis of one doc: health score, status, issues, positives, related code list with `includedInAnalysis` flags, and `diagnostics` (caveats like "2 mapped files not found").
+- **`RunResults`** — the complete output of one pipeline run: all `DocResult`s, aggregated totals, overall health score.
+
+A mock fixture (`examples/mock-results.json`) exercises every schema and unblocks dashboard development before any real pipeline output exists. This is the primary coordination mechanism between Track A and Track B.
+
+---
+
+## Doc Ingestion (`DocSource`)
+
+**Purpose:** produce a normalised list of docs with their content, regardless of where they live. The rest of the pipeline — mapping, validation, dashboard — should never know whether a doc came from a git repo, a WordPress site, or a local filesystem. DocSource is the boundary that absorbs that complexity.
+
+**Pattern:** source-agnostic fetch, normalised output. Each `DocSource` implementation returns `Doc[]` with a consistent shape regardless of where the docs came from.
+
+**Phase 1 — `manifest-url`:** fetches a Gutenberg-style `manifest.json`, filters entries by `parent` slug, fetches each `markdown_source` URL, parses frontmatter via `gray-matter`, and counts code blocks + links via `remark`. Graceful 404/500 handling — a failed fetch produces a diagnostic, not a crash.
+
+**Why manifest-first:** Gutenberg already publishes a `manifest.json`. Consuming it verbatim means zero maintenance for the doc index on the most important PoC target. Later sources (`wordpress-rest`, `fs-walk`) produce the same manifest shape so nothing downstream changes.
+
+**Key decision — metrics at ingest time:** word count, code example count, and link counts are computed here during fetch, not during validation. The Validator receives a `Doc` that already has these; it never re-parses markdown.
+
+---
+
+## Code Ingestion (`CodeSource`)
+
+**Purpose:** give the validator access to exact, current file contents from the source repository — the ground truth the docs are supposed to reflect. Without this, the validator would have to trust the doc's own claims about the code rather than verifying them directly.
+
+**Pattern:** fetch-once, cache by commit SHA. The code source clones (or reads) a repository into a local cache dir and exposes `readFile(path)` and `listDir(path)`. Callers never know if the file came from a fresh clone or a cache hit.
+
+**Phase 1 — `git-clone`:** shallow-clone via `simple-git` into a temp dir keyed by repo URL + commit SHA. On re-runs the cache dir exists and clone is skipped — the full run goes from ~30s clone to <1s. Exposes line-range reads (`readFile(path, startLine, endLine)`) for Pass 2 targeted verification.
+
+**Key decision — commit SHA on `DocResult`:** the SHA of the code repo at analysis time is stored on every `DocResult`. This enables the change detector (deferred to Stretch): next run compares current SHA to stored SHA and skips docs whose mapped code hasn't changed.
+
+---
+
+## Doc–Code Mapping (`DocCodeMapper`)
+
+**Purpose:** tell the validator *which* code files are relevant to each doc. This is the bridge between the documentation world and the source world — without it, the validator would have no idea where to look and would either guess wrong or ignore large parts of the codebase. Getting the mapping right is the single biggest factor in the quality of the analysis.
+
+**Pattern:** slug → tiered file list. The mapper answers "given this doc slug, which code files should the validator read?" It produces a `CodeTiers` object that the context assembler turns into a token-budgeted file set.
+
+**Phase 1 — `manual-map`:** reads a slug-keyed JSON file checked into the repo. Deterministic, zero cost, auditable. A dev-time LLM helper (`scripts/bootstrap-mapping.ts`) proposes initial entries — it asks Claude "given this doc content and this repo file tree, which files are primary/secondary/context?" — but a human reviews and commits the result. The bootstrap script is a one-time accelerator, not a runtime dependency.
+
+**Two files, decoupled concerns:**
+- `manifest.json` (doc index) — *what docs exist*. Could be upstreamed, machine-generated, owned by doc authors.
+- `mapping.json` (doc → code) — *what code each doc relates to*. Tool-specific knowledge, owned by the analysis team.
+
+This separation means adding a new site requires only a new `mapping.json`. The manifest comes from the site itself.
+
+**Phase 2 — `symbol-search`:** extracts symbols from doc prose and code fences (function names, hooks, attribute names, import paths), runs AST search over the Gutenberg codebase via `ast-grep` or `tree-sitter`, and ranks candidates by symbol specificity × package centrality × recency. Validated against Phase 1 manual mappings (target: ≥70% agreement on `primary`). The manual `mapping.json` becomes an overrides layer — corrections that the automatic search can't infer.
+
+**Known limitation:** slug renames break mappings silently. If `block-metadata` is renamed in the manifest, the mapping key becomes stale and the validator reports "no mapping found." Mitigation is a lint step at run-start — deferred.
+
+---
+
+## Drift Validator
+
+**Purpose:** determine whether each doc accurately describes the code it maps to, and produce actionable findings a doc author can act on. This is where the core problem is solved — comparing what a doc claims against what the code actually does, at a level of specificity that makes the output trustworthy rather than just suggestive. It also needs to confidently report when a doc is healthy, not just find problems.
+
+**Pattern:** two-pass LLM evaluation with evidence requirements and a runtime fabrication check.
+
+**Pass 1 — candidate generation.** A single Claude call with a cached system prompt receives the full doc + tiered code context assembled to a token budget (~50k tokens). Claude uses structured tool use to emit `Issue[]` — not free prose. Each issue must include a verbatim `codeSays` quote from the referenced file. A runtime check immediately after the call drops any issue where `evidence.codeSays` doesn't literally appear in the referenced file — catches hallucinations the prompt missed.
+
+**Pass 2 — targeted verification.** For each surviving candidate, Claude can call a `fetch_code(path, startLine, endLine)` tool to read a specific file region and re-evaluate. Issues with `confidence < 0.7` are dropped. Critical/major issues with weak suggestions (generic words like "update", "revise") retry once; if still weak, the issue is dropped. Pass 2 can be cut entirely (fall back to confidence ≥ 0.8 threshold in Pass 1 only) if the Phase 0 validation gate reveals it adds noise rather than signal.
+
+**Prompt caching:** the system prompt (which includes the drift definition, severity calibration, and evidence rules) and the shared code context are cached across the run. Cache hit rate >90% on a typical run cuts both cost and latency significantly.
+
+**Positives:** the validator also emits evidence-backed `positives` — specific things the doc gets right. Capped at 3 per doc to force substantive picks, not boilerplate praise. The health report must be able to say "this doc is healthy" credibly, not just find problems.
+
+**Health scoring:** `100 − (critical×15 + major×7 + minor×2)`, clamped 0..100. Thresholds: ≥85 = healthy, 60–84 = needs-attention, <60 = critical. Overall score = average across docs.
+
+**Graceful degradation:** when the validator can't fully assess a doc (stale mapping, missing file, budget exhausted), it proceeds and records caveats in `DocResult.diagnostics`. No special `inconclusive` status — the dashboard shows diagnostics next to the score so readers know the assessment has caveats.
+
+---
+
+### What counts as drift
 
 - Type signature changes (param added/removed/renamed, return type changed).
 - Default value changes.
 - Deprecated APIs shown as current or recommended.
-- Code examples that would throw if run against the current code.
-- Function/hook/attribute names that no longer exist in the source.
+- Code examples that would throw against current code.
+- Function/hook/attribute names that no longer exist.
 - Required parameters documented as optional (or vice versa).
 
-### What does not count as drift (skip silently)
+### What does not count as drift
 
-- Teaching simplifications — docs intentionally omitting edge cases or error handling for clarity.
-- Undocumented optional parameters (unless commonly used and absence would surprise a reader).
+- Teaching simplifications — intentional omission of edge cases for clarity.
+- Undocumented optional parameters (unless commonly used and their absence would surprise a reader).
 - Style, grammar, typos.
 - Broken external links (a future phase).
 
-### The judgment rule for partial coverage
+**Judgment rule for partial coverage:** if the documented behavior is a strict subset of actual behavior *and* the omission doesn't mislead a reader following the doc, it's not drift. If the omission would cause a reader's code to fail or produce a surprise, it is drift.
 
-> *If the documented behavior is a strict subset of actual behavior AND the omission doesn't mislead a reader following the doc, it's not drift. If omission would cause a reader's code to fail or be surprised, it is drift.*
+---
 
-### Severity calibration
+## Dashboard + CLI
 
-- **Critical** — a reader's code would break or behave incorrectly if they followed the doc.
-- **Major** — the doc is meaningfully misleading but a reader's code usually still works.
-- **Minor** — technically wrong but most readers wouldn't be misled.
+**Purpose:** make the findings useful to doc authors, not just developers. The pipeline produces a `results.json`; the dashboard turns that into something a human can open, browse, and act on. The CLI is the operational entry point that ties everything together. These two concerns are coupled by the output format but otherwise independent — Track B can build and validate the full dashboard experience before a single real analysis run exists.
 
-Health score: `100 − (critical*15 + major*7 + minor*2)`, clamped 0..100. Thresholds: ≥85 healthy, 60–84 needs-attention, <60 critical.
+**Pattern:** pipeline orchestrator + static site generator, built against a contract not an implementation.
 
-### Confidence thresholds
+The CLI is the entry point: loads config, wires adapters, calls `runPipeline()`, writes `results.json`, invokes the dashboard generator. Track B builds the dashboard against the mock fixture from day one — `runPipeline()` is a stub that returns mock data until Track A's implementation lands. The CLI and dashboard never import concrete pipeline code directly; they depend on the `RunResults` type and the `runPipeline` function signature.
 
-- **Two-pass validation** (Pass 1 + `fetch_code` Pass 2): discard issues with `confidence < 0.7`.
-- **Pass-1-only fallback** (if Day-3 gate cuts Pass 2): tighten to `confidence < 0.8`.
-- Low-confidence hunches (0.5–0.7) are silently dropped for PoC, not exposed as "needs review." Re-evaluate post-month.
+**Static HTML, no framework.** Templates (`eta` or plain template literals) + Tailwind CDN. No build step means the dashboard can be opened directly from the filesystem without a local server — important for the publish flow. Three page types: index (overall health + tree view), per-doc detail (issues, evidence, suggestions, positives, diagnostics), folder rollup (section aggregation).
 
-### Evidence requirements
-
-- Every `Issue.evidence.codeSays` must appear **verbatim** in the referenced code file. Runtime check rejects fabrications the prompt missed.
-- Every `positive` must be evidence-backed too — not praise for its own sake. Cap of 3 positives per doc to force substantive picks.
-
-### Suggestion quality bar
-
-- **Critical / Major:** the suggestion must include specific proposed text — a rewritten sentence, a code snippet to replace the current example, or an explicit *"add parameter X of type Y here"* instruction. No hand-waving.
-- **Minor:** a loose nudge is fine.
-- Enforcement: if a critical/major issue comes back with a weak suggestion (e.g., *"update the wording"*), the validator retries once with a sharper prompt; if still weak, the issue is dropped. Trustworthiness > coverage.
-
-### Scope
-
-- **Per-doc only.** Cross-doc analysis (inter-doc link validity, inter-doc consistency) is out of scope for month-end — it's a separate batch pass over completed `RunResults`.
-- `broken-code-reference` means *the doc → code pointer is broken*, not *doc → other doc*.
-
-### Graceful degradation
-
-When the validator can't fully assess a doc (stale mapping, missing file, budget exhausted), it **proceeds and records the caveat** in `DocResult.diagnostics`. No special `inconclusive` status — the dashboard shows the diagnostics next to the health score so readers know the assessment has caveats.
+**Tree structure:** docs are grouped by `parent` slug from the manifest. Folder health scores are weighted averages of their docs. The tree builder must handle ≥200 docs without layout collapse — Phase 2 adds collapse/expand and search/filter on top of the same data structure.
 
 ---
 
 ## Results Storage & History
 
-Historical data from Week 1 onward — UI lands in Phase 2 (milestone M8). Shape:
+**Purpose:** preserve every run's output so the dashboard can show trends over time and issues can be tracked across runs — without a database. The `gh-pages` branch doubles as both the published dashboard host and the append-only data store.
+
+Run output is stored on the `gh-pages` branch, not in the source repo:
 
 ```
-gh-pages branch:
-├── index.html                       # latest dashboard (points to latest run)
-├── doc/<slug>.html                  # latest per-doc pages
-├── folder/<parent>.html             # latest folder pages
-└── data/
-    ├── latest.json                  # symlink/pointer to newest runs/<runId>/results.json
-    ├── runs/
-    │   ├── 2026-04-22T06-00-00Z/
-    │   │   └── results.json
-    │   ├── 2026-04-29T06-00-00Z/
-    │   │   └── results.json
-    │   └── ...
-    └── history.json                 # { runs: [{runId, timestamp, commitSha, overallHealth, totals}] }
+data/
+  runs/<runId>/results.json     # one per run, never overwritten
+  history.json                  # index: [{runId, timestamp, commitSha, overallHealth, totals}]
 ```
 
-**Issue fingerprinting** — each `Issue.fingerprint` is a stable hash of `slug + type + evidence.codeFile + normalize(issue.text)`. Same fingerprint across runs = same issue. Tolerant of doc line shifts (the normalized text ignores line numbers and minor whitespace). Enables "new this week" and "persistent for N runs" badges in M8.
+The `publish` script copies the generated `out/` into `gh-pages` while *preserving* any existing `data/runs/` dirs — it never clobbers prior run data.
 
-**Retention** — no pruning for PoC. At ~50–200 KB per `results.json` × 52 weeks ≈ 2–10 MB per year on the `gh-pages` branch. Revisit if it bloats.
+**Issue fingerprinting:** `Issue.fingerprint` is a stable hash of `slug + type + evidence.codeFile + normalize(issue.text)`. Same fingerprint across runs = same issue. Tolerant of doc line shifts. Enables "new this week" and "persistent for N runs" badges without a database — the history index is the only persistent state.
+
+**Retention:** no pruning for PoC. ~50–200 KB per `results.json` × 52 weeks ≈ 2–10 MB/year on `gh-pages`. Revisit if it grows.
 
 ---
 
 ## Risks and Mitigations
 
-- **AI hallucination / false positives** → two-pass validation + quoted evidence + `confidence ≥ 0.7` + **runtime verbatim check** (`evidence.codeSays` must literally appear in the referenced file). Clean-doc fixture in tests catches drift in the validator itself.
-- **Two-pass validation is complex and time-hungry** → Day-3 decision point with a Pass-1-only fallback that still demos.
-- **Premature abstraction** → adapter interfaces designed broadly, implemented narrowly. Registry documents extension surface without dead code.
-- **Track A / Track B divergence** → Day-1 schema handshake + mock fixture; Track B never blocks on Track A.
-- **Mapping accuracy for ~10 docs** → hand-curated via bootstrap script, checked into git. Mapping errors are trivial to fix.
-- **Slug renames breaking mappings silently** → deferred. A lint step handles it later when it bites.
-- **Timeline pressure (1 week)** → GitHub Action (M7) and `symbol-search` mapper (M1) deferred to Phase 2. Change detector further deferred to Stretch (S3). Core Week-1 shippable demo is CLI + local dashboard + manual `gh-pages` push via `publish.sh`.
-- **Cost runaway** → 50k input-token cap per doc + prompt caching. Expected total per 10-doc run: ≤$1. Alert threshold: $5. Measured at the end of each run, logged to console.
+| Risk | Mitigation |
+|------|-----------|
+| AI hallucination / false positives | Two-pass validation + runtime verbatim check + `confidence ≥ 0.7`. Clean-doc fixture in tests catches validator regression. |
+| Pass 2 adds noise rather than signal | Phase 0 gate at 3 docs measures this explicitly. Fallback: cut Pass 2, tighten confidence to ≥ 0.8 for Pass-1-only ship. |
+| Track A / Track B divergence | Day-1 schema handshake + mock fixture. Track B never blocks on Track A. |
+| Mapping inaccuracy | Hand-curated via bootstrap script, reviewed and committed. Mapping errors are cheap to fix. |
+| Slug renames breaking mappings silently | Deferred. A lint step at run-start will surface stale keys when we hit it. |
+| Cost overrun | 50k input-token cap per doc + prompt caching. Per-run cost logged to console. Phase 2 adds a hard `--cost-cap` flag. |
+| Premature abstraction | Adapter interfaces designed broadly, implemented narrowly. `NotImplementedError` stubs document the surface without adding dead code to maintain. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ Technical reference: how the pieces fit, the schemas they exchange, and the file
 ```
 wp-docs-health-monitor/
 ├── src/
-│   ├── adapters/                    # Dev A
+│   ├── adapters/                    # Track A
 │   │   ├── index.ts                  # registry
 │   │   ├── doc-source/
 │   │   │   ├── types.ts
@@ -25,30 +25,30 @@ wp-docs-health-monitor/
 │   │   └── validator/
 │   │       ├── types.ts
 │   │       └── claude.ts             # two-pass, prompt-cached, tool-use
-│   ├── pipeline.ts                  # Dev A — wires adapters, emits RunResults
-│   ├── health-scorer.ts             # Dev A
-│   ├── config/                      # Dev B
+│   ├── pipeline.ts                  # Track A — wires adapters, emits RunResults
+│   ├── health-scorer.ts             # Track A
+│   ├── config/                      # Track B
 │   │   ├── schema.ts
 │   │   └── loader.ts
-│   ├── dashboard/                   # Dev B
+│   ├── dashboard/                   # Track B
 │   │   ├── generate.ts               # RunResults → static HTML
 │   │   ├── templates/
 │   │   │   ├── index.html.eta
 │   │   │   ├── doc-detail.html.eta
 │   │   │   └── folder.html.eta
 │   │   └── tree-builder.ts
-│   ├── cli.ts                       # Dev B — main entry
+│   ├── cli.ts                       # Track B — main entry
 │   └── types/
 │       ├── results.ts                # SHARED CONTRACT (zod)
 │       └── mapping.ts                # MappingSchema + Manifest types
 ├── scripts/
-│   └── bootstrap-mapping.ts         # LLM-assisted helper: slug → JSON candidate (Dev A)
+│   └── bootstrap-mapping.ts         # LLM-assisted helper: slug → JSON candidate (Track A)
 ├── config/
 │   └── gutenberg-block-api.yml      # PoC config
 ├── mappings/
-│   └── gutenberg-block-api.json     # slug-keyed tiered map (Dev A)
+│   └── gutenberg-block-api.json     # slug-keyed tiered map (Track A)
 ├── examples/
-│   ├── mock-results.json            # for dashboard dev without running pipeline (Dev B)
+│   ├── mock-results.json            # for dashboard dev without running pipeline (Track B)
 │   └── results.schema.json          # generated from zod
 ├── out/                             # gitignored — generated dashboard
 ├── package.json                     # single flat package
@@ -183,10 +183,12 @@ export type Mapping = z.infer<typeof MappingSchema>;
 
 export const IssueSchema = z.object({
   id: z.string(),
+  fingerprint: z.string(),                 // hash(slug + type + codeFile + normalize(issue)) — stable across runs
   severity: z.enum(["critical", "major", "minor"]),
   type: z.enum([
     "outdated-api", "missing-parameter", "incorrect-example",
-    "broken-link", "unclear-explanation", "deprecated-usage"
+    "broken-code-reference",                // doc references a code path that no longer exists
+    "unclear-explanation", "deprecated-usage"
   ]),
   location: z.object({ line: z.number().int(), text: z.string() }),
   issue: z.string(),
@@ -223,7 +225,8 @@ export const DocResultSchema = z.object({
     includedInAnalysis: z.boolean()                        // false if dropped to fit budget
   })),
   issues: z.array(IssueSchema),
-  positives: z.array(z.string())
+  positives: z.array(z.string()),
+  diagnostics: z.array(z.string()).default([])             // honesty signal: "2 mapped files not found", "budget exhausted, 3 context files skipped"
 });
 
 export const RunResultsSchema = z.object({
@@ -246,7 +249,93 @@ export const RunResultsSchema = z.object({
 export type RunResults = z.infer<typeof RunResultsSchema>;
 ```
 
-Dev B generates `examples/results.schema.json` from this and mocks a fixture, so Dev B's dashboard work is unblocked immediately — doesn't have to wait for real pipeline output.
+Track B generates `examples/results.schema.json` from this and mocks a fixture, so dashboard work is unblocked immediately — doesn't have to wait for real pipeline output.
+
+---
+
+## Validator Behavior (Prompt Rules)
+
+Decisions from design review, encoded into the validator's system prompt + runtime wrappers. The prompt is cached; these rules are part of what's cached.
+
+### What counts as drift (report it)
+
+- Type signature changes (param added/removed/renamed, return type changed).
+- Default value changes.
+- Deprecated APIs shown as current or recommended.
+- Code examples that would throw if run against the current code.
+- Function/hook/attribute names that no longer exist in the source.
+- Required parameters documented as optional (or vice versa).
+
+### What does not count as drift (skip silently)
+
+- Teaching simplifications — docs intentionally omitting edge cases or error handling for clarity.
+- Undocumented optional parameters (unless commonly used and absence would surprise a reader).
+- Style, grammar, typos.
+- Broken external links (a future phase).
+
+### The judgment rule for partial coverage
+
+> *If the documented behavior is a strict subset of actual behavior AND the omission doesn't mislead a reader following the doc, it's not drift. If omission would cause a reader's code to fail or be surprised, it is drift.*
+
+### Severity calibration
+
+- **Critical** — a reader's code would break or behave incorrectly if they followed the doc.
+- **Major** — the doc is meaningfully misleading but a reader's code usually still works.
+- **Minor** — technically wrong but most readers wouldn't be misled.
+
+Health score: `100 − (critical*15 + major*7 + minor*2)`, clamped 0..100. Thresholds: ≥85 healthy, 60–84 needs-attention, <60 critical.
+
+### Confidence thresholds
+
+- **Two-pass validation** (Pass 1 + `fetch_code` Pass 2): discard issues with `confidence < 0.7`.
+- **Pass-1-only fallback** (if Day-3 gate cuts Pass 2): tighten to `confidence < 0.8`.
+- Low-confidence hunches (0.5–0.7) are silently dropped for PoC, not exposed as "needs review." Re-evaluate post-month.
+
+### Evidence requirements
+
+- Every `Issue.evidence.codeSays` must appear **verbatim** in the referenced code file. Runtime check rejects fabrications the prompt missed.
+- Every `positive` must be evidence-backed too — not praise for its own sake. Cap of 3 positives per doc to force substantive picks.
+
+### Suggestion quality bar
+
+- **Critical / Major:** the suggestion must include specific proposed text — a rewritten sentence, a code snippet to replace the current example, or an explicit *"add parameter X of type Y here"* instruction. No hand-waving.
+- **Minor:** a loose nudge is fine.
+- Enforcement: if a critical/major issue comes back with a weak suggestion (e.g., *"update the wording"*), the validator retries once with a sharper prompt; if still weak, the issue is dropped. Trustworthiness > coverage.
+
+### Scope
+
+- **Per-doc only.** Cross-doc analysis (inter-doc link validity, inter-doc consistency) is out of scope for month-end — it's a separate batch pass over completed `RunResults`.
+- `broken-code-reference` means *the doc → code pointer is broken*, not *doc → other doc*.
+
+### Graceful degradation
+
+When the validator can't fully assess a doc (stale mapping, missing file, budget exhausted), it **proceeds and records the caveat** in `DocResult.diagnostics`. No special `inconclusive` status — the dashboard shows the diagnostics next to the health score so readers know the assessment has caveats.
+
+---
+
+## Results Storage & History
+
+Historical data from Week 1 onward — UI lands in Phase 2 (milestone M8). Shape:
+
+```
+gh-pages branch:
+├── index.html                       # latest dashboard (points to latest run)
+├── doc/<slug>.html                  # latest per-doc pages
+├── folder/<parent>.html             # latest folder pages
+└── data/
+    ├── latest.json                  # symlink/pointer to newest runs/<runId>/results.json
+    ├── runs/
+    │   ├── 2026-04-22T06-00-00Z/
+    │   │   └── results.json
+    │   ├── 2026-04-29T06-00-00Z/
+    │   │   └── results.json
+    │   └── ...
+    └── history.json                 # { runs: [{runId, timestamp, commitSha, overallHealth, totals}] }
+```
+
+**Issue fingerprinting** — each `Issue.fingerprint` is a stable hash of `slug + type + evidence.codeFile + normalize(issue.text)`. Same fingerprint across runs = same issue. Tolerant of doc line shifts (the normalized text ignores line numbers and minor whitespace). Enables "new this week" and "persistent for N runs" badges in M8.
+
+**Retention** — no pruning for PoC. At ~50–200 KB per `results.json` × 52 weeks ≈ 2–10 MB per year on the `gh-pages` branch. Revisit if it bloats.
 
 ---
 
@@ -255,7 +344,7 @@ Dev B generates `examples/results.schema.json` from this and mocks a fixture, so
 - **AI hallucination / false positives** → two-pass validation + quoted evidence + `confidence ≥ 0.7` + **runtime verbatim check** (`evidence.codeSays` must literally appear in the referenced file). Clean-doc fixture in tests catches drift in the validator itself.
 - **Two-pass validation is complex and time-hungry** → Day-3 decision point with a Pass-1-only fallback that still demos.
 - **Premature abstraction** → adapter interfaces designed broadly, implemented narrowly. Registry documents extension surface without dead code.
-- **Dev A / Dev B divergence** → Day-1 schema handshake + mock fixture; Dev B never blocks on Dev A.
+- **Track A / Track B divergence** → Day-1 schema handshake + mock fixture; Track B never blocks on Track A.
 - **Mapping accuracy for ~10 docs** → hand-curated via bootstrap script, checked into git. Mapping errors are trivial to fix.
 - **Slug renames breaking mappings silently** → deferred. A lint step handles it later when it bites.
 - **Timeline pressure (1 week)** → GitHub Action, `symbol-search` mapper, change detector all deferred to Phase 2. Core shippable demo is CLI + local dashboard + manual `gh-pages` push.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,6 +92,8 @@ A mock fixture (`examples/mock-results.json`) exercises every schema and unblock
 
 **Key decision — commit SHA on `DocResult`:** the SHA of the code repo at analysis time is stored on every `DocResult`. This enables the change detector (deferred to Stretch): next run compares current SHA to stored SHA and skips docs whose mapped code hasn't changed.
 
+**Open design issue — `trunk` as default ref:** the Phase 1 `git-clone` implementation clones without specifying a ref, resolving to `trunk`. `trunk` contains unreleased code that no end user runs, so a doc correctly describing released behavior can be flagged against unreleased refactors, and a doc describing unreleased APIs can be flagged as *healthy* when no plugin user can use them yet. Small implementation footprint; Phase 2 scope. See [release-pinning.md](./release-pinning.md) for the proposed fix and deferral rationale.
+
 ---
 
 ## Doc–Code Mapping (`DocCodeMapper`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,262 @@
+# Architecture
+
+Back to [PLAN.md](../PLAN.md) · For the issue backlog see [backlog.md](./backlog.md).
+
+Technical reference: how the pieces fit, the schemas they exchange, and the file layout. Changes as we learn; keep in sync with `src/types/*`.
+
+---
+
+## Repo Layout
+
+```
+wp-docs-health-monitor/
+├── src/
+│   ├── adapters/                    # Dev A
+│   │   ├── index.ts                  # registry
+│   │   ├── doc-source/
+│   │   │   ├── types.ts
+│   │   │   └── manifest-url.ts       # PoC impl (consumes Gutenberg manifest.json)
+│   │   ├── code-source/
+│   │   │   ├── types.ts
+│   │   │   └── git-clone.ts
+│   │   ├── mapper/
+│   │   │   ├── types.ts
+│   │   │   └── manual-map.ts         # reads slug-keyed JSON
+│   │   └── validator/
+│   │       ├── types.ts
+│   │       └── claude.ts             # two-pass, prompt-cached, tool-use
+│   ├── pipeline.ts                  # Dev A — wires adapters, emits RunResults
+│   ├── health-scorer.ts             # Dev A
+│   ├── config/                      # Dev B
+│   │   ├── schema.ts
+│   │   └── loader.ts
+│   ├── dashboard/                   # Dev B
+│   │   ├── generate.ts               # RunResults → static HTML
+│   │   ├── templates/
+│   │   │   ├── index.html.eta
+│   │   │   ├── doc-detail.html.eta
+│   │   │   └── folder.html.eta
+│   │   └── tree-builder.ts
+│   ├── cli.ts                       # Dev B — main entry
+│   └── types/
+│       ├── results.ts                # SHARED CONTRACT (zod)
+│       └── mapping.ts                # MappingSchema + Manifest types
+├── scripts/
+│   └── bootstrap-mapping.ts         # LLM-assisted helper: slug → JSON candidate (Dev A)
+├── config/
+│   └── gutenberg-block-api.yml      # PoC config
+├── mappings/
+│   └── gutenberg-block-api.json     # slug-keyed tiered map (Dev A)
+├── examples/
+│   ├── mock-results.json            # for dashboard dev without running pipeline (Dev B)
+│   └── results.schema.json          # generated from zod
+├── out/                             # gitignored — generated dashboard
+├── package.json                     # single flat package
+├── tsconfig.json
+├── PLAN.md
+├── README.md
+└── docs/
+    ├── architecture.md              # this file
+    └── backlog.md
+```
+
+No `packages/` directory, no monorepo, no GitHub Action workflow in Week 1. All deferred to Phase 2.
+
+---
+
+## Tech Stack
+
+- **Node.js 20 + TypeScript (strict).** Matches Gutenberg ecosystem, first-class Anthropic SDK, natural fit for `setup-node` in Actions later.
+- **Anthropic SDK (`@anthropic-ai/sdk`)** with **prompt caching** for the system prompt + shared code context, and **tool use with JSON schema** for structured issue output. Two-pass validation: (1) find candidate issues with quoted evidence, (2) verify each with targeted code re-read. Model: **`claude-sonnet-4-6`** (cost/accuracy sweet spot; upgrade to `claude-opus-4-7` only if Sonnet misses real issues during Phase 0).
+- **`simple-git`** for repo clones. **`gray-matter` + `remark`** for markdown parsing. **`zod`** for runtime schema validation on config + results.
+- **Static HTML dashboard** — no framework. `index.html` + per-doc detail pages via templates (`eta` or plain template literals). Tailwind via CDN, no build step.
+- **Single flat npm package** for Week 1. No monorepo, no pnpm workspaces.
+
+When implementing, use the **context7 MCP** for up-to-date Anthropic SDK docs (prompt caching, tool use, streaming).
+
+---
+
+## Doc Index & Mapping Format
+
+Two files per site. Decoupled concerns: *what docs exist* vs *what code each one relates to*.
+
+### File 1 — `manifest.json` (doc index)
+
+Canonical format = **Gutenberg's `manifest.json`** (https://github.com/WordPress/gutenberg/blob/trunk/docs/manifest.json). Each entry:
+
+```json
+{
+  "title": "Block Metadata",
+  "slug": "block-metadata",
+  "markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/docs/reference-guides/block-api/block-metadata.md",
+  "parent": "block-api"
+}
+```
+
+For Gutenberg, we **consume the existing manifest verbatim** — no work, no maintenance. Just fetch the URL and filter by `parent: "block-api"` for Week 1.
+
+For sites that don't publish a manifest (WooCommerce docs, internal A8C sites, any markdown repo), later phases **generate** one: `fs-walk` adapter for markdown repos, `wordpress-rest` adapter for WP-sourced sites. Output conforms to the same shape.
+
+### File 2 — `mapping.json` (doc → code)
+
+Slug-keyed JSON with tiered code lists. **Slug is the primary key**, not file path — more stable when docs get reorganized.
+
+```json
+// mappings/gutenberg-block-api.json
+{
+  "block-metadata": {
+    "primary":   ["packages/blocks/src/api/registration.js", "schemas/json/block.json"],
+    "secondary": ["packages/blocks/src/api/parser.js", "packages/blocks/src/api/process-block-type.js"],
+    "context":   ["packages/block-editor/src/components/block-edit/index.js"]
+  },
+  "block-registration": {
+    "primary":   ["packages/blocks/src/api/registration.js"],
+    "secondary": [],
+    "context":   []
+  }
+}
+```
+
+**Tiers are token-budget hints for the validator:**
+- `primary` — always sent. Source of truth for this doc.
+- `secondary` — usually sent. Supporting context that catches most real drift.
+- `context` — dropped first when budget is tight; retrieved on demand in Pass 2.
+
+### Why two separate files
+
+- `manifest.json` is **site metadata** (could be upstreamed, machine-generated, maintained by doc owners).
+- `mapping.json` is **tool-specific knowledge** (maintained by us or by contributors using the tool).
+- Separation means we can drop a new site in by adding one `mapping.json` — the manifest is whatever the site already has (or generated once).
+
+### LLM-assisted bootstrap
+
+Hand-writing mappings doesn't scale past ~50 docs. A one-shot dev-time helper — `scripts/bootstrap-mapping.ts <slug>` — asks Claude *"given this doc and this file tree, which files are `primary`/`secondary`/`context`?"* and writes a candidate JSON block. A human reviews and trims before committing.
+
+Not a runtime adapter — a CLI helper you run once per doc. The `manual-map` adapter stays deterministic at analysis time.
+
+### Scaling path beyond PoC
+
+1. **Phase 1 (PoC):** `manual-map` slug-keyed JSON + bootstrap script. ~10 docs, <1 hour with the helper.
+2. **Phase 2+:** `symbol-search` mapper — extract symbols from doc (functions, hooks, attribute names, code-block imports), AST-grep the codebase via `ast-grep`/`tree-sitter`, rank by proximity and specificity. Auto-generates a candidate mapping.
+3. **Phase 3:** `hybrid` mapper — `symbol-search` candidates + a JSON overrides layer (`include` / `exclude` / `pin`) for manual corrections. Long-term shape.
+4. **(Optional) `embedding-retrieval`:** semantic similarity when symbol matching isn't enough. Heavier infra; only if needed.
+
+All four share the same `DocCodeMapper` interface — swapping is an adapter-config change, not a rewrite. The PoC JSON format is forward-compatible: it becomes the "override" layer in the hybrid adapter with an `overrides:` key added.
+
+### Known limitation (deferred)
+
+**Slug renames break the mapping silently.** If the manifest renames `block-metadata` → `block-json-metadata`, our `mapping.json` key is stale and the validator reports "no mapping found". Low probability in practice. Mitigation when we hit it: a lint step at run-start warning about mapping keys not present in the manifest. Deferred — not implemented in Week 1.
+
+---
+
+## Shared Contract (Day 1, before branching)
+
+This is the single most important artifact. Both devs pair on it in a 1-hour kickoff, commit to `main`, then diverge.
+
+```ts
+// src/types/results.ts
+import { z } from "zod";
+
+// ─── Manifest (doc index) ──────────────────────────────────────────────
+
+export const ManifestEntrySchema = z.object({
+  title: z.string(),
+  slug: z.string(),                       // primary key within a site
+  markdown_source: z.string().url(),      // URL to raw markdown (or local path)
+  parent: z.string().optional()           // parent slug for hierarchy
+});
+export type ManifestEntry = z.infer<typeof ManifestEntrySchema>;
+
+// ─── Mapping (slug → code files) ───────────────────────────────────────
+
+export const CodeTiersSchema = z.object({
+  primary:   z.array(z.string()).default([]),
+  secondary: z.array(z.string()).default([]),
+  context:   z.array(z.string()).default([])
+});
+
+// mapping.json is a Record<slug, CodeTiers>
+export const MappingSchema = z.record(z.string(), CodeTiersSchema);
+export type Mapping = z.infer<typeof MappingSchema>;
+
+// ─── Issues & results ──────────────────────────────────────────────────
+
+export const IssueSchema = z.object({
+  id: z.string(),
+  severity: z.enum(["critical", "major", "minor"]),
+  type: z.enum([
+    "outdated-api", "missing-parameter", "incorrect-example",
+    "broken-link", "unclear-explanation", "deprecated-usage"
+  ]),
+  location: z.object({ line: z.number().int(), text: z.string() }),
+  issue: z.string(),
+  evidence: z.object({
+    docSays: z.string(),
+    codeSays: z.string(),
+    codeFile: z.string(),
+    codeLine: z.number().int().optional()
+  }),
+  suggestion: z.string(),
+  confidence: z.number().min(0).max(1)
+});
+
+export const DocResultSchema = z.object({
+  slug: z.string(),                                        // key from manifest
+  title: z.string(),
+  parent: z.string().optional(),
+  sourceUrl: z.string().url(),                             // markdown_source
+  publishedUrl: z.string().url().optional(),               // rendered doc URL if known
+  analyzedAt: z.string().datetime(),
+  commitSha: z.string().optional(),                        // enables change detection later
+  healthScore: z.number().min(0).max(100),
+  status: z.enum(["healthy", "needs-attention", "critical"]),
+  metrics: z.object({
+    wordCount: z.number(),
+    codeExamples: z.number(),
+    internalLinks: z.number(),
+    externalLinks: z.number(),
+    lastModified: z.string().datetime().optional()
+  }),
+  relatedCode: z.array(z.object({
+    path: z.string(),
+    tier: z.enum(["primary", "secondary", "context"]),
+    includedInAnalysis: z.boolean()                        // false if dropped to fit budget
+  })),
+  issues: z.array(IssueSchema),
+  positives: z.array(z.string())
+});
+
+export const RunResultsSchema = z.object({
+  project: z.string(),
+  runId: z.string(),
+  analyzedAt: z.string().datetime(),
+  scope: z.object({
+    source: z.string(),
+    docsCount: z.number()
+  }),
+  overallHealth: z.number().min(0).max(100),
+  totals: z.object({
+    critical: z.number(),
+    major: z.number(),
+    minor: z.number()
+  }),
+  docs: z.array(DocResultSchema)
+});
+
+export type RunResults = z.infer<typeof RunResultsSchema>;
+```
+
+Dev B generates `examples/results.schema.json` from this and mocks a fixture, so Dev B's dashboard work is unblocked immediately — doesn't have to wait for real pipeline output.
+
+---
+
+## Risks and Mitigations
+
+- **AI hallucination / false positives** → two-pass validation + quoted evidence + `confidence ≥ 0.7` + **runtime verbatim check** (`evidence.codeSays` must literally appear in the referenced file). Clean-doc fixture in tests catches drift in the validator itself.
+- **Two-pass validation is complex and time-hungry** → Day-3 decision point with a Pass-1-only fallback that still demos.
+- **Premature abstraction** → adapter interfaces designed broadly, implemented narrowly. Registry documents extension surface without dead code.
+- **Dev A / Dev B divergence** → Day-1 schema handshake + mock fixture; Dev B never blocks on Dev A.
+- **Mapping accuracy for ~10 docs** → hand-curated via bootstrap script, checked into git. Mapping errors are trivial to fix.
+- **Slug renames breaking mappings silently** → deferred. A lint step handles it later when it bites.
+- **Timeline pressure (1 week)** → GitHub Action, `symbol-search` mapper, change detector all deferred to Phase 2. Core shippable demo is CLI + local dashboard + manual `gh-pages` push.
+- **Cost runaway** → 50k input-token cap per doc + prompt caching. Expected total per 10-doc run: ≤$1. Alert threshold: $5. Measured at the end of each run, logged to console.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,7 +60,7 @@ wp-docs-health-monitor/
     └── backlog.md
 ```
 
-No `packages/` directory, no monorepo, no GitHub Action workflow in Week 1. All deferred to Phase 2.
+No `packages/` directory, no monorepo, no GitHub Action workflow in Week 1. The Action ships in Phase 2 (M7); monorepo stays out unless genuinely needed later.
 
 ---
 
@@ -347,5 +347,5 @@ gh-pages branch:
 - **Track A / Track B divergence** → Day-1 schema handshake + mock fixture; Track B never blocks on Track A.
 - **Mapping accuracy for ~10 docs** → hand-curated via bootstrap script, checked into git. Mapping errors are trivial to fix.
 - **Slug renames breaking mappings silently** → deferred. A lint step handles it later when it bites.
-- **Timeline pressure (1 week)** → GitHub Action, `symbol-search` mapper, change detector all deferred to Phase 2. Core shippable demo is CLI + local dashboard + manual `gh-pages` push.
+- **Timeline pressure (1 week)** → GitHub Action (M7) and `symbol-search` mapper (M1) deferred to Phase 2. Change detector further deferred to Stretch (S3). Core Week-1 shippable demo is CLI + local dashboard + manual `gh-pages` push via `publish.sh`.
 - **Cost runaway** → 50k input-token cap per doc + prompt caching. Expected total per 10-doc run: ≤$1. Alert threshold: $5. Measured at the end of each run, logged to console.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,216 +1,125 @@
 # Backlog
 
-Back to [PLAN.md](../PLAN.md) · For architecture and schemas see [architecture.md](./architecture.md).
+Back to [PLAN.md](../PLAN.md) · Schedule in [timeline.md](./timeline.md) · Architecture and schemas in [architecture.md](./architecture.md).
 
-What to build, in order. Each issue is individually shippable (one person, one PR, one merge). Sizes: **S** <1h, **M** 1–3h, **L** 3–6h.
+**What to build.** Not *when* — that's in [timeline.md](./timeline.md).
+
+**Week 1: five ambitious feature-level issues**, each with a clear outcome and a detailed checklist of what's inside. Breaking each into smaller sub-PRs during implementation is fine — the issue here is the *unit of agreement*, not the unit of merge.
+
+Sizes: **S** <1h, **M** 1–3h, **L** 3–6h, **XL** 6+h (likely multi-day).
 
 Every issue has:
 - **Track** (A = pipeline / B = presentation / Either) — suggested, swap freely. Both devs using Claude Code so either can pick up either track.
-- **Deps** — prerequisite issue IDs that must be merged first
-- **Done when** — acceptance check a reviewer uses
-
-**Total:** ~30 issues, ~50 dev-hours. Fits two devs × ~5 days with buffer.
-
----
-
-## Month-end Target
-
-By end of month: the **full Block Editor Handbook** (~150 editorial docs) analyzed and published on GitHub Pages. Architecture stays source-agnostic so post-month we can add `wordpress-rest` for a second handbook, but that's not committed for this month.
-
-Three phases:
-
-- **Week 1 — PoC** (issues S/A/B/V below, ~50 dev-hours): 10 docs from Block API Reference, manual mapping, two-pass Claude validator, static dashboard.
-- **Weeks 2–4 — Scale-up** (milestones M1–M6 below, sized at Week-2 kickoff): `symbol-search` mapper, editorial-only filter, pipeline + dashboard at 150-doc scale, one production run, runbook.
-
-## Week 1 Timeline
-
-- **Deadline:** ~2026-04-27 (one week from kickoff).
-- **Capacity:** 2 devs × 5 working days × 6 focused hours ≈ 60 dev-hours. Plan for ~50h of issues, leaving 20% buffer.
-- **Rough split:** Track A (pipeline) ~30h, Track B (presentation) ~15h, shared ~5h. Track B finishes presentation early → helps with A9 fixtures and V0 manual review.
-
-### Week-1 cut list (already applied)
-
-- ❌ GitHub Action workflow — deferred to Phase 2 (P2-1).
-- ❌ pnpm workspaces / monorepo — single flat package.
-- ❌ `wordpress-rest` / `fs-walk` / `a8c-context` DocSources — Phase 2.
-- ❌ `symbol-search` / `hybrid` / `embedding-retrieval` mappers — Phase 2+.
-- ❌ PHP / wordpress-develop code source — gutenberg only.
-- ❌ Change detector, slug-rename lint, trend tracking, auto-PRs.
-- ✅ **Kept:** two-pass validation (with Day-3 decision point), LLM-bootstrap script, Tailwind-CDN dashboard.
-
-### Day-3 decision point on two-pass validation
-
-If Phase 0 precision on 3 docs ≥80% AND the clean doc shows 0 issues → **keep** Pass 2 (A6e) and proceed. If <80% or false positives on the clean doc → **cut** Pass 2 (A6e), tighten `confidence ≥ 0.8`, rely on the runtime verbatim-evidence check (A6d), ship the Pass-1-only version. Dashboard still demos.
+- **Outcome** — one-line "done" that a reviewer can check.
+- **Includes** — the concrete deliverables inside.
+- **Deps** — prerequisite issues that must land first.
 
 ---
 
-## Day 1 — Shared Kickoff (both devs, half-day pair session)
+## Week 1 Issues
 
-- **S0 — Bootstrap repo** · Either · S
-  - Deps: —
-  - Done when: `package.json`, `tsconfig.json` (strict), ESLint + Prettier, `.gitignore`, `src/index.ts` placeholder. `npm run typecheck` passes on an empty project.
-
-- **S1 — Manifest + mapping types** · Track A · S
-  - Deps: S0
-  - Done when: `src/types/mapping.ts` exports `ManifestEntrySchema`, `CodeTiersSchema`, `MappingSchema` (zod). Types compile.
-
-- **S2 — Issue + result types** · Track A · M
-  - Deps: S0
-  - Done when: `src/types/results.ts` exports `IssueSchema`, `DocResultSchema`, `RunResultsSchema` (zod). Matches the Shared Contract in [architecture.md](./architecture.md#shared-contract-day-1-before-branching) exactly.
-
-- **S3 — Config schema** · Track B · S
-  - Deps: S0
-  - Done when: `src/config/schema.ts` exports `ConfigSchema` with fields for project, docs source, code source, mapping path, output dir.
-
-- **S4 — Pipeline entry stub** · Either · S
-  - Deps: S2
-  - Done when: `src/pipeline.ts` exports `runPipeline(config: Config): Promise<RunResults>` returning an empty-but-valid `RunResults`. This is the interface Track B codes against.
-
-- **S5 — Export JSON Schema** · Either · S
-  - Deps: S2
-  - Done when: `npm run gen:schema` writes `examples/results.schema.json` via `zod-to-json-schema`.
-
-- **S6 — Mock results fixture** · Either · M
-  - Deps: S2, S5
-  - Done when: `examples/mock-results.json` has ~4 fake docs (one healthy, one needs-attention, one critical, one with varied issue types) and passes `RunResultsSchema` validation. **Unblocks Track B fully.**
-
-- **S7 — History data-model groundwork** · Either · S
-  - Deps: S2
-  - Done when: `src/history.ts` exports `fingerprintIssue(slug, type, codeFile, issueText) → string` (stable hash, tolerant of line shifts — normalizes whitespace + line numbers). Output layout documented: results write to `out/data/runs/<runId>/results.json`, plus an updated `out/data/history.json` run index. Publish script preserves prior runs when pushing to `gh-pages`. UI for history is Phase 2 (M8); this is the data-model foundation so Run 1 isn't lost.
+Five feature-level issues. Each can be broken into smaller sub-PRs during implementation — the issue is the *unit of agreement* on scope and outcome, not necessarily the unit of merge.
 
 ---
 
-## Track A — Pipeline (~30h)
+### Issue #1 — Project foundation & shared contracts
 
-- **A1 — Adapter registry** · Track A · S
-  - Deps: S0
-  - Done when: `src/adapters/index.ts` exports a registry and `NotImplementedError`. Empty type files for `doc-source`, `code-source`, `mapper`, `validator`.
+**Track:** Either (pair session on Day 1) · **Size:** M (~5h) · **Deps:** —
 
-- **A2a — DocSource interface** · Track A · S
-  - Deps: A1, S1
-  - Done when: `src/adapters/doc-source/types.ts` defines `DocSource.list(config) → Doc[]` returning `{slug, title, parent, sourceUrl, content, codeExamples, metrics}`.
+**Outcome:** Repo skeleton in place, every zod schema locked, CLI entry stub compiles, mock fixture passes validation. After this lands on `main`, both tracks work fully in parallel with zero schema ambiguity.
 
-- **A2b — `manifest-url`: fetch + validate** · Track A · M
-  - Deps: A2a
-  - Done when: given a manifest URL, fetches JSON, validates each entry against `ManifestEntrySchema`, warns on invalid entries without crashing.
-
-- **A2c — `manifest-url`: filter + fetch markdown** · Track A · M
-  - Deps: A2b
-  - Done when: filters entries by `parent` slug, fetches each `markdown_source` URL, handles 404/500 gracefully, returns `{entry, content}` pairs.
-
-- **A2d — `manifest-url`: parse markdown → Doc** · Track A · M
-  - Deps: A2c
-  - Done when: frontmatter via `gray-matter`, code blocks/links counted via `remark`. Returns complete `Doc[]`. Unit test against a checked-in mini-manifest fixture.
-
-- **A3a — `git-clone` CodeSource** · Track A · M
-  - Deps: A1
-  - Done when: `src/adapters/code-source/git-clone.ts` shallow-clones a repo, exposes `readFile(path, startLine?, endLine?)` and `listDir(path)`. Cleans up old clones.
-
-- **A3b — `git-clone`: SHA caching** · Track A · S
-  - Deps: A3a
-  - Done when: if cache exists and HEAD SHA matches ref, skips clone. Reruns are <1s.
-
-- **A4 — `manual-map` Mapper** · Track A · M
-  - Deps: A1, S1
-  - Done when: reads `mappings/<project>.json`, validates against `MappingSchema`, returns `CodeTiers` by slug. Throws helpful error when a requested slug is missing.
-
-- **A4c — `bootstrap-mapping` script** · Track A · L
-  - Deps: A2d, A3a
-  - Done when: `npx tsx scripts/bootstrap-mapping.ts <slug>` prints a proposed `{slug: CodeTiers}` JSON snippet. Uses Claude with the doc content + repo file tree. Human reviews, pastes into `mappings/*.json`.
-
-- **A5 — Seed mapping for ~10 slugs** · Track A · M
-  - Deps: A4c
-  - Done when: `mappings/gutenberg-block-api.json` has entries for ~10 Block API Reference slugs. Caps: ≤3 primary, ≤5 secondary, ≤8 context each. Committed.
-
-- **A6a — Validator interface** · Track A · S
-  - Deps: A1, S2
-  - Done when: `src/adapters/validator/types.ts` defines `Validator.validate(doc, context) → Issue[]`.
-
-- **A6b — Validator: context assembler** · Track A · M
-  - Deps: A3a, A4, S2
-  - Done when: `assembleContext(doc, mapping, budget) → {files, stats}`. Starts with primary+secondary, adds context until budget hit, records what was dropped.
-
-- **A6c — Validator: Pass 1 (system prompt + tool use)** · Track A · L
-  - Deps: A6a, A6b
-  - Done when: Claude call with cached system prompt emits `Issue[]` via tool-use matching `IssueSchema`. Unit-tested against fixture doc+code.
-
-- **A6d — Validator: verbatim evidence check** · Track A · S
-  - Deps: A6c
-  - Done when: issues whose `evidence.codeSays` isn't literally found in the referenced file are silently rejected. Counter logged.
-
-- **A6e — Validator: Pass 2 (`fetch_code` retrieve-on-demand)** · Track A · L
-  - Deps: A6c, A3a
-  - Done when: for each candidate issue, Claude can call `fetch_code(path, startLine?, endLine?)` to verify. Issues with `confidence < 0.7` dropped. **This is the issue to cut at the Day-3 decision point if it's not stable.**
-
-- **A7 — Pipeline orchestrator** · Track A · M
-  - Deps: A2d, A3a, A4, A6c (Pass 1 at minimum)
-  - Done when: `runPipeline(config)` wires DocSource → CodeSource → Mapper → Validator, analyzes docs with `p-limit(3)`, emits `RunResults` that validates against the schema.
-
-- **A8 — Health scorer** · Track A · S
-  - Deps: S2
-  - Done when: `scoreDoc(issues) → {healthScore, status}` implemented. Formula `100 − (critical*15 + major*7 + minor*2)`, clamped 0..100. Thresholds: ≥85 healthy, 60–84 needs-attention, <60 critical. Overall average computed in the orchestrator.
-
-- **A9a — Test fixture: drifted doc** · Track A · M
-  - Deps: A6c
-  - Done when: `tests/fixtures/drifted/` has a hand-tampered doc+code pair. Validator reports ≥1 `critical` issue.
-
-- **A9b — Test fixture: clean doc** · Track A · S
-  - Deps: A6c
-  - Done when: `tests/fixtures/clean/` has a known-accurate doc+code pair. Validator reports 0 issues (after confidence filter).
+**Includes:**
+- `package.json`, `tsconfig.json` (strict), ESLint + Prettier, `.gitignore`, placeholder `src/index.ts`. `npm run typecheck` passes on an empty project.
+- `src/types/mapping.ts` — `ManifestEntrySchema`, `CodeTiersSchema`, `MappingSchema` (zod). Matches the Shared Contract in [architecture.md](./architecture.md#shared-contract-day-1-before-branching).
+- `src/types/results.ts` — `IssueSchema` (with `fingerprint`), `DocResultSchema` (with `diagnostics`), `RunResultsSchema`.
+- `src/config/schema.ts` — `ConfigSchema` (project, docs source, code source, mapping path, output dir).
+- `src/pipeline.ts` — exports stub `runPipeline(config: Config): Promise<RunResults>` returning an empty-but-valid `RunResults`. This is the interface Track B codes against from Day 2 onward.
+- `src/history.ts` — exports `fingerprintIssue(slug, type, codeFile, issueText) → string` (stable hash, line-shift tolerant). Output layout documented: `out/data/runs/<runId>/results.json` + `out/data/history.json` run index.
+- `examples/results.schema.json` — generated from zod via `zod-to-json-schema`. `npm run gen:schema` rebuilds it.
+- `examples/mock-results.json` — ~4 fake docs (one healthy, one needs-attention, one critical, one with varied issue types) passing `RunResultsSchema`. **This unblocks Track B entirely.**
 
 ---
 
-## Track B — Presentation (~15h)
+### Issue #2 — Doc + code ingestion pipeline
 
-- **B1 — Config loader** · Track B · S
-  - Deps: S3
-  - Done when: `loadConfig(path)` reads YAML, validates via `ConfigSchema`, returns typed `Config`.
+**Track:** A (pipeline) · **Size:** L (~12h) · **Deps:** #1
 
-- **B2a — CLI skeleton** · Track B · S
-  - Deps: S0
-  - Done when: `src/cli.ts` with flags `--config`, `--output`, `--only <slug>`, `--dry-run`. `npm run analyze -- --help` prints usage.
+**Outcome:** The pipeline can pull the Gutenberg manifest, filter to Block API Reference slugs, fetch each doc's markdown, clone Gutenberg source, and resolve tiered code mappings from a slug-keyed JSON file. Returns typed `{Doc, CodeTiers}` pairs for every doc in scope. No AI yet — pure plumbing, cost $0.
 
-- **B2b — CLI wired to pipeline** · Track B · S
-  - Deps: B2a, B1, S4
-  - Done when: `npm run analyze -- --config config/gutenberg-block-api.yml --output ./out` writes `out/results.json` + a log file. Works with stub `runPipeline` returning empty results.
+**Includes:**
+- `src/adapters/index.ts` — registry + `NotImplementedError` for unimplemented adapters.
+- `DocSource` interface in `src/adapters/doc-source/types.ts`. Returns `Doc[]` with `{slug, title, parent, sourceUrl, content, codeExamples, metrics}`.
+- `manifest-url` DocSource: fetches manifest JSON, validates against `ManifestEntrySchema`, filters by `parent` slug (e.g. `block-api`), fetches each `markdown_source` URL with graceful 404/500 handling, parses frontmatter via `gray-matter`, counts code blocks + links via `remark`.
+- `CodeSource` interface + `git-clone` implementation: shallow-clones a repo into a cache dir, exposes `readFile(path, startLine?, endLine?)` and `listDir(path)`, caches by commit SHA so reruns are <1s.
+- `DocCodeMapper` interface + `manual-map` implementation: reads `mappings/<project>.json`, validates against `MappingSchema`, returns `CodeTiers` by slug, throws a helpful error on missing slugs.
+- `scripts/bootstrap-mapping.ts <slug>` — LLM helper that proposes a `{slug: CodeTiers}` JSON snippet using Claude with doc content + repo file tree. Human-reviewed output pastes into `mappings/*.json`. Dev-time only, not a runtime adapter.
+- `mappings/gutenberg-block-api.json` seeded with the ~10 PoC slugs (`block-metadata`, `block-registration`, `block-attributes`, `block-supports`, `block-variations`, `block-context`, `block-deprecation`, `block-transforms`, `block-patterns`, `block-bindings`). Caps: ≤3 primary, ≤5 secondary, ≤8 context per slug.
+- Unit tests against a checked-in mini-manifest fixture (no network).
 
-- **B3a — Dashboard: reader + generator entry** · Track B · S
-  - Deps: S6
-  - Done when: `src/dashboard/generate.ts` reads + validates a `results.json`, exposes `generate(results, outDir)` that writes to disk.
+**Done when:** calling `runPipeline(config)` (validator stubbed) prints each slug + its primary code file list for all ~10 docs. Zero API cost.
 
-- **B3b — Dashboard: index.html** · Track B · M
-  - Deps: B3a, B4
-  - Done when: `out/index.html` shows overall health %, totals (critical/major/minor), and the tree view grouped by parent slug with per-folder aggregated score. Tailwind CDN, one-file HTML.
+---
 
-- **B3c — Dashboard: doc-detail.html** · Track B · L
-  - Deps: B3a
-  - Done when: `out/doc/<slug>.html` shows title, health score, metrics, issues (severity, confidence, quoted evidence, proposed action), positives, related-code list, source URL link. Generated one per doc from `examples/mock-results.json`.
+### Issue #3 — Claude drift validator with two-pass evaluation
 
-- **B3d — Dashboard: folder.html** · Track B · M
-  - Deps: B3a, B4
-  - Done when: `out/folder/<parent>.html` shows a section's rollup and its docs. Reached via links in `index.html`.
+**Track:** A (pipeline) · **Size:** XL (~18h) · **Deps:** #2
 
-- **B4 — Tree builder** · Track B · M
-  - Deps: S2
-  - Done when: `buildTree(docs) → TreeNode[]` groups by parent slug, aggregates health (doc-count weighted). Handles ≥200 docs cleanly.
+**Outcome:** End-to-end pipeline produces a valid `RunResults` over all ~10 docs. Each doc has a health score, evidence-backed issues (or 0 issues when healthy), evidence-backed positives, and diagnostics where relevant. Day-3 Phase 0 gate documented (Go, No-go with Pass 2 cut, or Abort).
 
-- **B6 — `publish.sh`** · Track B · S
-  - Deps: B3b, B3c, B3d
-  - Done when: `scripts/publish.sh` (or `npm run publish`) copies `out/` to a `gh-pages` worktree and pushes. GitHub Pages serves the result.
+**Includes:**
+- `Validator` interface in `src/adapters/validator/types.ts`.
+- Context assembler: `assembleContext(doc, mapping, budget) → {files, stats}`. Loads `primary + secondary`, appends `context` until the 50k-token budget is hit, records dropped files in `DocResult.relatedCode[].includedInAnalysis`.
+- **Pass 1** — Claude Sonnet 4.6 call with a cached system prompt encoding the Validator Behavior rules from [architecture.md](./architecture.md#validator-behavior-prompt-rules) (drift definition, severity calibration, evidence-backed positives cap 3, suggestion quality bar). Tool-use emits `Issue[]` matching `IssueSchema`. `Issue.fingerprint` computed from `src/history.ts`.
+- Runtime verbatim evidence check: any issue whose `evidence.codeSays` doesn't literally appear in the referenced code file is silently dropped. Drop counter logged.
+- **Pass 2** — for each Pass-1 candidate, Claude can call a `fetch_code(path, startLine?, endLine?)` tool to verify. Issues with `confidence < 0.7` dropped. Critical/major issues with weak suggestions (generic words like "update", "revise") retry once with a sharper prompt; still-weak → drop.
+- `src/health-scorer.ts` — `scoreDoc(issues) → {healthScore, status}`. Formula `100 − (critical*15 + major*7 + minor*2)`, clamped 0..100. Thresholds: ≥85 `healthy`, 60–84 `needs-attention`, <60 `critical`. Overall = average across docs.
+- Pipeline orchestrator: wires DocSource → CodeSource → Mapper → ContextAssembler → Validator → HealthScorer. Concurrency `p-limit(3)`. Run-end cost meter.
+- Test fixtures: `tests/fixtures/drifted/` (hand-tampered doc+code, must yield ≥1 critical) and `tests/fixtures/clean/` (known-accurate, must yield 0 issues post-filter).
+- **Day-3 Phase 0 gate** — run the validator on 3 docs (1 known-drifted, 1 known-clean, 1 uncertain). Measure precision ≥80%, recall ≥70%, clean-doc false positives = 0. Document results + decision in `docs/phase-0-results.md`. If no-go, cut Pass 2 and tighten `confidence ≥ 0.8` for Pass-1-only ship. If still failing, abort honestly.
 
-- **B7 — README** · Track B · M
-  - Deps: B2b (so examples are real)
-  - Done when: install steps, API key setup, CLI usage, sample output, cost expectation, dashboard screenshot. Enough for your partner's partner to reproduce.
+**Done when:** `npm run analyze` on the PoC config produces a valid `RunResults` with real issues on drifted docs, 0 issues on healthy docs, for under $1 per 10-doc run. `docs/phase-0-results.md` documents the decision.
+
+---
+
+### Issue #4 — Static HTML dashboard + CLI
+
+**Track:** B (presentation) · **Size:** L (~12h) · **Deps:** #1
+
+**Outcome:** `npm run analyze -- --config config/gutenberg-block-api.yml --output ./out` runs the pipeline (or reads `results.json`) and produces a browsable static dashboard with overall health %, tree view of docs by parent slug, per-doc detail pages with issues + evidence + suggestions + diagnostics + positives, and per-folder rollups. Track B builds against the mock fixture from #1 and never waits for #2 or #3.
+
+**Includes:**
+- `src/config/loader.ts` — `loadConfig(path)` reads YAML, validates via `ConfigSchema`, returns typed `Config`.
+- `src/cli.ts` — flags `--config`, `--output`, `--only <slug>`, `--dry-run`. `npm run analyze -- --help` prints usage. Wires config loader → `runPipeline` → writes `out/data/runs/<runId>/results.json` + `out/data/logs.txt`.
+- `src/dashboard/generate.ts` — reads and validates `results.json`, exposes `generate(results, outDir)` that writes the full static site.
+- `src/dashboard/tree-builder.ts` — `buildTree(docs) → TreeNode[]` groups by parent slug, doc-count-weighted health aggregation. Handles ≥200 docs for Phase 2.
+- Templates (`eta` or plain template literals), rendered with Tailwind via CDN (no build step):
+  - `out/index.html` — overall health %, totals (critical/major/minor), tree view grouped by parent with per-folder aggregated scores.
+  - `out/doc/<slug>.html` — title, health score, metrics, issues (severity, confidence, quoted evidence, proposed action), positives, related-code list, diagnostics strip, source URL link.
+  - `out/folder/<parent>.html` — section rollup + list of its docs.
+- `README.md` — install, `ANTHROPIC_API_KEY` setup, CLI usage, sample invocation, cost expectation (~$1/10-doc run), screenshot of the dashboard.
+
+**Done when:** feeding `examples/mock-results.json` through the dashboard generator produces a browsable static site at `out/` with working navigation between index, folders, and per-doc pages. The same command works with a real `results.json` from Issue #3 once it lands.
+
+---
+
+### Issue #5 — Publish to GitHub Pages
+
+**Track:** B (presentation) · **Size:** S (~2h) · **Deps:** #4
+
+**Outcome:** One command publishes the generated dashboard publicly at `https://juanma-wp.github.io/wp-docs-health-monitor/`. Prior runs are preserved under `data/runs/<runId>/` on the `gh-pages` branch so Phase 2's historical UI (M8) has data to draw on.
+
+**Includes:**
+- `scripts/publish.sh` (also `npm run publish`) — uses a `gh-pages` git worktree, copies `out/` into it *preserving* any existing `data/runs/<runId>/` directories from prior runs, commits, pushes.
+- Repo settings: public visibility confirmed, GitHub Pages source = `gh-pages` branch root.
+- Runbook entry in `docs/runbook.md`: one paragraph on how to run it, what to expect, how to revert if the publish goes wrong.
+
+**Done when:** `npm run analyze && npm run publish` results in a publicly reachable dashboard URL. A second run archives its `results.json` under `data/runs/<runId>/` without clobbering the first.
 
 ---
 
 ## Phase 0 Validation Gate (Day 3 — Decision Point)
 
-Gate everything else behind this check. It's also the go/no-go for two-pass validation.
-
-- **V0 — Run on 3 docs, measure P/R** · Track A + manual review · M
-  - Deps: A5, A7 (with at least Pass 1 wired)
-  - Done when: `docs/phase-0-results.md` (or PR comment) records precision, recall, clean-doc false positives. Day-3 decision documented.
+Embedded in Issue #3 but called out here because it's the project's single most important gate.
 
 ### Method
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -2,6 +2,20 @@
 
 Back to [PLAN.md](../PLAN.md) · Schedule in [timeline.md](./timeline.md) · Architecture and schemas in [architecture.md](./architecture.md).
 
+## Contents
+
+- [Week 1 Issues](#week-1-issues)
+  - [Issue #1 — Project foundation & shared contracts](#issue-1--project-foundation--shared-contracts)
+  - [Issue #2 — Doc + code ingestion pipeline](#issue-2--doc--code-ingestion-pipeline)
+  - [Issue #3 — Claude drift validator with two-pass evaluation](#issue-3--claude-drift-validator-with-two-pass-evaluation)
+  - [Issue #4 — Static HTML dashboard + CLI](#issue-4--static-html-dashboard--cli)
+  - [Issue #5 — Publish to GitHub Pages](#issue-5--publish-to-github-pages)
+- [Phase 0 Validation Gate](#phase-0-validation-gate-day-3--decision-point)
+- [End-to-end Verification](#end-to-end-verification-day-67)
+- [Phase 2 — Scale-up](#phase-2--scale-up-to-full-block-editor-handbook-weeks-24)
+
+---
+
 **What to build.** Not *when* — that's in [timeline.md](./timeline.md).
 
 **Week 1: five ambitious feature-level issues**, each with a clear outcome and a detailed checklist of what's inside. Breaking each into smaller sub-PRs during implementation is fine — the issue here is the *unit of agreement*, not the unit of merge.
@@ -85,7 +99,7 @@ Five feature-level issues. Each can be broken into smaller sub-PRs during implem
 
 **Track:** B (presentation) · **Size:** L (~12h) · **Deps:** #1
 
-**Outcome:** `npm run analyze -- --config config/gutenberg-block-api.yml --output ./out` runs the pipeline (or reads `results.json`) and produces a browsable static dashboard with overall health %, tree view of docs by parent slug, per-doc detail pages with issues + evidence + suggestions + diagnostics + positives, and per-folder rollups. Track B builds against the mock fixture from #1 and never waits for #2 or #3.
+**Outcome:** `npm run analyze -- --config config/gutenberg-block-api.json --output ./out` runs the pipeline (or reads `results.json`) and produces a browsable static dashboard with overall health %, tree view of docs by parent slug, per-doc detail pages with issues + evidence + suggestions + diagnostics + positives, and per-folder rollups. Track B builds against the mock fixture from #1 and never waits for #2 or #3.
 
 **Includes:**
 - `src/config/loader.ts` — `loadConfig(path)` reads YAML, validates via `ConfigSchema`, returns typed `Config`.
@@ -141,7 +155,7 @@ Embedded in Issue #3 but called out here because it's the project's single most 
 
 1. `npm install`
 2. `export ANTHROPIC_API_KEY=...`
-3. `npm run analyze -- --config config/gutenberg-block-api.yml --output ./out`
+3. `npm run analyze -- --config config/gutenberg-block-api.json --output ./out`
 4. `open out/index.html` — verify overall health %, tree view renders all ~10 docs grouped under `block-api`, clicking a doc opens a detail page with issues, evidence, proposed actions, and a link to the source URL.
 5. Manual precision check on 10 random issues: confirm they're real drift, not hallucination.
 6. Clean-doc check: at least one doc shows `healthy` status with 0 issues (or proves the tool can recognize health).
@@ -199,7 +213,7 @@ Committed. Break into individual issues at Week-2 kickoff once Week-1 findings a
 - **M7 — GitHub Action with weekly cron** · Track B · ~1–2 days
   - `.github/workflows/analyze-docs.yml` with `workflow_dispatch` (manual) and `schedule: - cron: '0 6 * * 1'` (weekly, Mon 06:00 UTC).
   - Uses `ANTHROPIC_API_KEY` as a repo secret (set this up in Settings once).
-  - Steps: checkout → setup-node 20 → `npm ci` → `npm run analyze -- --config config/gutenberg-block-api.yml --output ./out` → upload `out/results.json` as artifact → `actions/deploy-pages` for the dashboard.
+  - Steps: checkout → setup-node 20 → `npm ci` → `npm run analyze -- --config config/gutenberg-block-api.json --output ./out` → upload `out/results.json` as artifact → `actions/deploy-pages` for the dashboard.
   - Cost-cap flag (`--cost-cap 5`) on the CLI so a runaway run can't blow the budget.
   - Slack/email notification on failure (stretch — can be step-level `if: failure()` using `actions/github-script` or just rely on GitHub's default email to the repo owner).
   - **Acceptance:**

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -5,7 +5,7 @@ Back to [PLAN.md](../PLAN.md) · For architecture and schemas see [architecture.
 What to build, in order. Each issue is individually shippable (one person, one PR, one merge). Sizes: **S** <1h, **M** 1–3h, **L** 3–6h.
 
 Every issue has:
-- **Owner** (Dev A / Dev B / Either) — suggested, swap freely
+- **Track** (A = pipeline / B = presentation / Either) — suggested, swap freely. Both devs using Claude Code so either can pick up either track.
 - **Deps** — prerequisite issue IDs that must be merged first
 - **Done when** — acceptance check a reviewer uses
 
@@ -13,11 +13,20 @@ Every issue has:
 
 ---
 
+## Month-end Target
+
+By end of month: the **full Block Editor Handbook** (~150 editorial docs) analyzed and published on GitHub Pages. Architecture stays source-agnostic so post-month we can add `wordpress-rest` for a second handbook, but that's not committed for this month.
+
+Three phases:
+
+- **Week 1 — PoC** (issues S/A/B/V below, ~50 dev-hours): 10 docs from Block API Reference, manual mapping, two-pass Claude validator, static dashboard.
+- **Weeks 2–4 — Scale-up** (milestones M1–M6 below, sized at Week-2 kickoff): `symbol-search` mapper, editorial-only filter, pipeline + dashboard at 150-doc scale, one production run, runbook.
+
 ## Week 1 Timeline
 
 - **Deadline:** ~2026-04-27 (one week from kickoff).
 - **Capacity:** 2 devs × 5 working days × 6 focused hours ≈ 60 dev-hours. Plan for ~50h of issues, leaving 20% buffer.
-- **Rough split:** Dev A (pipeline) ~30h, Dev B (presentation) ~15h, shared ~5h. Dev B finishes presentation early → helps with A9 fixtures and V0 manual review.
+- **Rough split:** Track A (pipeline) ~30h, Track B (presentation) ~15h, shared ~5h. Track B finishes presentation early → helps with A9 fixtures and V0 manual review.
 
 ### Week-1 cut list (already applied)
 
@@ -41,21 +50,21 @@ If Phase 0 precision on 3 docs ≥80% AND the clean doc shows 0 issues → **kee
   - Deps: —
   - Done when: `package.json`, `tsconfig.json` (strict), ESLint + Prettier, `.gitignore`, `src/index.ts` placeholder. `npm run typecheck` passes on an empty project.
 
-- **S1 — Manifest + mapping types** · Dev A · S
+- **S1 — Manifest + mapping types** · Track A · S
   - Deps: S0
   - Done when: `src/types/mapping.ts` exports `ManifestEntrySchema`, `CodeTiersSchema`, `MappingSchema` (zod). Types compile.
 
-- **S2 — Issue + result types** · Dev A · M
+- **S2 — Issue + result types** · Track A · M
   - Deps: S0
   - Done when: `src/types/results.ts` exports `IssueSchema`, `DocResultSchema`, `RunResultsSchema` (zod). Matches the Shared Contract in [architecture.md](./architecture.md#shared-contract-day-1-before-branching) exactly.
 
-- **S3 — Config schema** · Dev B · S
+- **S3 — Config schema** · Track B · S
   - Deps: S0
   - Done when: `src/config/schema.ts` exports `ConfigSchema` with fields for project, docs source, code source, mapping path, output dir.
 
 - **S4 — Pipeline entry stub** · Either · S
   - Deps: S2
-  - Done when: `src/pipeline.ts` exports `runPipeline(config: Config): Promise<RunResults>` returning an empty-but-valid `RunResults`. This is the interface Dev B codes against.
+  - Done when: `src/pipeline.ts` exports `runPipeline(config: Config): Promise<RunResults>` returning an empty-but-valid `RunResults`. This is the interface Track B codes against.
 
 - **S5 — Export JSON Schema** · Either · S
   - Deps: S2
@@ -63,129 +72,133 @@ If Phase 0 precision on 3 docs ≥80% AND the clean doc shows 0 issues → **kee
 
 - **S6 — Mock results fixture** · Either · M
   - Deps: S2, S5
-  - Done when: `examples/mock-results.json` has ~4 fake docs (one healthy, one needs-attention, one critical, one with varied issue types) and passes `RunResultsSchema` validation. **Unblocks Dev B fully.**
+  - Done when: `examples/mock-results.json` has ~4 fake docs (one healthy, one needs-attention, one critical, one with varied issue types) and passes `RunResultsSchema` validation. **Unblocks Track B fully.**
+
+- **S7 — History data-model groundwork** · Either · S
+  - Deps: S2
+  - Done when: `src/history.ts` exports `fingerprintIssue(slug, type, codeFile, issueText) → string` (stable hash, tolerant of line shifts — normalizes whitespace + line numbers). Output layout documented: results write to `out/data/runs/<runId>/results.json`, plus an updated `out/data/history.json` run index. Publish script preserves prior runs when pushing to `gh-pages`. UI for history is Phase 2 (M8); this is the data-model foundation so Run 1 isn't lost.
 
 ---
 
-## Dev A — Pipeline (~30h)
+## Track A — Pipeline (~30h)
 
-- **A1 — Adapter registry** · Dev A · S
+- **A1 — Adapter registry** · Track A · S
   - Deps: S0
   - Done when: `src/adapters/index.ts` exports a registry and `NotImplementedError`. Empty type files for `doc-source`, `code-source`, `mapper`, `validator`.
 
-- **A2a — DocSource interface** · Dev A · S
+- **A2a — DocSource interface** · Track A · S
   - Deps: A1, S1
   - Done when: `src/adapters/doc-source/types.ts` defines `DocSource.list(config) → Doc[]` returning `{slug, title, parent, sourceUrl, content, codeExamples, metrics}`.
 
-- **A2b — `manifest-url`: fetch + validate** · Dev A · M
+- **A2b — `manifest-url`: fetch + validate** · Track A · M
   - Deps: A2a
   - Done when: given a manifest URL, fetches JSON, validates each entry against `ManifestEntrySchema`, warns on invalid entries without crashing.
 
-- **A2c — `manifest-url`: filter + fetch markdown** · Dev A · M
+- **A2c — `manifest-url`: filter + fetch markdown** · Track A · M
   - Deps: A2b
   - Done when: filters entries by `parent` slug, fetches each `markdown_source` URL, handles 404/500 gracefully, returns `{entry, content}` pairs.
 
-- **A2d — `manifest-url`: parse markdown → Doc** · Dev A · M
+- **A2d — `manifest-url`: parse markdown → Doc** · Track A · M
   - Deps: A2c
   - Done when: frontmatter via `gray-matter`, code blocks/links counted via `remark`. Returns complete `Doc[]`. Unit test against a checked-in mini-manifest fixture.
 
-- **A3a — `git-clone` CodeSource** · Dev A · M
+- **A3a — `git-clone` CodeSource** · Track A · M
   - Deps: A1
   - Done when: `src/adapters/code-source/git-clone.ts` shallow-clones a repo, exposes `readFile(path, startLine?, endLine?)` and `listDir(path)`. Cleans up old clones.
 
-- **A3b — `git-clone`: SHA caching** · Dev A · S
+- **A3b — `git-clone`: SHA caching** · Track A · S
   - Deps: A3a
   - Done when: if cache exists and HEAD SHA matches ref, skips clone. Reruns are <1s.
 
-- **A4 — `manual-map` Mapper** · Dev A · M
+- **A4 — `manual-map` Mapper** · Track A · M
   - Deps: A1, S1
   - Done when: reads `mappings/<project>.json`, validates against `MappingSchema`, returns `CodeTiers` by slug. Throws helpful error when a requested slug is missing.
 
-- **A4c — `bootstrap-mapping` script** · Dev A · L
+- **A4c — `bootstrap-mapping` script** · Track A · L
   - Deps: A2d, A3a
   - Done when: `npx tsx scripts/bootstrap-mapping.ts <slug>` prints a proposed `{slug: CodeTiers}` JSON snippet. Uses Claude with the doc content + repo file tree. Human reviews, pastes into `mappings/*.json`.
 
-- **A5 — Seed mapping for ~10 slugs** · Dev A · M
+- **A5 — Seed mapping for ~10 slugs** · Track A · M
   - Deps: A4c
   - Done when: `mappings/gutenberg-block-api.json` has entries for ~10 Block API Reference slugs. Caps: ≤3 primary, ≤5 secondary, ≤8 context each. Committed.
 
-- **A6a — Validator interface** · Dev A · S
+- **A6a — Validator interface** · Track A · S
   - Deps: A1, S2
   - Done when: `src/adapters/validator/types.ts` defines `Validator.validate(doc, context) → Issue[]`.
 
-- **A6b — Validator: context assembler** · Dev A · M
+- **A6b — Validator: context assembler** · Track A · M
   - Deps: A3a, A4, S2
   - Done when: `assembleContext(doc, mapping, budget) → {files, stats}`. Starts with primary+secondary, adds context until budget hit, records what was dropped.
 
-- **A6c — Validator: Pass 1 (system prompt + tool use)** · Dev A · L
+- **A6c — Validator: Pass 1 (system prompt + tool use)** · Track A · L
   - Deps: A6a, A6b
   - Done when: Claude call with cached system prompt emits `Issue[]` via tool-use matching `IssueSchema`. Unit-tested against fixture doc+code.
 
-- **A6d — Validator: verbatim evidence check** · Dev A · S
+- **A6d — Validator: verbatim evidence check** · Track A · S
   - Deps: A6c
   - Done when: issues whose `evidence.codeSays` isn't literally found in the referenced file are silently rejected. Counter logged.
 
-- **A6e — Validator: Pass 2 (`fetch_code` retrieve-on-demand)** · Dev A · L
+- **A6e — Validator: Pass 2 (`fetch_code` retrieve-on-demand)** · Track A · L
   - Deps: A6c, A3a
   - Done when: for each candidate issue, Claude can call `fetch_code(path, startLine?, endLine?)` to verify. Issues with `confidence < 0.7` dropped. **This is the issue to cut at the Day-3 decision point if it's not stable.**
 
-- **A7 — Pipeline orchestrator** · Dev A · M
+- **A7 — Pipeline orchestrator** · Track A · M
   - Deps: A2d, A3a, A4, A6c (Pass 1 at minimum)
   - Done when: `runPipeline(config)` wires DocSource → CodeSource → Mapper → Validator, analyzes docs with `p-limit(3)`, emits `RunResults` that validates against the schema.
 
-- **A8 — Health scorer** · Dev A · S
+- **A8 — Health scorer** · Track A · S
   - Deps: S2
   - Done when: `scoreDoc(issues) → {healthScore, status}` implemented. Formula `100 − (critical*15 + major*7 + minor*2)`, clamped 0..100. Thresholds: ≥85 healthy, 60–84 needs-attention, <60 critical. Overall average computed in the orchestrator.
 
-- **A9a — Test fixture: drifted doc** · Dev A · M
+- **A9a — Test fixture: drifted doc** · Track A · M
   - Deps: A6c
   - Done when: `tests/fixtures/drifted/` has a hand-tampered doc+code pair. Validator reports ≥1 `critical` issue.
 
-- **A9b — Test fixture: clean doc** · Dev A · S
+- **A9b — Test fixture: clean doc** · Track A · S
   - Deps: A6c
   - Done when: `tests/fixtures/clean/` has a known-accurate doc+code pair. Validator reports 0 issues (after confidence filter).
 
 ---
 
-## Dev B — Presentation (~15h)
+## Track B — Presentation (~15h)
 
-- **B1 — Config loader** · Dev B · S
+- **B1 — Config loader** · Track B · S
   - Deps: S3
   - Done when: `loadConfig(path)` reads YAML, validates via `ConfigSchema`, returns typed `Config`.
 
-- **B2a — CLI skeleton** · Dev B · S
+- **B2a — CLI skeleton** · Track B · S
   - Deps: S0
   - Done when: `src/cli.ts` with flags `--config`, `--output`, `--only <slug>`, `--dry-run`. `npm run analyze -- --help` prints usage.
 
-- **B2b — CLI wired to pipeline** · Dev B · S
+- **B2b — CLI wired to pipeline** · Track B · S
   - Deps: B2a, B1, S4
   - Done when: `npm run analyze -- --config config/gutenberg-block-api.yml --output ./out` writes `out/results.json` + a log file. Works with stub `runPipeline` returning empty results.
 
-- **B3a — Dashboard: reader + generator entry** · Dev B · S
+- **B3a — Dashboard: reader + generator entry** · Track B · S
   - Deps: S6
   - Done when: `src/dashboard/generate.ts` reads + validates a `results.json`, exposes `generate(results, outDir)` that writes to disk.
 
-- **B3b — Dashboard: index.html** · Dev B · M
+- **B3b — Dashboard: index.html** · Track B · M
   - Deps: B3a, B4
   - Done when: `out/index.html` shows overall health %, totals (critical/major/minor), and the tree view grouped by parent slug with per-folder aggregated score. Tailwind CDN, one-file HTML.
 
-- **B3c — Dashboard: doc-detail.html** · Dev B · L
+- **B3c — Dashboard: doc-detail.html** · Track B · L
   - Deps: B3a
   - Done when: `out/doc/<slug>.html` shows title, health score, metrics, issues (severity, confidence, quoted evidence, proposed action), positives, related-code list, source URL link. Generated one per doc from `examples/mock-results.json`.
 
-- **B3d — Dashboard: folder.html** · Dev B · M
+- **B3d — Dashboard: folder.html** · Track B · M
   - Deps: B3a, B4
   - Done when: `out/folder/<parent>.html` shows a section's rollup and its docs. Reached via links in `index.html`.
 
-- **B4 — Tree builder** · Dev B · M
+- **B4 — Tree builder** · Track B · M
   - Deps: S2
   - Done when: `buildTree(docs) → TreeNode[]` groups by parent slug, aggregates health (doc-count weighted). Handles ≥200 docs cleanly.
 
-- **B6 — `publish.sh`** · Dev B · S
+- **B6 — `publish.sh`** · Track B · S
   - Deps: B3b, B3c, B3d
   - Done when: `scripts/publish.sh` (or `npm run publish`) copies `out/` to a `gh-pages` worktree and pushes. GitHub Pages serves the result.
 
-- **B7 — README** · Dev B · M
+- **B7 — README** · Track B · M
   - Deps: B2b (so examples are real)
   - Done when: install steps, API key setup, CLI usage, sample output, cost expectation, dashboard screenshot. Enough for your partner's partner to reproduce.
 
@@ -195,7 +208,7 @@ If Phase 0 precision on 3 docs ≥80% AND the clean doc shows 0 issues → **kee
 
 Gate everything else behind this check. It's also the go/no-go for two-pass validation.
 
-- **V0 — Run on 3 docs, measure P/R** · Dev A + manual review · M
+- **V0 — Run on 3 docs, measure P/R** · Track A + manual review · M
   - Deps: A5, A7 (with at least Pass 1 wired)
   - Done when: `docs/phase-0-results.md` (or PR comment) records precision, recall, clean-doc false positives. Day-3 decision documented.
 
@@ -225,3 +238,70 @@ Gate everything else behind this check. It's also the go/no-go for two-pass vali
 6. Clean-doc check: at least one doc shows `healthy` status with 0 issues (or proves the tool can recognize health).
 7. Cost check: ≤$1 for the full 10-doc run. Flag if it exceeds $5.
 8. `npm run publish` (or `scripts/publish.sh`) pushes `out/` to the `gh-pages` branch; verify the dashboard loads at `https://juanma-wp.github.io/wp-docs-health-monitor/`.
+
+---
+
+## Phase 2 — Scale-up to Full Block Editor Handbook (Weeks 2–4)
+
+Committed. Break into individual issues at Week-2 kickoff once Week-1 findings are in. Keeping milestones coarse here on purpose — we'll know more after the PoC.
+
+### Goals
+
+- All ~150 editorial Block Editor Handbook docs analyzed end-to-end.
+- `symbol-search` replaces hand-written mapping for scale.
+- Dashboard stays fast and readable at 150-doc scale.
+- One production-shaped weekly run, published to GitHub Pages.
+
+### Milestones
+
+- **M1 — `symbol-search` Mapper** · Track A · ~3 days
+  - Symbol extractor: parse doc's code fences + prose for function names, types, hooks, attribute names, import paths.
+  - AST-grep the Gutenberg repo (via `ast-grep` or `tree-sitter`) for definitions of those symbols (not usages, which are noisier).
+  - Ranker: score each candidate by `symbol_match_strength × symbol_specificity × package_centrality × recency`.
+  - Tiering: top 3 → `primary`, next 5 → `secondary`, next 10 → `context`.
+  - Acceptance: for the ~10 Week-1 slugs, agreement with manual mappings is ≥70% on `primary`, ≥60% on `secondary`. Break further if you need unit tests or benchmarks.
+
+- **M2 — Editorial filter** · Track A · S
+  - Extend `manifest-url` with an option to exclude entries whose `markdown_source` resolves under `packages/*/README.md` or `packages/components/src/*/README.md`.
+  - Acceptance: filter on → ~150 docs returned; filter off → ~424.
+
+- **M3 — Pipeline at scale** · Track A · M
+  - Raise concurrency to `p-limit(5)` (or higher with rate-limit backoff).
+  - Per-run cost meter: sum input + output tokens × model pricing, print running total, hard-stop at `$5` (configurable via `--cost-cap`).
+  - Checkpointing: after each doc, write partial `results.json` so a crash/interrupt doesn't redo work.
+  - Acceptance: 150-doc run completes under cap, can resume after `SIGINT`.
+
+- **M4 — Dashboard at scale** · Track B · ~1–2 days
+  - Tree view collapses/expands section groups.
+  - Search/filter docs by `slug`/`title`/`status`/parent.
+  - Performance: initial page load <1s with 150 docs in fixture.
+  - Acceptance: scroll through 150 docs smoothly, filter narrows the list instantly.
+
+- **M5 — Full-handbook production run** · Both · ~1 day
+  - Run the pipeline on all ~150 editorial docs (triggered via `workflow_dispatch` on the Action once M7 is in).
+  - Manual precision check on 20 randomly-selected issues.
+  - Publish to Pages. Write up findings (precision %, total issues, surprises) for the Radical Speed Month P2 post.
+  - Acceptance: dashboard live at the public URL, write-up drafted.
+
+- **M6 — Runbook** · Either · S
+  - Document the end-to-end manual steps in `docs/runbook.md`: when to run, which commands, how to verify, how to publish. Backup path when the Action is down or under development.
+  - Acceptance: a teammate could run an ad-hoc update using just the runbook.
+
+- **M7 — GitHub Action with weekly cron** · Track B · ~1–2 days
+  - `.github/workflows/analyze-docs.yml` with `workflow_dispatch` (manual) and `schedule: - cron: '0 6 * * 1'` (weekly, Mon 06:00 UTC).
+  - Uses `ANTHROPIC_API_KEY` as a repo secret (set this up in Settings once).
+  - Steps: checkout → setup-node 20 → `npm ci` → `npm run analyze -- --config config/gutenberg-block-api.yml --output ./out` → upload `out/results.json` as artifact → `actions/deploy-pages` for the dashboard.
+  - Cost-cap flag (`--cost-cap 5`) on the CLI so a runaway run can't blow the budget.
+  - Slack/email notification on failure (stretch — can be step-level `if: failure()` using `actions/github-script` or just rely on GitHub's default email to the repo owner).
+  - **Acceptance:**
+    1. Manual dispatch runs green and updates the live dashboard at `https://juanma-wp.github.io/wp-docs-health-monitor/`.
+    2. One fully automated scheduled run completes green before month-end.
+    3. Subsequent runs append to `data/runs/` on `gh-pages` (preserving history per S7) while replacing the live dashboard views.
+
+- **M8 — Historical dashboard UI** · Track B · ~1–2 days
+  - Deps: S7 (groundwork), M7 (so runs are archived by the Action)
+  - Dashboard index shows a **trend line of `overallHealth`** across the last N runs (pull from `data/history.json`).
+  - Issues with a `fingerprint` matching a prior run get a **"persistent · N runs"** badge on the doc-detail page.
+  - Issues appearing for the first time get a **"new this week"** badge.
+  - Per-doc sparkline of health score over time on the doc-detail page.
+  - Acceptance: with at least 2 archived runs in `data/runs/`, the dashboard renders the trend line and badges correctly. If only 1 run exists, UI gracefully hides the history widgets.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,0 +1,227 @@
+# Backlog
+
+Back to [PLAN.md](../PLAN.md) · For architecture and schemas see [architecture.md](./architecture.md).
+
+What to build, in order. Each issue is individually shippable (one person, one PR, one merge). Sizes: **S** <1h, **M** 1–3h, **L** 3–6h.
+
+Every issue has:
+- **Owner** (Dev A / Dev B / Either) — suggested, swap freely
+- **Deps** — prerequisite issue IDs that must be merged first
+- **Done when** — acceptance check a reviewer uses
+
+**Total:** ~30 issues, ~50 dev-hours. Fits two devs × ~5 days with buffer.
+
+---
+
+## Week 1 Timeline
+
+- **Deadline:** ~2026-04-27 (one week from kickoff).
+- **Capacity:** 2 devs × 5 working days × 6 focused hours ≈ 60 dev-hours. Plan for ~50h of issues, leaving 20% buffer.
+- **Rough split:** Dev A (pipeline) ~30h, Dev B (presentation) ~15h, shared ~5h. Dev B finishes presentation early → helps with A9 fixtures and V0 manual review.
+
+### Week-1 cut list (already applied)
+
+- ❌ GitHub Action workflow — deferred to Phase 2 (P2-1).
+- ❌ pnpm workspaces / monorepo — single flat package.
+- ❌ `wordpress-rest` / `fs-walk` / `a8c-context` DocSources — Phase 2.
+- ❌ `symbol-search` / `hybrid` / `embedding-retrieval` mappers — Phase 2+.
+- ❌ PHP / wordpress-develop code source — gutenberg only.
+- ❌ Change detector, slug-rename lint, trend tracking, auto-PRs.
+- ✅ **Kept:** two-pass validation (with Day-3 decision point), LLM-bootstrap script, Tailwind-CDN dashboard.
+
+### Day-3 decision point on two-pass validation
+
+If Phase 0 precision on 3 docs ≥80% AND the clean doc shows 0 issues → **keep** Pass 2 (A6e) and proceed. If <80% or false positives on the clean doc → **cut** Pass 2 (A6e), tighten `confidence ≥ 0.8`, rely on the runtime verbatim-evidence check (A6d), ship the Pass-1-only version. Dashboard still demos.
+
+---
+
+## Day 1 — Shared Kickoff (both devs, half-day pair session)
+
+- **S0 — Bootstrap repo** · Either · S
+  - Deps: —
+  - Done when: `package.json`, `tsconfig.json` (strict), ESLint + Prettier, `.gitignore`, `src/index.ts` placeholder. `npm run typecheck` passes on an empty project.
+
+- **S1 — Manifest + mapping types** · Dev A · S
+  - Deps: S0
+  - Done when: `src/types/mapping.ts` exports `ManifestEntrySchema`, `CodeTiersSchema`, `MappingSchema` (zod). Types compile.
+
+- **S2 — Issue + result types** · Dev A · M
+  - Deps: S0
+  - Done when: `src/types/results.ts` exports `IssueSchema`, `DocResultSchema`, `RunResultsSchema` (zod). Matches the Shared Contract in [architecture.md](./architecture.md#shared-contract-day-1-before-branching) exactly.
+
+- **S3 — Config schema** · Dev B · S
+  - Deps: S0
+  - Done when: `src/config/schema.ts` exports `ConfigSchema` with fields for project, docs source, code source, mapping path, output dir.
+
+- **S4 — Pipeline entry stub** · Either · S
+  - Deps: S2
+  - Done when: `src/pipeline.ts` exports `runPipeline(config: Config): Promise<RunResults>` returning an empty-but-valid `RunResults`. This is the interface Dev B codes against.
+
+- **S5 — Export JSON Schema** · Either · S
+  - Deps: S2
+  - Done when: `npm run gen:schema` writes `examples/results.schema.json` via `zod-to-json-schema`.
+
+- **S6 — Mock results fixture** · Either · M
+  - Deps: S2, S5
+  - Done when: `examples/mock-results.json` has ~4 fake docs (one healthy, one needs-attention, one critical, one with varied issue types) and passes `RunResultsSchema` validation. **Unblocks Dev B fully.**
+
+---
+
+## Dev A — Pipeline (~30h)
+
+- **A1 — Adapter registry** · Dev A · S
+  - Deps: S0
+  - Done when: `src/adapters/index.ts` exports a registry and `NotImplementedError`. Empty type files for `doc-source`, `code-source`, `mapper`, `validator`.
+
+- **A2a — DocSource interface** · Dev A · S
+  - Deps: A1, S1
+  - Done when: `src/adapters/doc-source/types.ts` defines `DocSource.list(config) → Doc[]` returning `{slug, title, parent, sourceUrl, content, codeExamples, metrics}`.
+
+- **A2b — `manifest-url`: fetch + validate** · Dev A · M
+  - Deps: A2a
+  - Done when: given a manifest URL, fetches JSON, validates each entry against `ManifestEntrySchema`, warns on invalid entries without crashing.
+
+- **A2c — `manifest-url`: filter + fetch markdown** · Dev A · M
+  - Deps: A2b
+  - Done when: filters entries by `parent` slug, fetches each `markdown_source` URL, handles 404/500 gracefully, returns `{entry, content}` pairs.
+
+- **A2d — `manifest-url`: parse markdown → Doc** · Dev A · M
+  - Deps: A2c
+  - Done when: frontmatter via `gray-matter`, code blocks/links counted via `remark`. Returns complete `Doc[]`. Unit test against a checked-in mini-manifest fixture.
+
+- **A3a — `git-clone` CodeSource** · Dev A · M
+  - Deps: A1
+  - Done when: `src/adapters/code-source/git-clone.ts` shallow-clones a repo, exposes `readFile(path, startLine?, endLine?)` and `listDir(path)`. Cleans up old clones.
+
+- **A3b — `git-clone`: SHA caching** · Dev A · S
+  - Deps: A3a
+  - Done when: if cache exists and HEAD SHA matches ref, skips clone. Reruns are <1s.
+
+- **A4 — `manual-map` Mapper** · Dev A · M
+  - Deps: A1, S1
+  - Done when: reads `mappings/<project>.json`, validates against `MappingSchema`, returns `CodeTiers` by slug. Throws helpful error when a requested slug is missing.
+
+- **A4c — `bootstrap-mapping` script** · Dev A · L
+  - Deps: A2d, A3a
+  - Done when: `npx tsx scripts/bootstrap-mapping.ts <slug>` prints a proposed `{slug: CodeTiers}` JSON snippet. Uses Claude with the doc content + repo file tree. Human reviews, pastes into `mappings/*.json`.
+
+- **A5 — Seed mapping for ~10 slugs** · Dev A · M
+  - Deps: A4c
+  - Done when: `mappings/gutenberg-block-api.json` has entries for ~10 Block API Reference slugs. Caps: ≤3 primary, ≤5 secondary, ≤8 context each. Committed.
+
+- **A6a — Validator interface** · Dev A · S
+  - Deps: A1, S2
+  - Done when: `src/adapters/validator/types.ts` defines `Validator.validate(doc, context) → Issue[]`.
+
+- **A6b — Validator: context assembler** · Dev A · M
+  - Deps: A3a, A4, S2
+  - Done when: `assembleContext(doc, mapping, budget) → {files, stats}`. Starts with primary+secondary, adds context until budget hit, records what was dropped.
+
+- **A6c — Validator: Pass 1 (system prompt + tool use)** · Dev A · L
+  - Deps: A6a, A6b
+  - Done when: Claude call with cached system prompt emits `Issue[]` via tool-use matching `IssueSchema`. Unit-tested against fixture doc+code.
+
+- **A6d — Validator: verbatim evidence check** · Dev A · S
+  - Deps: A6c
+  - Done when: issues whose `evidence.codeSays` isn't literally found in the referenced file are silently rejected. Counter logged.
+
+- **A6e — Validator: Pass 2 (`fetch_code` retrieve-on-demand)** · Dev A · L
+  - Deps: A6c, A3a
+  - Done when: for each candidate issue, Claude can call `fetch_code(path, startLine?, endLine?)` to verify. Issues with `confidence < 0.7` dropped. **This is the issue to cut at the Day-3 decision point if it's not stable.**
+
+- **A7 — Pipeline orchestrator** · Dev A · M
+  - Deps: A2d, A3a, A4, A6c (Pass 1 at minimum)
+  - Done when: `runPipeline(config)` wires DocSource → CodeSource → Mapper → Validator, analyzes docs with `p-limit(3)`, emits `RunResults` that validates against the schema.
+
+- **A8 — Health scorer** · Dev A · S
+  - Deps: S2
+  - Done when: `scoreDoc(issues) → {healthScore, status}` implemented. Formula `100 − (critical*15 + major*7 + minor*2)`, clamped 0..100. Thresholds: ≥85 healthy, 60–84 needs-attention, <60 critical. Overall average computed in the orchestrator.
+
+- **A9a — Test fixture: drifted doc** · Dev A · M
+  - Deps: A6c
+  - Done when: `tests/fixtures/drifted/` has a hand-tampered doc+code pair. Validator reports ≥1 `critical` issue.
+
+- **A9b — Test fixture: clean doc** · Dev A · S
+  - Deps: A6c
+  - Done when: `tests/fixtures/clean/` has a known-accurate doc+code pair. Validator reports 0 issues (after confidence filter).
+
+---
+
+## Dev B — Presentation (~15h)
+
+- **B1 — Config loader** · Dev B · S
+  - Deps: S3
+  - Done when: `loadConfig(path)` reads YAML, validates via `ConfigSchema`, returns typed `Config`.
+
+- **B2a — CLI skeleton** · Dev B · S
+  - Deps: S0
+  - Done when: `src/cli.ts` with flags `--config`, `--output`, `--only <slug>`, `--dry-run`. `npm run analyze -- --help` prints usage.
+
+- **B2b — CLI wired to pipeline** · Dev B · S
+  - Deps: B2a, B1, S4
+  - Done when: `npm run analyze -- --config config/gutenberg-block-api.yml --output ./out` writes `out/results.json` + a log file. Works with stub `runPipeline` returning empty results.
+
+- **B3a — Dashboard: reader + generator entry** · Dev B · S
+  - Deps: S6
+  - Done when: `src/dashboard/generate.ts` reads + validates a `results.json`, exposes `generate(results, outDir)` that writes to disk.
+
+- **B3b — Dashboard: index.html** · Dev B · M
+  - Deps: B3a, B4
+  - Done when: `out/index.html` shows overall health %, totals (critical/major/minor), and the tree view grouped by parent slug with per-folder aggregated score. Tailwind CDN, one-file HTML.
+
+- **B3c — Dashboard: doc-detail.html** · Dev B · L
+  - Deps: B3a
+  - Done when: `out/doc/<slug>.html` shows title, health score, metrics, issues (severity, confidence, quoted evidence, proposed action), positives, related-code list, source URL link. Generated one per doc from `examples/mock-results.json`.
+
+- **B3d — Dashboard: folder.html** · Dev B · M
+  - Deps: B3a, B4
+  - Done when: `out/folder/<parent>.html` shows a section's rollup and its docs. Reached via links in `index.html`.
+
+- **B4 — Tree builder** · Dev B · M
+  - Deps: S2
+  - Done when: `buildTree(docs) → TreeNode[]` groups by parent slug, aggregates health (doc-count weighted). Handles ≥200 docs cleanly.
+
+- **B6 — `publish.sh`** · Dev B · S
+  - Deps: B3b, B3c, B3d
+  - Done when: `scripts/publish.sh` (or `npm run publish`) copies `out/` to a `gh-pages` worktree and pushes. GitHub Pages serves the result.
+
+- **B7 — README** · Dev B · M
+  - Deps: B2b (so examples are real)
+  - Done when: install steps, API key setup, CLI usage, sample output, cost expectation, dashboard screenshot. Enough for your partner's partner to reproduce.
+
+---
+
+## Phase 0 Validation Gate (Day 3 — Decision Point)
+
+Gate everything else behind this check. It's also the go/no-go for two-pass validation.
+
+- **V0 — Run on 3 docs, measure P/R** · Dev A + manual review · M
+  - Deps: A5, A7 (with at least Pass 1 wired)
+  - Done when: `docs/phase-0-results.md` (or PR comment) records precision, recall, clean-doc false positives. Day-3 decision documented.
+
+### Method
+
+1. Pick 3 of the ~10 docs — ideally **one known-drifted, one known-clean, one uncertain** so we can measure both precision and recall.
+2. Manually read each doc + its mapped code. Write down (a) the real drift issues a human reviewer would flag, and (b) that the clean doc is actually clean.
+3. Run the validator on those 3 docs.
+4. **Measure:**
+   - **Precision** — of issues reported, how many are real? Target ≥80%.
+   - **Recall** — of the human-found issues, how many did the tool surface? Target ≥70%.
+   - **Clean-doc false positives** — on the clean doc, tool must report 0 issues (or all <0.7 confidence, which we filter). This is the single most important check: a tool that fabricates issues on good docs is worse than useless.
+5. **Day-3 decision:**
+   - **Go** (precision ≥80% + clean doc shows 0 issues): keep two-pass validation, proceed to full 10-doc run.
+   - **No-go** (precision <80% OR clean doc shows false positives): iterate the system prompt for up to half a day. If still failing, **cut Pass 2**, tighten `confidence ≥ 0.8`, rely on the runtime verbatim-evidence check, and ship the Pass-1-only version. Dashboard still demos.
+   - **Fail** (still bad after cuts): honest conversation about whether the PoC is viable — better to surface that at day 3 than day 7.
+
+---
+
+## End-to-end Verification (Day 6–7)
+
+1. `npm install`
+2. `export ANTHROPIC_API_KEY=...`
+3. `npm run analyze -- --config config/gutenberg-block-api.yml --output ./out`
+4. `open out/index.html` — verify overall health %, tree view renders all ~10 docs grouped under `block-api`, clicking a doc opens a detail page with issues, evidence, proposed actions, and a link to the source URL.
+5. Manual precision check on 10 random issues: confirm they're real drift, not hallucination.
+6. Clean-doc check: at least one doc shows `healthy` status with 0 issues (or proves the tool can recognize health).
+7. Cost check: ≤$1 for the full 10-doc run. Flag if it exceeds $5.
+8. `npm run publish` (or `scripts/publish.sh`) pushes `out/` to the `gh-pages` branch; verify the dashboard loads at `https://juanma-wp.github.io/wp-docs-health-monitor/`.

--- a/docs/release-pinning.md
+++ b/docs/release-pinning.md
@@ -1,0 +1,99 @@
+# Release Pinning — Which Code Version Counts as Ground Truth
+
+Back to [PLAN.md](../PLAN.md) · Architecture in [architecture.md](./architecture.md) · Schedule in [timeline.md](./timeline.md).
+
+When the Validator compares a doc claim against "the code," it needs to answer: *which* code? Trunk, the latest released plugin, or the snapshot that ships inside a specific WordPress core version? The answer changes what verdicts the tool produces, so it belongs in the design before the pipeline is wired at scale.
+
+---
+
+## Contents
+
+- [The problem](#the-problem)
+- [Three availability tiers](#three-availability-tiers)
+- [Why trunk is the wrong default](#why-trunk-is-the-wrong-default)
+- [Proposed solution](#proposed-solution)
+- [Implementation footprint](#implementation-footprint)
+- [PoC scope decision](#poc-scope-decision)
+- [Out of scope for v1](#out-of-scope-for-v1)
+- [Open questions](#open-questions)
+
+---
+
+## The problem
+
+The Block Editor Handbook documents features of the Block Editor, which ships through two channels with different feature availability:
+
+1. **Gutenberg plugin** — released every ~2 weeks; latest is [v22.9.0 (2026-04-08)](https://github.com/WordPress/gutenberg/releases).
+2. **WordPress core** — versions like 6.8, 6.9, 7.0 bundle a frozen Gutenberg snapshot, typically several plugin releases behind.
+
+`trunk` is neither of these — it contains work-in-progress code that is not available to any end user. If the Validator reads from `trunk`, the tool reports *healthy* when a doc describes an API that hasn't shipped yet, or reports *broken* when the doc correctly describes released behavior that differs from unreleased refactors.
+
+## Three availability tiers
+
+Any API referenced in the Handbook sits at one of:
+
+| Tier | Where it lives | Who can use it |
+|------|----------------|----------------|
+| Trunk-only | Merged to `trunk`, not in any release | Nobody — internal to development |
+| Plugin-only | Released in the Gutenberg plugin, not yet in WP core | Developers running the Gutenberg plugin |
+| Core-shipped | Bundled into a WP core release | Anyone on that WP version or later |
+
+A verdict of "this doc is accurate" is only meaningful **relative to a target tier.** The Handbook's primary audience is plugin users, so **plugin-latest** is the natural default for v1.
+
+## Why trunk is the wrong default
+
+The Phase 1 `git-clone` `CodeSource` in `architecture.md` does a shallow clone without specifying a ref, which resolves to the default branch (`trunk`). This hasn't surfaced as a bug yet because the Week-1 PoC target is the Block API Reference — a historically stable surface where trunk and the latest release are effectively identical. At scale (150 Handbook docs, including newer / more experimental APIs), trunk-vs-release divergence will start producing false verdicts in both directions.
+
+## Proposed solution
+
+Pin the two sides of the analysis to different refs — **on purpose**:
+
+- **`DocSource`** stays at the **live published manifest** (Gutenberg `docs/manifest.json` on trunk / developer.wordpress.org). The Handbook as published is what readers actually encounter today.
+- **`CodeSource`** pins to the **latest stable Gutenberg release tag**, not trunk.
+
+The drift being measured is then: *"is the currently-published Handbook accurate for a user running the current plugin?"* — which is the question the tool's audience actually needs answered.
+
+Resolve "latest stable release" dynamically at run time via the GitHub API:
+
+```
+GET https://api.github.com/repos/WordPress/gutenberg/releases/latest
+```
+
+This endpoint auto-filters prereleases / release candidates — no extra filtering logic needed. The resolved tag is recorded on each `DocResult` alongside the commit SHA; the plumbing already exists (see `architecture.md` § Code Ingestion — commit SHA on `DocResult`).
+
+## Implementation footprint
+
+Small — this is a config + resolver change, not a new pipeline stage.
+
+1. **Tag resolver** (~5 lines): pre-run step that hits `releases/latest` and returns the tag name.
+2. **Config field on `git-clone`**: `ref: string` — accepts a branch, tag, or SHA. Default becomes `"latest-release"` (a sentinel the resolver handles) rather than `"trunk"`.
+3. **New drift type in the Validator**: *"API referenced in doc does not exist in the released code at target ref."* Complements the existing *"name no longer exists"* drift type in `architecture.md` § What counts as drift.
+4. **`DocResult` field**: `codeRef: { tag, sha }` — records what was analyzed against, for dashboard display and reproducibility.
+
+## PoC scope decision
+
+**Defer to Phase 2.** Rationale:
+
+- Week-1 PoC analyzes 10 Block API Reference docs (`block.json`, `register_block_type`, attributes, supports). These APIs are rock-stable across years of releases. Trunk vs. latest release tag will produce effectively identical verdicts on this set.
+- The Week-1 schedule (`timeline.md`) is already ambitious: full pipeline + dashboard + public deploy in 7 days.
+- The change is small when it lands, but **one more moving part** during Phase 0 validation gate tuning has real cost.
+- Revisit during **P2-M3** (150-doc pipeline) — that's when newer / experimental APIs enter the analyzed set and trunk-vs-release divergence starts producing false verdicts.
+
+This decision is captured as an Open Question in `PLAN.md` so it isn't forgotten when Phase 2 expands scope.
+
+## Out of scope for v1
+
+The following are deliberately **not** part of this doc's proposed change and belong to later phases:
+
+- **WP core version mapping** (`docs/contributors/versions-in-wordpress.md`) — needed to answer "is this API in WP 6.8 yet?" Adds a second target-version axis. Phase 2+.
+- **Dev notes** (`make.wordpress.org/core/tag/dev-notes/`) — curated per-core-release developer-facing notes. Enrichment signal for deprecation and stability context.
+- **"What's new in Gutenberg" posts** (`make.wordpress.org/core/tag/gutenberg-new/`) — curated per-plugin-release summaries. Same role as dev notes, at plugin granularity.
+- **`__experimental` / `__unstable` prefix detection** — stability signal beyond "does the name exist."
+- **Deprecation detection** (`@deprecated` tags, soft-deprecation) — orthogonal to release pinning but overlaps conceptually.
+
+## Open questions
+
+- **Should `DocSource` also pin to the release tag?** Arguments for: consistency, reproducibility. Arguments against: the Handbook is a live-published site, so "docs as they were at v22.9.0" is not what readers encounter today. Current answer: **no** — docs stay at live/latest; only code pins. Revisit if we ever need fully reproducible historical runs.
+- **How often should the resolved tag refresh?** Per-run is simplest. Caching adds complexity for no clear win at PoC scale.
+- **Runbook for broken releases** — non-semver tag, yanked release, missing release asset. Low-probability but worth a runbook entry when P2-M3 lands.
+- **Dashboard display of analyzed tag + SHA** — a one-line footer or header such as *"Analyzed against Gutenberg v22.9.0 @ sha1234…"* for transparency and reproducibility. Phase 2 UI concern.

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -8,6 +8,29 @@ Dates are aspirational — adjust as reality hits. The *sequence* and *gates* ma
 
 ---
 
+## Contents
+
+- [At a glance](#at-a-glance)
+- [Week 1 — PoC milestones](#week-1--poc-milestones)
+  - [W1-M1: Foundation locked](#-w1-m1-foundation-locked-target-end-of-day-1--mon)
+  - [W1-M2: Ingestion pipeline ready](#-w1-m2-ingestion-pipeline-ready-target-end-of-day-2--tue)
+  - [W1-M3: Dashboard against mock fixture](#-w1-m3-dashboard-against-mock-fixture-target-end-of-day-3--wed)
+  - [W1-M4: Phase 0 validation gate](#-w1-m4-phase-0-validation-gate-target-end-of-day-3--wed)
+  - [W1-M5: Full 10-doc run](#-w1-m5-full-10-doc-run-target-end-of-day-5--fri)
+  - [W1-M6: Dashboard complete](#-w1-m6-dashboard-complete-target-end-of-day-5--fri)
+  - [W1-M7: PoC live publicly](#-w1-m7-poc-live-publicly-target-end-of-day-7--sunmon)
+- [Phase 2 — Scale-up milestones](#phase-2--scale-up-milestones)
+  - [P2-M1: Symbol-search mapper validated](#-p2-m1-symbol-search-mapper-validated-target-end-of-week-2)
+  - [P2-M2: Dashboard handles scale](#-p2-m2-dashboard-handles-scale-target-end-of-week-2)
+  - [P2-M3: 150-doc pipeline](#-p2-m3-150-doc-pipeline-target-mid-week-3)
+  - [P2-M4: First automated cron run](#-p2-m4-first-automated-cron-run-target-end-of-week-3)
+  - [P2-M5: Historical UI](#-p2-m5-historical-ui-target-mid-week-4)
+  - [P2-M6: Month-end demo](#-p2-m6-month-end-demo-target-2026-05-15)
+- [Milestone calendar](#milestone-calendar-headline-dates)
+- [Risks that can shift the schedule](#risks-that-can-shift-the-schedule)
+
+---
+
 ## At a glance
 
 | Phase | Window | Goal |

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -1,0 +1,163 @@
+# Timeline
+
+Back to [PLAN.md](../PLAN.md) · Tasks in [backlog.md](./backlog.md) · Architecture in [architecture.md](./architecture.md).
+
+The distribution of work in [backlog.md](./backlog.md) across the month, expressed as **named milestones**. Each milestone has a target date, an owner, and a concrete "done when" check.
+
+Dates are aspirational — adjust as reality hits. The *sequence* and *gates* matter more than the exact day.
+
+---
+
+## At a glance
+
+| Phase | Window | Goal |
+|-------|--------|------|
+| **Week 1 — PoC** | 2026-04-21 → 2026-04-27 | 10 docs from Block API Reference, CLI + static dashboard, live publicly |
+| **Week 2 — Automate mapping** | 2026-04-28 → 2026-05-03 | Symbol-search mapper; dashboard at scale |
+| **Week 3 — Scale + CI** | 2026-05-04 → 2026-05-10 | 150-doc pipeline run; GitHub Action with weekly cron |
+| **Week 4 — History & demo** | 2026-05-11 → ~2026-05-15 | Historical UI; full run; write-up |
+
+**Capacity:** 2 devs × ~5 days × 6 focused hours ≈ 60 dev-hours per week. Plan ~50 productive, 20% buffer.
+
+---
+
+## Week 1 — PoC milestones
+
+### ⚑ W1-M1: Foundation locked (target: end of Day 1 — Mon)
+
+- **Owner:** Both (pair session)
+- **Delivers:** Issue #1
+- **Done when:** `main` contains the repo skeleton, all zod schemas (`MappingSchema`, `IssueSchema` with `fingerprint`, `DocResultSchema` with `diagnostics`, `RunResultsSchema`, `ConfigSchema`), stub `runPipeline()`, `fingerprintIssue()` helper, and `examples/mock-results.json` validating green. Both tracks can start independently tomorrow.
+
+### ⚑ W1-M2: Ingestion pipeline ready (target: end of Day 2 — Tue)
+
+- **Owner:** Track A
+- **Delivers:** Issue #2
+- **Done when:** `runPipeline` (with validator stubbed) prints each slug + its `primary` code-file list for all ~10 Block API Reference docs. `mappings/gutenberg-block-api.json` seeded via `scripts/bootstrap-mapping.ts`. Zero API cost to this point.
+
+### ⚑ W1-M3: Dashboard against mock fixture (target: end of Day 3 — Wed)
+
+- **Owner:** Track B
+- **Delivers:** Issue #4 (most of it)
+- **Done when:** `npm run analyze -- --dry-run` + feeding `examples/mock-results.json` through the dashboard generator produces a browsable static site at `out/` with `index.html`, `doc/<slug>.html`, and `folder/<parent>.html` all rendering and linking correctly. No real AI yet — proves the presentation layer independent of the pipeline.
+
+### 🚪 W1-M4: Phase 0 validation gate (target: end of Day 3 — Wed)
+
+- **Owner:** Track A + manual review
+- **Delivers:** `docs/phase-0-results.md`
+- **Done when:** validator (Pass 1 at minimum) run on 3 docs — one known-drifted, one known-clean, one uncertain. Metrics recorded: precision ≥80%, recall ≥70%, 0 false positives on the clean doc. Day-3 decision documented: **keep Pass 2** (proceed) / **cut Pass 2** (tighten `confidence ≥ 0.8`) / **abort** (honest conversation).
+
+### ⚑ W1-M5: Full 10-doc run (target: end of Day 5 — Fri)
+
+- **Owner:** Track A
+- **Delivers:** Issue #3
+- **Done when:** `npm run analyze` on the PoC config produces a valid `RunResults` over all ~10 docs, with real issues on drifted docs and 0 issues on healthy docs, under $1. Test fixtures (drifted + clean) pass in CI.
+
+### ⚑ W1-M6: Dashboard complete (target: end of Day 5 — Fri)
+
+- **Owner:** Track B
+- **Delivers:** Issue #4 complete
+- **Done when:** README written, screenshots captured, dashboard renders real results from W1-M5 correctly (overall health %, tree view, detail pages with evidence + suggestions + diagnostics + positives, folder rollups).
+
+### ⚑ W1-M7: PoC live publicly (target: end of Day 7 — Sun/Mon)
+
+- **Owner:** Track B
+- **Delivers:** Issue #5
+- **Done when:** dashboard reachable at `https://juanma-wp.github.io/wp-docs-health-monitor/`. `npm run publish` preserves `data/runs/<runId>/` on `gh-pages` for future M8 history UI.
+
+### Dependency graph — Week 1
+
+```
+W1-M1 Foundation
+  ├→ W1-M2 Ingestion ──┐
+  │                    ├→ W1-M5 Full run
+  │                    │    (validator on top of ingestion)
+  │                    │
+  └→ W1-M3 Dashboard mock ─→ W1-M6 Dashboard complete
+                                ↓
+                            W1-M4 Phase 0 gate (blocks W1-M5 if fails)
+                                ↓
+                            W1-M7 Live publish
+```
+
+Track B never waits for Track A — dashboard is built against the mock fixture from W1-M1 and swaps to real results once W1-M5 lands.
+
+---
+
+## Phase 2 — Scale-up milestones
+
+### ⚑ P2-M1: Symbol-search mapper validated (target: end of Week 2)
+
+- **Owner:** Track A
+- **Delivers:** Backlog milestones M1 + M2
+- **Done when:** auto-generated mappings agree with the Week-1 manual mappings ≥70% on `primary` files, ≥60% on `secondary` for the 10 PoC slugs. Editorial-only filter turns the 424-entry manifest into ~150 entries.
+
+### ⚑ P2-M2: Dashboard handles scale (target: end of Week 2)
+
+- **Owner:** Track B
+- **Delivers:** Backlog milestone M4
+- **Done when:** dashboard renders a 200-doc fixture. Initial load <1s. Search/filter by slug/title/status works. Tree collapse/expand for sections.
+
+### ⚑ P2-M3: 150-doc pipeline (target: mid Week 3)
+
+- **Owner:** Track A
+- **Delivers:** Backlog milestone M3
+- **Done when:** full editorial-handbook run completes under `--cost-cap 5`. Concurrency `p-limit(5)` with rate-limit backoff. Checkpointing: `SIGINT` → resume from last completed doc. Total cost logged at run end.
+
+### ⚑ P2-M4: First automated cron run (target: end of Week 3)
+
+- **Owner:** Track B
+- **Delivers:** Backlog milestone M7
+- **Done when:** one **scheduled** Monday 06:00 UTC Action run completes green and auto-publishes the full handbook dashboard to GitHub Pages. `ANTHROPIC_API_KEY` secret configured. `--cost-cap 5` enforced. Manual `workflow_dispatch` also functional.
+
+### ⚑ P2-M5: Historical UI (target: mid Week 4)
+
+- **Owner:** Track B
+- **Delivers:** Backlog milestone M8
+- **Depends on:** P2-M4 having produced ≥2 archived runs
+- **Done when:** dashboard index shows a trend line of `overallHealth` across runs; issues have "persistent · N runs" and "new this week" badges via `Issue.fingerprint`; per-doc detail pages show a health sparkline. Gracefully hides widgets when only 1 run exists.
+
+### ⚑ P2-M6: Month-end demo (target: ~2026-05-15)
+
+- **Owner:** Both
+- **Delivers:** Backlog milestones M5 + M6
+- **Done when:** live public dashboard with ≥2 weekly runs of history visible. Write-up drafted summarizing precision %, total issues, surprises, costs — ready for the Radical Speed Month P2 post. `docs/runbook.md` complete so any teammate can reproduce a manual run.
+
+### Dependency graph — Phase 2
+
+```
+P2-M1 Symbol-search ─┐
+P2-M2 Dashboard scale ┤
+                      ├→ P2-M3 Pipeline at scale ─┬→ P2-M4 Cron run ─→ P2-M5 History UI ─→ P2-M6 Demo
+                      │                           │
+                      └──────────────────────────→┘
+```
+
+---
+
+## Milestone calendar (headline dates)
+
+| Date | Milestone | Kind |
+|------|-----------|------|
+| Day 1 (~Apr 21) | W1-M1 Foundation locked | ⚑ delivery |
+| Day 2 (~Apr 22) | W1-M2 Ingestion pipeline | ⚑ delivery |
+| Day 3 (~Apr 23) | W1-M3 Dashboard on mock | ⚑ delivery |
+| Day 3 (~Apr 23) | W1-M4 Phase 0 gate | 🚪 go/no-go |
+| Day 5 (~Apr 25) | W1-M5 Full 10-doc run | ⚑ delivery |
+| Day 5 (~Apr 25) | W1-M6 Dashboard complete | ⚑ delivery |
+| Day 7 (~Apr 27) | W1-M7 PoC live | 🎯 **Week-1 demo** |
+| End Week 2 (~May 3) | P2-M1 Symbol-search validated | ⚑ delivery |
+| End Week 2 (~May 3) | P2-M2 Dashboard at scale | ⚑ delivery |
+| Mid Week 3 (~May 6) | P2-M3 150-doc pipeline | ⚑ delivery |
+| End Week 3 (~May 10) | P2-M4 First cron run | 🎯 **CI live** |
+| Mid Week 4 (~May 13) | P2-M5 History UI | ⚑ delivery |
+| Month-end (~May 15) | P2-M6 Month-end demo | 🎯 **Final demo** |
+
+---
+
+## Risks that can shift the schedule
+
+- **W1-M4 fails** → cut Pass 2, re-plan W1-M5 as Pass-1-only. ~½ day of prompt iteration cost.
+- **P2-M1 agreement <70%** → fall back to auto-bootstrap: run `bootstrap-mapping.ts` across all 150 slugs with human spot-check. P2-M3 still happens.
+- **Cost overrun on full run** (~P2-M3) → `--cost-cap 5` hard-stops the run. Tighten context budget or downgrade Pass 1 to Haiku 4.5 for bulk, keep Sonnet 4.6 for Pass 2 verification only.
+- **P2-M4 non-obvious config issue** → slip to Week 4. Month-end demo becomes "manual trigger" rather than "automated", which is a softer story but still shippable.


### PR DESCRIPTION
## Summary

Proposed design for the PoC. Review, challenge, refine — **no implementation has started**; this PR is the contract we agree on before writing code.

**End goal:** keep WordPress-hosted documentation sites accurate against the code they describe, supporting both markdown-sourced docs and WordPress-edited custom posts.

**Phase 1 (PoC):** 5–8 docs from Gutenberg `reference-guides/block-api/` via `markdown-git` + `git-clone` + manual mapping + Claude two-pass validator → static HTML dashboard. Local CLI first, GitHub Action stretch.

**Phase 2 (committed, not a maybe):** `wordpress-rest` DocSource demoed against a real WP docs site.

## Shape of the work (vertical split for two devs)

- **Dev A — Pipeline** (`packages/core`): fetchers + mapper + Claude validator → emits `results.json`.
- **Dev B — Presentation & ops**: CLI + static HTML dashboard + config + GitHub Action.
- They sync on **one contract** day 1: the `RunResultsSchema` (zod) + `runPipeline(config) -> RunResults` signature. Dev B mocks a fixture and is unblocked immediately.

See [`PLAN.md`](./PLAN.md) for the full design:
- [Architecture overview](./PLAN.md#architecture-overview) — adapter pattern
- [Shared contract](./PLAN.md#shared-contract-day-1-before-branching) — `RunResultsSchema`
- [Issues for parallel work](./PLAN.md#issues-for-parallel-work) — S0–S2 kickoff, A1–A9 pipeline, B1–B7 presentation, P2-* Phase 2, S3–S8 stretch
- [Phase 0 validation](./PLAN.md#phase-0-validation-before-poc-scale-up) — precision/recall gate at day 3 before scaling

## Key design calls I want pushback on

- **Manual doc→code mapping** for the 5–8 PoC docs. Cheap, deterministic, eliminates a whole failure class. Symbol-search mapper is Phase 2+.
- **Two-pass Claude validation** with quoted-evidence requirement + confidence ≥ 0.7 + runtime verification that `evidence.codeSays` literally appears in the referenced file. This is the main false-positive mitigation.
- **Auto-generated package READMEs excluded** from PoC (most are docgen output — low signal).
- **Adapter stubs, not implementations** for `wordpress-rest`, `sitemap-crawler`, etc. Interfaces exist, `NotImplementedError` everywhere else. Avoids premature abstraction.
- **Static HTML dashboard** (no React/framework). Generated from `results.json` with templates + Tailwind CDN.

## Open questions to resolve in review

- Licensing confirmed MIT?
- Which specific 5–8 docs? Include any known-clean "controls"?
- Phase 2 target site: developer.wordpress.org vs a WooCommerce docs page vs an A8C-internal P2?
- Round-trip fixes (auto-PR on markdown source / draft WP post update) — in Phase 2 scope or defer?

## Test plan

- [ ] Review plan end-to-end, flag anything missing or wrong
- [ ] Agree on `RunResultsSchema` and `runPipeline` signature (day-1 handshake)
- [ ] Confirm repo visibility/licensing
- [ ] Split Issues A*/B* between the two developers
- [ ] Open individual issues on GitHub mirroring the PLAN.md breakdown
- [ ] Phase 0 validation gate (precision ≥ 80%, recall ≥ 70% on 3 docs) before scaling to 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)