### PR TITLE
fix(validator): guard against all-whitespace promptExtension

### DIFF
--- a/src/adapters/validator/claude.ts
+++ b/src/adapters/validator/claude.ts
@@ -248,7 +248,7 @@ export class ClaudeValidator implements Validator {
     this.pass1Model = pass1Model;
     this.pass2Model = pass2Model;
     this.anthropic = anthropic;
-    this.systemPrompt = promptExtension
+    this.systemPrompt = promptExtension?.trim()
       ? `${SYSTEM_PROMPT}\n\n## Site-specific rules\n\n${promptExtension}`
       : SYSTEM_PROMPT;
   }


### PR DESCRIPTION
## Summary

- In `ClaudeValidator` constructor, change the ternary condition from `promptExtension` to `promptExtension?.trim()` so that an extension file containing only whitespace is treated as absent
- Prevents a dangling `## Site-specific rules` heading with no content from appearing in the assembled system prompt

## Test plan

- [ ] Pass a whitespace-only string as `promptExtension` — verify `systemPrompt` equals `SYSTEM_PROMPT` unchanged
- [ ] Pass `undefined` — verify same fallback to `SYSTEM_PROMPT`
- [ ] Pass a non-empty string — verify the heading and content are still appended correctly

https://claude.ai/code/session_01WFXqJNiKA9ViWCixU6v4vt

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFXqJNiKA9ViWCixU6v4vt)_