### PR TITLE
Add test for Claude validator handling missing suggestions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "wp-docs-health-monitor",
       "version": "0.1.0",
       "dependencies": {
-        "commander": "^12.1.0",
         "@anthropic-ai/sdk": "^0.91.0",
+        "commander": "^12.1.0",
         "gray-matter": "^4.0.3",
         "p-limit": "^5.0.0",
         "remark": "^15.0.1",

--- a/src/adapters/validator/__tests__/claude.test.ts
+++ b/src/adapters/validator/__tests__/claude.test.ts
@@ -345,6 +345,34 @@ describe('ClaudeValidator — weak suggestion handling', () => {
     // pass1 + pass2 + retry = 3 calls
     expect(createSpy).toHaveBeenCalledTimes(3);
   });
+
+  it('does not crash when Pass 2 returns an issue with missing suggestion', async () => {
+    const fileContent = 'function registerBlockType(name, settings) {}';
+    const codeSays = 'function registerBlockType(name, settings)';
+
+    // Pass 1: codeSays is present in the file so it survives the verbatim check
+    const pass1Response = makeReportFindingsResponse([
+      { ...BASE_ISSUE, evidence: { ...BASE_ISSUE.evidence, codeSays } },
+    ], []);
+
+    // Pass 2: returns an issue with suggestion omitted (undefined)
+    const pass2Response = makeReportFindingsResponse([
+      {
+        ...BASE_ISSUE,
+        evidence:   { ...BASE_ISSUE.evidence, codeSays },
+        confidence: 0.8,
+        suggestion: undefined,
+      },
+    ], []);
+
+    const client = makeAnthropicClient([pass1Response, pass2Response]);
+    const codeSources = makeCodeSources(fileContent);
+
+    const validator = new ClaudeValidator('claude-sonnet-4-6', 'claude-sonnet-4-6', client);
+    const result = await validator.validateDoc(makeDoc(), makeCodeTiers(), codeSources);
+
+    expect(result.issues).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Added a test case to ensure the Claude validator gracefully handles scenarios where Pass 2 returns an issue with an undefined suggestion field, preventing crashes during validation.

## Key Changes
- Added test case `does not crash when Pass 2 returns an issue with missing suggestion` to the Claude validator test suite
- The test verifies that when Pass 2 returns an issue with `suggestion: undefined`, the validator handles it safely and returns no issues (filtering out the invalid result)
- Test covers the edge case where an issue passes the verbatim check in Pass 1 but lacks a suggestion in Pass 2

## Implementation Details
- The test creates a two-pass scenario: Pass 1 returns a valid issue with suggestion, Pass 2 returns the same issue but with `suggestion: undefined`
- Validates that the validator doesn't crash and correctly filters out the malformed issue from Pass 2
- Uses existing test utilities (`makeReportFindingsResponse`, `makeAnthropicClient`, etc.) to construct the test scenario

https://claude.ai/code/session_01BpzRnGNGHAxrjDD1vMeqUT