### PR TITLE
feat(validator): add site-specific prompt extension support

### DIFF
--- a/config/gutenberg-block-api.json
+++ b/config/gutenberg-block-api.json
@@ -25,6 +25,7 @@
   "validator": {
     "type": "claude",
     "pass1Model": "claude-sonnet-4-6",
-    "pass2Model": "claude-sonnet-4-6"
+    "pass2Model": "claude-sonnet-4-6",
+    "systemPromptExtension": "prompts/gutenberg-block-api.md"
   }
 }

--- a/docs/mapping-guidelines.md
+++ b/docs/mapping-guidelines.md
@@ -76,6 +76,18 @@ The schema is first in `primary` because it is the most authoritative source for
 
 ---
 
+## Site-specific prompt extensions
+
+The validator supports a `systemPromptExtension` in `config.validator` — a path to a Markdown file appended to the base system prompt as a "Site-specific rules" section. Use this to encode project-specific knowledge that would otherwise cause false positives:
+
+- Internal or reserved identifiers that are intentionally undocumented
+- Known patterns in how the codebase uses PHP or JavaScript that the model tends to misread
+- Clarifications about which schemas or sources are authoritative for this project
+
+See `prompts/gutenberg-block-api.md` for an example. Update the extension file whenever the Phase 0 gate review reveals a recurring false positive pattern.
+
+---
+
 ## Adding a new doc
 
 1. Read the doc at developer.wordpress.org

--- a/prompts/gutenberg-block-api.md
+++ b/prompts/gutenberg-block-api.md
@@ -1,5 +1,3 @@
-## WordPress Block Editor — site-specific rules
-
 These rules apply when validating the Gutenberg Block API Reference documentation. They encode learnings from the Phase 0 gate manual review.
 
 ### Known internal / reserved identifiers — do not flag as missing from docs

--- a/prompts/gutenberg-block-api.md
+++ b/prompts/gutenberg-block-api.md
@@ -1,0 +1,25 @@
+## WordPress Block Editor — site-specific rules
+
+These rules apply when validating the Gutenberg Block API Reference documentation. They encode learnings from the Phase 0 gate manual review.
+
+### Known internal / reserved identifiers — do not flag as missing from docs
+
+- `reusable` block category — used exclusively by `core/block` (the Reusable Block block itself). It is intentionally omitted from the public category list. Do not report it as missing.
+
+### Short-circuit evaluation — verify before reporting
+
+Before reporting that a function "is not called" or "is always called" based on a conditional, verify the full boolean expression including short-circuit behaviour.
+
+Example: `if (block.isValid && !isEligible(...))` — when `block.isValid` is `false`, JavaScript short-circuits and `isEligible` is never evaluated. The function is NOT called. Do not report the opposite.
+
+### PHP `_doing_it_wrong()` vs required fields
+
+A PHP `_doing_it_wrong()` call does not automatically make a field "required" in the documentation sense. If the requirement is stated clearly in the prose of the documentation page (not just the parameter table), the documentation is correct. Only flag as drift if the requirement is genuinely absent from the documentation.
+
+### JSON schemas in `schemas/json/`
+
+These schemas are designed for IDE tooling (VS Code autocomplete, editor validation). They represent current recommendations, not runtime contracts. Do not use their `required` arrays to claim a field is required — confirm that from TypeScript or PHP source instead.
+
+### Deprecated functions
+
+Only report a deprecated function as drift if the documentation explicitly names and recommends that deprecated function. Do not flag it if the documentation only links to or mentions a related but different identifier.

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,4 +1,5 @@
 import { join, basename } from 'path';
+import { readFileSync } from 'fs';
 
 import Anthropic from '@anthropic-ai/sdk';
 
@@ -46,10 +47,18 @@ export function createDocCodeMapper(config: Config, codeSources: Record<string, 
 }
 
 export function createValidator(config: Config): Validator {
-  const { type, pass1Model, pass2Model } = config.validator;
+  const { type, pass1Model, pass2Model, systemPromptExtension } = config.validator;
   if (type === 'claude') {
     const anthropic = new Anthropic();
-    return new ClaudeValidator(pass1Model, pass2Model, anthropic);
+    let promptExtension: string | undefined;
+    if (systemPromptExtension) {
+      try {
+        promptExtension = readFileSync(systemPromptExtension, 'utf-8');
+      } catch (err) {
+        throw new Error(`Could not read systemPromptExtension "${systemPromptExtension}": ${(err as Error).message}`);
+      }
+    }
+    return new ClaudeValidator(pass1Model, pass2Model, anthropic, promptExtension);
   }
   throw new NotImplementedError(type);
 }

--- a/src/adapters/validator/claude.ts
+++ b/src/adapters/validator/claude.ts
@@ -240,13 +240,17 @@ export class ClaudeValidator implements Validator {
   private readonly pass1Model: string;
   private readonly pass2Model: string;
   private readonly anthropic: Anthropic;
+  private readonly systemPrompt: string;
   readonly costAccumulator: CostAccumulator = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
   droppedHallucinations = 0;
 
-  constructor(pass1Model: string, pass2Model: string, anthropic: Anthropic) {
+  constructor(pass1Model: string, pass2Model: string, anthropic: Anthropic, promptExtension?: string) {
     this.pass1Model = pass1Model;
     this.pass2Model = pass2Model;
     this.anthropic = anthropic;
+    this.systemPrompt = promptExtension
+      ? `${SYSTEM_PROMPT}\n\n## Site-specific rules\n\n${promptExtension}`
+      : SYSTEM_PROMPT;
   }
 
   async validateDoc(
@@ -378,7 +382,7 @@ ${codeContext || '(No source files were available for this document.)'}${missing
       system: [
         {
           type:          'text',
-          text:          SYSTEM_PROMPT,
+          text:          this.systemPrompt,
           cache_control: { type: 'ephemeral' },
         },
       ],
@@ -438,7 +442,7 @@ ${JSON.stringify(candidate, null, 2)}`,
         system: [
           {
             type:          'text',
-            text:          SYSTEM_PROMPT,
+            text:          this.systemPrompt,
             cache_control: { type: 'ephemeral' },
           },
         ],
@@ -553,7 +557,7 @@ ${JSON.stringify(candidate, null, 2)}`,
       system: [
         {
           type:          'text',
-          text:          SYSTEM_PROMPT,
+          text:          this.systemPrompt,
           cache_control: { type: 'ephemeral' },
         },
       ],

--- a/src/adapters/validator/claude.ts
+++ b/src/adapters/validator/claude.ts
@@ -248,7 +248,7 @@ export class ClaudeValidator implements Validator {
     this.pass1Model = pass1Model;
     this.pass2Model = pass2Model;
     this.anthropic = anthropic;
-    this.systemPrompt = promptExtension
+    this.systemPrompt = promptExtension?.trim()
       ? `${SYSTEM_PROMPT}\n\n## Site-specific rules\n\n${promptExtension}`
       : SYSTEM_PROMPT;
   }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -22,9 +22,10 @@ export const ConfigSchema = z.object({
   mappingPath: z.string(),
   outputDir:   z.string(),
   validator: z.object({
-    type:       z.literal('claude'),
-    pass1Model: z.string().default('claude-sonnet-4-6'),
-    pass2Model: z.string().default('claude-sonnet-4-6'),
+    type:                   z.literal('claude'),
+    pass1Model:             z.string().default('claude-sonnet-4-6'),
+    pass2Model:             z.string().default('claude-sonnet-4-6'),
+    systemPromptExtension:  z.string().optional(), // path to a .md file with site-specific prompt rules
   }),
   // Token pricing in USD per million tokens. Defaults match Sonnet 4.6 rates.
   // Check https://www.anthropic.com/pricing for current values and update as needed.


### PR DESCRIPTION
  Adds optional systemPromptExtension to validator config — a path to
  a Markdown file appended to the base system prompt as a "Site-specific
  rules" section. Keeps the tool generic while allowing per-project
  knowledge to be encoded and versioned alongside the config.

  Includes prompts/gutenberg-block-api.md with rules derived from Phase 0
  gate review: reusable category, short-circuit evaluation, PHP
  _doing_it_wrong(), JSON schema authority, deprecated function handling.

  Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>