### PR TITLE
Product refinements: stable fingerprints, usage tracking, MVP framing, operability docs

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -44,9 +44,9 @@ scope and validating signal at each level before investing in the next.
 
 | MVP | Phases | Goal |
 |-----|--------|------|
-| **MVP 1 — Tracer bullet** | Phase 2 Track A | One doc, full stack, result to console. Does the idea work? |
-| **MVP 2 — PoC usable** | Phase 2 Track B + Phase 3 + Phase 4 | Ten docs, dashboard, real issues, cost measured, results persisted. Does it generate useful signal? |
-| **MVP 3 — Production monitor** | Phase 5 | ~150 docs, auto-mappings, weekly cron, historical UI, cost cap. Is it a reliable continuous monitor? |
+| **MVP 1 — Tracer bullet** | [Phase 2 — Track A](#track-a--one-doc-full-stack) | One doc, full stack, result to console. Does the idea work? |
+| **MVP 2 — PoC usable** | [Phase 2 — Track B](#track-b--dashboard-against-mock-parallel) + [Phase 3](#phase-3--full-pipeline--phase-0-gate) + [Phase 4](#phase-4--integration--publish) | Ten docs, dashboard, real issues, cost measured, results persisted. Does it generate useful signal? |
+| **MVP 3 — Production monitor** | [Phase 5](#phase-5--scale-weeks-24) | ~150 docs, auto-mappings, weekly cron, historical UI, cost cap. Is it a reliable continuous monitor? |
 
 Acceptance criteria scale with the MVP:
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -12,6 +12,7 @@ The original plan (component breakdown, timeline, backlog) is preserved in
 ## Contents
 
 - [How to prompt each phase](#how-to-prompt-each-phase)
+- [MVP framing](#mvp-framing)
 - [Phase 1 — Foundation](#phase-1--foundation--complete)
 - [Phase 2 — Tracer bullet](#phase-2--tracer-bullet)
 - [Phase 3 — Full pipeline + Phase 0 gate](#phase-3--full-pipeline--phase-0-gate)
@@ -33,6 +34,29 @@ User stories in scope: [numbers from prd.md].
 
 That is all. The PRD is the destination; this file is the journey; the phase block
 scopes the work. After each phase: commit, clear context, move to the next.
+
+---
+
+## MVP framing
+
+The phases map onto three product MVPs. This overlay is useful for communicating
+scope and validating signal at each level before investing in the next.
+
+| MVP | Phases | Goal |
+|-----|--------|------|
+| **MVP 1 — Tracer bullet** | Phase 2 Track A | One doc, full stack, result to console. Does the idea work? |
+| **MVP 2 — PoC usable** | Phase 2 Track B + Phase 3 + Phase 4 | Ten docs, dashboard, real issues, cost measured, results persisted. Does it generate useful signal? |
+| **MVP 3 — Production monitor** | Phase 5 | ~150 docs, auto-mappings, weekly cron, historical UI, cost cap. Is it a reliable continuous monitor? |
+
+Acceptance criteria scale with the MVP:
+
+- **MVP 1:** one `DocResult` produced end-to-end; at least one real issue detected OR
+  explicit `healthy` status; cost < $0.10.
+- **MVP 2:** precision ≥ 80%; zero false positives on a known-clean doc; dashboard
+  renders all three page types; `usage` field populated in `results.json`; full 10-doc
+  run < $1.
+- **MVP 3:** 150-doc run under cost cap; cron runs unattended; historical badges
+  correct across ≥ 2 archived runs; dashboard responsive with 150 docs.
 
 ---
 
@@ -111,6 +135,14 @@ Wire into CLI with `--config` and `--output` flags. Write
 `out/data/runs/<runId>/results.json`. Add `p-limit(3)` concurrency and a per-run cost
 meter printed at completion.
 
+**Usage tracking belongs here.** Accumulate `inputTokens`, `outputTokens`,
+`cacheReadTokens`, `cacheWriteTokens` across all Claude calls in the run. Compute
+`estimatedCostUsd` using the current Sonnet 4.6 pricing. Populate `RunResults.usage`
+before writing `results.json`. Print a cost summary to console at run completion:
+```
+Run complete: 10 docs | $0.42 | 98,234 input | 12,100 output | cache hit 88%
+```
+
 Then run the **Phase 0 gate** before calling this phase complete.
 
 ### Phase 0 gate
@@ -172,12 +204,20 @@ dashboard at `https://juanma-wp.github.io/wp-docs-health-monitor/`. Commit.
 Coarse milestones only — scope depends on Phase 3 and 4 findings.
 
 - **Symbol-search mapper** — auto-generate mappings for ~150 docs via AST search;
-  validated against Phase 3 manual mappings (≥70% agreement on primary files)
+  validated against Phase 3 manual mappings (≥70% agreement on primary files).
+  Manual mappings have priority: if a slug already has a hand-written entry in
+  `mappings/*.json`, the auto-generated mapping is stored separately (e.g.
+  `mappings/gutenberg-block-api.auto.json`) and never overwrites it. The pipeline
+  merges both at load time, preferring manual entries on conflict.
 - **Editorial filter** — exclude auto-generated package READMEs; ~424 → ~150 docs
 - **DocSource git-refactor** — share the existing Gutenberg clone between DocSource
   and CodeSource; eliminates 150+ per-doc HTTP requests per run
 - **Pipeline at scale** — `p-limit(5)`, `--cost-cap` flag, checkpointing on `SIGINT`
-- **Dashboard at scale** — collapse/expand tree, search/filter, <1s initial load
+- **Dashboard at scale** — collapse/expand tree, sortable/filterable table view,
+  <1s initial load. Table columns: health score, issue count, max severity,
+  section/parent, status (healthy/needs-attention/critical), estimated cost,
+  last analyzed, new-this-run badge, persistent-N-runs badge. Sortable on all
+  numeric/enum columns; filterable by section, status, and free-text slug/title.
 - **GitHub Action** — weekly cron Mon 06:00 UTC, `--cost-cap 5`, auto-publish
 - **Historical UI** — trend line across runs, "new this week" / "persistent N runs"
   badges via `Issue.fingerprint`

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -160,15 +160,57 @@ and suggested fixes, and explicit confirmation when docs are accurate.
 - Three page types: index (overall health + tree view by section), per-doc detail
   (issues, evidence, suggestions, positives, diagnostics, source link), folder rollup
   (section aggregation with weighted health scores).
+- At scale (Phase 5) the index includes a sortable, filterable table view. Columns:
+  health score, issue count, max severity, section/parent, status, estimated cost,
+  last analyzed, new-this-run badge, persistent-N-runs badge. This makes the dashboard
+  an operational tool, not just a report.
 
 ### Results storage
 
 - `gh-pages` branch doubles as static host and append-only data store:
   `data/runs/<runId>/results.json` + `data/history.json` index.
 - Publish script preserves all existing run directories. Never overwrites prior data.
-- Issue fingerprinting: stable hash of `slug + type + codeFile + normalize(text)`.
-  Same fingerprint across runs = same issue, regardless of doc line shifts. Enables
-  story 19 without a database.
+- Each `results.json` carries an optional `usage` field populated by the pipeline once
+  real Claude calls are wired up (Phase 3+):
+  ```json
+  "usage": {
+    "inputTokens": 123456,
+    "outputTokens": 23456,
+    "cacheReadTokens": 90000,
+    "cacheWriteTokens": 12000,
+    "estimatedCostUsd": 3.42
+  }
+  ```
+  The field is optional so Phase 1–2 fixtures validate without it.
+- Issue fingerprinting: stable hash of `slug + type + codeRepo + codeFile`.
+  Deliberately excludes LLM-generated text — Claude may paraphrase the same finding
+  differently across runs, which would produce a different hash and make persistent
+  issues look new. Using only structured fields ensures the same issue maps to the
+  same fingerprint even when the description varies. Enables story 19 without a
+  database. Multiple issues of the same `type` on the same file for the same doc are
+  rare in practice given the specificity of the type enum.
+
+### Operability
+
+The dashboard must surface enough information to answer "what did this run cost and
+was it within budget?" for both development runs and production crons.
+
+Required information per run (rendered in the dashboard index header):
+
+| Field | Description |
+|-------|-------------|
+| Run cost | `estimatedCostUsd` from `usage` |
+| Input tokens | raw + formatted with commas |
+| Output tokens | raw + formatted with commas |
+| Cache hit rate | `cacheReadTokens / (inputTokens + cacheReadTokens)` × 100% |
+| Cost cap | configured value; highlight in red if run approached it |
+| Docs analyzed | count from `totals.docs` |
+| Docs skipped | count from diagnostics entries |
+| Run duration | seconds from start to completion |
+
+This information also answers the "how much does it cost at scale?" question:
+measuring real token usage per doc makes projecting to 150–200 docs straightforward
+without guessing.
 
 ---
 

--- a/examples/results.schema.json
+++ b/examples/results.schema.json
@@ -66,6 +66,34 @@
           ],
           "additionalProperties": false
         },
+        "usage": {
+          "type": "object",
+          "properties": {
+            "inputTokens": {
+              "type": "integer"
+            },
+            "outputTokens": {
+              "type": "integer"
+            },
+            "cacheReadTokens": {
+              "type": "integer"
+            },
+            "cacheWriteTokens": {
+              "type": "integer"
+            },
+            "estimatedCostUsd": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "inputTokens",
+            "outputTokens",
+            "cacheReadTokens",
+            "cacheWriteTokens",
+            "estimatedCostUsd"
+          ],
+          "additionalProperties": false
+        },
         "docs": {
           "type": "array",
           "items": {
@@ -157,7 +185,8 @@
                       "maximum": 1
                     },
                     "fingerprint": {
-                      "type": "string"
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{16}$"
                     }
                   },
                   "required": [

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,16 +1,13 @@
 import { createHash } from 'crypto';
 
+// Uses structured fields only — not LLM-generated text — so fingerprints are
+// stable across runs even when Claude paraphrases the same finding differently.
 export function fingerprintIssue(
   slug: string,
   type: string,
+  codeRepo: string,
   codeFile: string,
-  issueText: string,
 ): string {
-  const normalized = issueText
-    .toLowerCase()
-    .replace(/[^\w\s]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-  const input = `${slug}|${type}|${codeFile}|${normalized}`;
+  const input = `${slug}|${type}|${codeRepo}|${codeFile}`;
   return createHash('sha256').update(input).digest('hex').slice(0, 16);
 }

--- a/src/types/__tests__/schemas.test.ts
+++ b/src/types/__tests__/schemas.test.ts
@@ -183,25 +183,31 @@ describe('ManifestEntrySchema', () => {
 
 describe('fingerprintIssue', () => {
   it('returns a 16-character hex string', () => {
-    const fp = fingerprintIssue('block-metadata', 'type-signature', 'src/index.ts', 'update the foo');
+    const fp = fingerprintIssue('block-metadata', 'type-signature', 'gutenberg', 'src/index.ts');
     expect(fp).toMatch(/^[0-9a-f]{16}$/);
   });
 
   it('is stable: same inputs produce the same fingerprint', () => {
-    const a = fingerprintIssue('block-metadata', 'type-signature', 'src/index.ts', 'update the foo');
-    const b = fingerprintIssue('block-metadata', 'type-signature', 'src/index.ts', 'update the foo');
-    expect(a).toBe(b);
-  });
-
-  it('is whitespace-tolerant: extra spaces produce the same fingerprint', () => {
-    const a = fingerprintIssue('block-metadata', 'type-signature', 'src/index.ts', 'update the foo');
-    const b = fingerprintIssue('block-metadata', 'type-signature', 'src/index.ts', '  update  the  foo  ');
+    const a = fingerprintIssue('block-metadata', 'type-signature', 'gutenberg', 'src/index.ts');
+    const b = fingerprintIssue('block-metadata', 'type-signature', 'gutenberg', 'src/index.ts');
     expect(a).toBe(b);
   });
 
   it('produces different fingerprints for different slugs', () => {
-    const a = fingerprintIssue('block-metadata', 'type-signature', 'src/index.ts', 'update the foo');
-    const b = fingerprintIssue('block-supports', 'type-signature', 'src/index.ts', 'update the foo');
+    const a = fingerprintIssue('block-metadata', 'type-signature', 'gutenberg', 'src/index.ts');
+    const b = fingerprintIssue('block-supports', 'type-signature', 'gutenberg', 'src/index.ts');
+    expect(a).not.toBe(b);
+  });
+
+  it('produces different fingerprints for different codeRepos', () => {
+    const a = fingerprintIssue('block-metadata', 'type-signature', 'gutenberg', 'src/index.ts');
+    const b = fingerprintIssue('block-metadata', 'type-signature', 'wordpress-develop', 'src/index.ts');
+    expect(a).not.toBe(b);
+  });
+
+  it('produces different fingerprints for different codeFiles', () => {
+    const a = fingerprintIssue('block-metadata', 'type-signature', 'gutenberg', 'src/index.ts');
+    const b = fingerprintIssue('block-metadata', 'type-signature', 'gutenberg', 'src/other.ts');
     expect(a).not.toBe(b);
   });
 });

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -43,6 +43,15 @@ export const DocResultSchema = z.object({
 });
 export type DocResult = z.infer<typeof DocResultSchema>;
 
+export const RunUsageSchema = z.object({
+  inputTokens:      z.number().int(),
+  outputTokens:     z.number().int(),
+  cacheReadTokens:  z.number().int(),
+  cacheWriteTokens: z.number().int(),
+  estimatedCostUsd: z.number(),
+});
+export type RunUsage = z.infer<typeof RunUsageSchema>;
+
 export const RunResultsSchema = z.object({
   runId:         z.string().regex(/^\d{8}-\d{6}$/),  // YYYYMMDD-HHmmss
   timestamp:     z.string().datetime(),
@@ -59,6 +68,7 @@ export const RunResultsSchema = z.object({
       minor:    z.number().int(),
     }),
   }),
+  usage: RunUsageSchema.optional(),
   docs: z.array(DocResultSchema),
 });
 export type RunResults = z.infer<typeof RunResultsSchema>;


### PR DESCRIPTION
## Summary

Captures product decisions and one code fix that came out of a design review conversation.

- **Fix `fingerprintIssue()`** — removes LLM-generated text from the hash. The old signature hashed `slug + type + codeFile + normalize(issueText)`, where `issueText` was a free-form string generated by Claude. The same finding rephrased slightly across runs would produce a different fingerprint, making persistent issues look new every time. New signature: `slug + type + codeRepo + codeFile` — all structured, all stable.
- **Add `RunUsageSchema` + optional `usage` field to `RunResultsSchema`** — tracks `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheWriteTokens`, `estimatedCostUsd` per run. Field is optional so existing fixtures validate without it; the pipeline will populate it in Phase 3 when real Claude calls are wired.
- **Regenerate `examples/results.schema.json`** to reflect the schema addition.
- **PRD additions:** updated fingerprint decision rationale; usage example in Results storage section; new Operability section (cost/token display requirements for the dashboard); sortable table columns spec for Phase 5 dashboard.
- **PLAN.md additions:** MVP 1/2/3 framing overlay with per-MVP acceptance criteria; usage tracking step in Phase 3; manual > auto mapping priority rule in Phase 5 M1; concrete table column list in Phase 5 M4.

## Test plan

- [ ] `npm test` — 52 tests pass (verified locally)
- [ ] `npm run typecheck` — clean (verified locally)
- [ ] `npm run gen:schema` — `examples/results.schema.json` regenerated and committed
- [ ] `RunResultsSchema.parse(mockResults)` still passes with the existing `examples/mock-results.json` (usage field is optional — no fixture update needed)

https://claude.ai/code/session_01Kzrf3L5dJaXQs9meXAANBe