### PR TITLE
Enforce 16-char hex format for fingerprint in IssueSchema

### DIFF
--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -18,7 +18,7 @@ export const IssueSchema = z.object({
   }),
   suggestion:  z.string(),
   confidence:  z.number().min(0).max(1),
-  fingerprint: z.string(),
+  fingerprint: z.string().regex(/^[0-9a-f]{16}$/),
 });
 export type Issue = z.infer<typeof IssueSchema>;
 


### PR DESCRIPTION
Adds a regex constraint to match the format that fingerprintIssue() always produces, catching malformed fingerprints at parse time.

https://claude.ai/code/session_011LbhqewF8fmwPN51drvsdR