### PR TITLE
fix(prompts): remove redundant heading from gutenberg-block-api.md

### DIFF
--- a/prompts/gutenberg-block-api.md
+++ b/prompts/gutenberg-block-api.md
@@ -1,5 +1,3 @@
-## WordPress Block Editor — site-specific rules
-
 These rules apply when validating the Gutenberg Block API Reference documentation. They encode learnings from the Phase 0 gate manual review.
 
 ### Known internal / reserved identifiers — do not flag as missing from docs


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The factory in `src/adapters/index.ts` prepends `## Site-specific rules` before injecting the prompt file content into the system prompt.
- `prompts/gutenberg-block-api.md` opened with its own `## WordPress Block Editor — site-specific rules` heading, producing a double `##`-level heading in the assembled prompt.
- Removed that first heading (and its trailing blank line) so the file's content flows cleanly under the factory-injected section header.

## Test plan

- [ ] Verify the assembled system prompt no longer contains two consecutive `##` headings at the site-specific rules boundary.
- [ ] Confirm `npm test` and `npm run typecheck` pass (no code changes, only prompt text).

https://claude.ai/code/session_015hw83Hqnde6TcbquXmGv5p
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015hw83Hqnde6TcbquXmGv5p)_