### PR TITLE
docs: add CLAUDE.md and expand README with setup + usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+- `npm test` — run the Vitest suite once.
+- `npm run test:watch` — Vitest in watch mode.
+- `npx vitest run <path>` — run a single test file (e.g. `npx vitest run src/adapters/doc-source/__tests__/manifest-url.test.ts`). Add `-t "<name>"` to match a single `it`/`describe`.
+- `npm run typecheck` — `tsc --noEmit`. CI-equivalent correctness check; run before pushing.
+- `npm run gen:schema` — regenerates `examples/results.schema.json` from `src/types/results.ts` (Zod → JSON Schema). Run after changing any of the `*Schema` exports in `src/types/`.
+- `npx tsx scripts/verify-ingestion.ts` — smoke-tests the full ingestion pipeline end-to-end against `config/gutenberg-block-api.json` (clones Gutenberg, fetches ~10 docs). Network-dependent; produces clone under `tmp/`.
+
+Node 20+ required. ESM throughout (`"type": "module"`); intra-package imports use `.js` suffixes even for `.ts` sources.
+
+## Architecture
+
+Read these in order when orienting: `PLAN.md` (overview) → `docs/architecture.md` (why decisions were made) → `AGENTS.md` (role-scoped reviewing/implementation) → `src/pipeline.ts` (the wire-up).
+
+### The contract is the center of gravity
+
+`src/types/results.ts` and `src/types/mapping.ts` define every object that crosses a component boundary — `ManifestEntry`, `CodeTiers`, `Issue`, `DocResult`, `RunResults`. These are **Zod schemas with inferred TypeScript types**; the schemas are the source of truth, the types are derivatives. Two implications:
+
+1. Every boundary-crossing value (config files, manifest JSON, Claude tool output, `results.json`) is parsed through a schema — no ambient trust.
+2. `examples/mock-results.json` must round-trip `RunResultsSchema.parse()` successfully. It's the coordination artifact that lets the dashboard track build against a contract while the pipeline track is still implementing it. `examples/results.schema.json` is a generated artifact — never edit by hand; re-run `npm run gen:schema`.
+
+`AGENTS.md` codifies this: `src/types/` is locked. Neither the Backend Engineer nor Frontend Engineer role is permitted to modify those contracts.
+
+### Adapter pattern drives the pipeline
+
+The pipeline (`src/pipeline.ts`) never imports concrete adapters. It depends on three interfaces — `DocSource`, `CodeSource`, `DocCodeMapper` — and asks `src/adapters/index.ts` to instantiate implementations based on config type strings:
+
+```
+config → adapters/index.ts factory → concrete adapter → pipeline uses interface only
+```
+
+`createDocSource` / `createCodeSources` throw `NotImplementedError` for unrecognised type strings. Those throws are the documented extension point — adding a new adapter means a new file plus one branch in `src/adapters/index.ts`, nothing else.
+
+Current Phase 1 adapters:
+- `manifest-url` (DocSource) — `src/adapters/doc-source/manifest-url.ts`. Fetches a Gutenberg-style `manifest.json`, filters by `parentSlug`, concurrently fetches each doc's raw markdown, strips frontmatter (`gray-matter`), counts code blocks + links (`remark`). Bounded concurrency via `p-limit(5)`.
+- `git-clone` (CodeSource) — `src/adapters/code-source/git-clone.ts`. Shallow-clones a repo into `tmp/<slug>-<ref>/`, lazy-initialized on first `readFile` / `listDir` / `getCommitSha`. Subsequent runs reuse the cached `.git` dir.
+- `manual-map` (DocCodeMapper) — `src/adapters/doc-code-mapper/manual-map.ts`. Loads a slug-keyed JSON file (see `mappings/`), cross-validates every `CodeFile.repo` against the configured `codeSources` at construction time (throws `ConfigError` on mismatch). Unknown slugs throw `MappingError`, which the pipeline now catches per-doc (see `pipeline.ts:30-36`) rather than aborting the run.
+
+### Error-handling stance
+
+The pipeline is designed to **produce a valid `RunResults` even when individual docs fail**. Failed fetches and mapping errors become per-doc `diagnostics` entries with `status: 'critical'` — never uncaught exceptions. Tests enforce this stance: see `src/types/__tests__/schemas.test.ts` (`runPipeline` block) and `src/adapters/doc-source/__tests__/manifest-url.test.ts` (error-handling block).
+
+Adapter-level invariants worth knowing before touching this code:
+- `deriveSourceUrl` in `manifest-url.ts` has two branches (URL-base transform vs. GitHub UI fallback); both are covered by tests. The transform requires a `/docs/` segment and falls through to the fallback if absent.
+- `GitCloneSource.readFile(path, startLine?, endLine?)` only slices when **both** bounds are provided. Partial bounds silently return the full file — this is the current contract, pinned by tests.
+- Metrics (`wordCount`, `codeExampleCount`, `linkCount`) are computed **at ingest**, not at validation time. The validator receives pre-parsed `Doc` objects.
+
+### AGENTS.md and role boundaries
+
+`AGENTS.md` defines three roles (Backend Engineer, Frontend Engineer, QA Engineer) with hard boundaries. When acting on a PR via `@claude act as the <Role>`, those boundaries are enforceable rules, not suggestions:
+
+- Backend owns `src/pipeline.ts`, all adapters, validator, storage, config. Cannot touch `src/types/` or frontend.
+- Frontend owns the static HTML dashboard + CLI. No frameworks, no build step (Tailwind via CDN). Cannot touch `src/types/`, pipeline, or validator.
+- QA owns the entire test suite. Writes tests only — never modifies feature code, never weakens an existing assertion. "A test is only worth writing if it can fail."
+
+Read `AGENTS.md` before assuming scope on any PR-driven task.
+
+### Phase context
+
+This repo is in **Phase 1 (PoC)** — ~10 docs from the Gutenberg Block API Reference, end-to-end. The Drift Validator and Dashboard are not yet implemented; `runPipeline` currently produces stub `DocResult`s with `healthScore: 0` and `status: 'critical'`. The `console.log` at `pipeline.ts:32` is intentional PoC-stage debug output and should not be mistaken for production logging. Phase 2 scope (symbol-search mapper, full handbook, weekly cron) is documented in `PLAN.md` and `docs/timeline.md` — do not proactively implement Phase 2 work unless a task explicitly targets it.
+
+## Repository layout quick reference
+
+- `src/adapters/` — interface types live in `types.ts` files next to implementations; `src/adapters/index.ts` is the factory registry.
+- `src/types/` — **locked contracts.** Zod schemas that drive everything else.
+- `config/*.json` — runtime configs (parsed through `src/config/schema.ts`).
+- `mappings/*.json` — doc-slug → tiered code-file mappings. `mappings/test.json` is an empty `{}` used by the unit tests.
+- `tests/fixtures/` — `mini-manifest.json`, `mini-mapping.json`, `sample-doc.md` for adapter tests.
+- `examples/mock-results.json` — the canonical `RunResults` fixture; must round-trip through `RunResultsSchema`.
+- `scripts/` — one-off tools (`bootstrap-mapping.ts` is a dev-time accelerator for generating mappings via Claude; `verify-ingestion.ts` is the end-to-end smoke test; `gen-schema.ts` regenerates the JSON Schema from Zod).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The tool compares docs (from markdown in a repo or from a WordPress REST API) ag
 
 ## Status
 
-🌱 Early. Design proposed via PR — review, challenge, and refine before implementation starts.
+🌱 Early. Phase 1 (Proof of Concept) is in progress. **Ingestion works end-to-end; the drift validator and dashboard are not yet implemented.** Running the pipeline today produces a list of docs with stub analysis results — useful for validating config, mappings, and adapter plumbing, but not yet producing real drift findings.
 
 - **[`PLAN.md`](./PLAN.md)** — overview, scope, architecture at a glance, out-of-scope, open questions.
 - **[`docs/architecture.md`](./docs/architecture.md)** — technical details: repo layout, schemas, mapping format, tech stack, risks.
@@ -25,6 +25,151 @@ The Block Editor Handbook alone has 150+ editorial docs that silently drift from
 4. **GitHub Action** for weekly cron + manual dispatch (stretch for the PoC).
 
 See [`PLAN.md`](./PLAN.md) for the design, [`docs/architecture.md`](./docs/architecture.md) for the schemas, [`docs/backlog.md`](./docs/backlog.md) for the issue breakdown, and [`docs/timeline.md`](./docs/timeline.md) for the schedule.
+
+## Getting started
+
+### Requirements
+
+- **Node.js 20+** (ESM + native `fetch`).
+- **Git** (the `git-clone` `CodeSource` shells out via `simple-git`).
+- Roughly 1 GB free disk for the Gutenberg + wordpress-develop shallow clones the smoke run produces under `tmp/`.
+
+### Install
+
+```bash
+git clone https://github.com/juanma-wp/wp-docs-health-monitor.git
+cd wp-docs-health-monitor
+npm install
+```
+
+### Verify the install
+
+```bash
+npm run typecheck   # tsc --noEmit
+npm test            # vitest run
+```
+
+Both should exit clean. The test suite includes a GitCloneSource test that initialises a local git repo under `tmp/` — `git` must be on PATH.
+
+### Run the ingestion pipeline end-to-end
+
+The bundled config targets the Gutenberg Block API Reference (10 docs).
+
+```bash
+npx tsx scripts/verify-ingestion.ts
+```
+
+What this does:
+
+1. Loads `config/gutenberg-block-api.json` and validates it against the config schema.
+2. Fetches the Gutenberg `manifest.json`, filters to entries where `parent === "block-api"`, and fetches each doc's raw markdown.
+3. Shallow-clones the Gutenberg and `wordpress-develop` repos into `tmp/`.
+4. Prints `Docs fetched: 10` and `Failed: 0` on success (the "Failed" count includes docs whose mapping slug is missing — harmless while the mapping is still being curated).
+
+Re-runs reuse the cached clones under `tmp/` — expect ~1s on subsequent runs vs. ~30s the first time. To start fresh, delete `tmp/`.
+
+### Optional environment variables
+
+| Variable | Used by | Purpose |
+|---|---|---|
+| `GITHUB_TOKEN` | `manifest-url` DocSource | Authenticates GitHub Commits API calls for each doc's `lastModified` field. Without it you'll hit the 60/hr anonymous rate limit after ~50 docs. |
+| `ANTHROPIC_API_KEY` | `scripts/bootstrap-mapping.ts` | Required for the mapping-bootstrap helper (see below). Not needed for the core pipeline until the validator lands. |
+
+## Customising for your own docs
+
+To monitor a different WordPress doc site or doc section, you supply two JSON files:
+
+### 1. A config file — `config/<your-site>.json`
+
+```json
+{
+  "project":   { "name": "Your Docs" },
+  "docSource": {
+    "type":          "manifest-url",
+    "manifestUrl":   "https://raw.githubusercontent.com/OWNER/REPO/BRANCH/docs/manifest.json",
+    "parentSlug":    "your-section",
+    "sourceUrlBase": "https://developer.example.com/your-section/"
+  },
+  "codeSources": {
+    "my-repo": {
+      "type":    "git-clone",
+      "repoUrl": "https://github.com/OWNER/REPO.git",
+      "ref":     "trunk"
+    }
+  },
+  "mappingPath": "mappings/your-site.json",
+  "outputDir":   "./out",
+  "validator":   { "type": "claude", "model": "claude-sonnet-4-6" }
+}
+```
+
+Keys of note:
+- `parentSlug` filters the manifest to a single section — start narrow.
+- `sourceUrlBase` is optional; omit it to get GitHub-UI `/blob/` URLs as `Doc.sourceUrl`.
+- Each key under `codeSources` (`my-repo`, `gutenberg`, `wordpress-develop`, …) becomes a valid `repo` value in the mapping file. A mapping entry that references a repo not listed here will fail config validation at construction time.
+
+### 2. A mapping file — `mappings/<your-site>.json`
+
+Slug-keyed, tiered code references. Tiers hint at token-budget priority: `primary` (≤3) is always sent to the validator, `secondary` (≤5) is added next, `context` (≤8) is dropped first under token pressure.
+
+```json
+{
+  "your-doc-slug": {
+    "primary":   [{ "repo": "my-repo", "path": "src/api.ts" }],
+    "secondary": [{ "repo": "my-repo", "path": "src/api-helpers.ts" }],
+    "context":   []
+  }
+}
+```
+
+See `mappings/gutenberg-block-api.json` for a real example.
+
+### Bootstrap a mapping with Claude
+
+Curating these by hand is tedious. The bootstrap helper asks Claude to propose a `CodeTiers` entry for a single slug, based on the doc content and the cloned repo's file tree. Review and commit the output yourself — it's a dev-time accelerator, not a runtime component.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+npx tsx scripts/bootstrap-mapping.ts <slug> --config config/your-site.json
+```
+
+Run it once per slug, paste the suggested JSON into your mapping file, then sanity-check that every referenced file exists in the repo.
+
+### Run your custom config
+
+The `verify-ingestion.ts` script currently hard-codes `config/gutenberg-block-api.json`. To run against your own config, either edit that path or write a thin wrapper:
+
+```ts
+import { loadConfig } from './src/config/loader.js';
+import { runPipeline } from './src/pipeline.js';
+
+const config = await loadConfig('config/your-site.json');
+const results = await runPipeline(config);
+console.log(JSON.stringify(results, null, 2));
+```
+
+Save it as `scripts/run-mine.ts` and run with `npx tsx scripts/run-mine.ts`. A proper CLI entry point is on the backlog.
+
+## Development
+
+- `npm run test:watch` — Vitest watch mode.
+- `npx vitest run <path>` — run a single test file. Add `-t "<name>"` to match a single `it`.
+- `npm run gen:schema` — regenerate `examples/results.schema.json` from the Zod schemas in `src/types/results.ts`. Run after any schema change.
+- `CLAUDE.md` — orientation for Claude Code / Claude Agent SDK sessions working in this repo.
+- `AGENTS.md` — role definitions (Backend Engineer, Frontend Engineer, QA Engineer) used when invoking `@claude` on a PR. Roles have hard scope boundaries; read before assigning reviews.
+
+## What works today vs. what doesn't
+
+| Works | Not yet |
+|---|---|
+| `manifest-url` DocSource (fetch + metrics + frontmatter) | `wordpress-rest`, `fs-walk`, `a8c-context` DocSources |
+| `git-clone` CodeSource (with commit-SHA caching) | `symbol-search` DocCodeMapper |
+| `manual-map` DocCodeMapper (with cross-validation) | Drift Validator (the Claude pipeline) |
+| Full pipeline producing schema-valid `RunResults` | Health scoring (current results are stubs with `healthScore: 0`) |
+| 51-test suite covering adapters, schemas, and error paths | Static HTML dashboard |
+| Mapping-bootstrap helper via Claude | CLI entry point, GitHub Action |
+
+See [`docs/backlog.md`](./docs/backlog.md) for what's queued and who owns it.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` — orientation for Claude Code / Claude Agent SDK sessions. Covers the commands, the Zod-schema contract at `src/types/`, the adapter-registry pattern, the per-doc diagnostics error-handling stance, and the hard scope boundaries from `AGENTS.md`.
- Expands `README.md` with user-facing setup: requirements (Node 20+, git, ~1 GB disk for the clones), install + verify steps, the `verify-ingestion` smoke run, an env-var table (`GITHUB_TOKEN`, `ANTHROPIC_API_KEY`), worked examples for customising `config/*.json` and `mappings/*.json` against a different doc site, and a "works today / not yet" table so readers calibrate against the Phase 1 (partial) state.

Docs-only — no source or test changes.

## Test plan

- [x] `npm test` — 51/51 passing (unchanged)
- [x] `npm run typecheck` — clean (unchanged)
- [ ] README renders correctly on GitHub (table formatting, fenced code blocks)
- [ ] Follow the README "Getting started" steps on a clean clone and confirm `npx tsx scripts/verify-ingestion.ts` reports `Docs fetched: 10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)