### PR TITLE
fix(tests): stub fetch in runPipeline tests to avoid network timeouts

### DIFF
--- a/src/types/__tests__/schemas.test.ts
+++ b/src/types/__tests__/schemas.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -229,6 +229,15 @@ const singleEntryManifest = JSON.stringify([{
 }]);
 
 describe('runPipeline', () => {
+  beforeEach(() => {
+    // Default: empty manifest. Individual tests override as needed.
+    // Without this stub, tests that don't override would hit example.com over
+    // the network and could exceed the 5s test timeout on slow/blocked networks.
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify([]), { status: 200 })
+    ));
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });


### PR DESCRIPTION
The first two runPipeline tests in schemas.test.ts called runPipeline without stubbing fetch, so they made real HTTP calls to https://example.com/manifest.json. On slow or restricted networks the fetch could stall past Vitest's 5s test timeout and fail the suite.

Add a beforeEach in the runPipeline describe block that stubs fetch with an empty-manifest response by default. Tests that need specific responses still override the stub in the test body, and the existing afterEach restoreAllMocks() cleans up between tests.

@juanmaguitar I'd appreciate your thoughts on this fix.