### PR TITLE
feat(extractors): add TypeScript AST symbol extractor

### DIFF
--- a/examples/results.schema.json
+++ b/examples/results.schema.json
@@ -61,7 +61,8 @@
               "type": "integer"
             },
             "notMapped": {
-              "type": "integer"
+              "type": "integer",
+              "default": 0
             },
             "issues": {
               "type": "object",
@@ -93,7 +94,6 @@
             "healthy",
             "needsAttention",
             "critical",
-            "notMapped",
             "issues"
           ],
           "additionalProperties": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "remark": "^15.0.1",
         "remark-parse": "^11.0.0",
         "simple-git": "^3.36.0",
+        "typescript": "^5.4.0",
         "unist-util-visit": "^5.1.0",
         "zod": "^3.23.0",
         "zod-to-json-schema": "^3.23.0"
@@ -26,7 +27,6 @@
         "eslint": "^8.57.0",
         "prettier": "^3.3.0",
         "tsx": "^4.0.0",
-        "typescript": "^5.4.0",
         "vitest": "^1.6.0"
       },
       "engines": {
@@ -4235,7 +4235,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "remark": "^15.0.1",
     "remark-parse": "^11.0.0",
     "simple-git": "^3.36.0",
+    "typescript": "^5.4.0",
     "unist-util-visit": "^5.1.0",
     "zod": "^3.23.0",
     "zod-to-json-schema": "^3.23.0"
@@ -31,7 +32,6 @@
     "eslint": "^8.57.0",
     "prettier": "^3.3.0",
     "tsx": "^4.0.0",
-    "typescript": "^5.4.0",
     "vitest": "^1.6.0"
   }
 }

--- a/scripts/test-extractor.ts
+++ b/scripts/test-extractor.ts
@@ -1,0 +1,11 @@
+import { extractSymbolsFromSource, formatSymbolsAsText } from '../src/extractors/typescript.js';
+import { readFileSync } from 'fs';
+
+const filePath = process.argv[2] ?? './tmp/gutenberg-trunk/packages/blocks/src/api/registration.ts';
+const repoRelPath = filePath.replace('./tmp/gutenberg-trunk/', '');
+
+const content = readFileSync(filePath, 'utf-8');
+const symbols = extractSymbolsFromSource(content, repoRelPath);
+
+console.log(formatSymbolsAsText([{ repo: 'gutenberg', path: repoRelPath, symbols }]));
+console.log(`\n→ ${symbols.length} symbols extracted`);

--- a/src/extractors/__tests__/typescript.test.ts
+++ b/src/extractors/__tests__/typescript.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { extractSymbolsFromSource, formatSymbolsAsText } from '../typescript.js';
+import type { ExtractedFile } from '../types.js';
+
+describe('extractSymbolsFromSource', () => {
+  it('extracts exported function with typed params and return type', () => {
+    const src = `
+export function registerBlockType(
+  blockNameOrMetadata: string | BlockConfiguration,
+  settings?: Partial<BlockConfiguration>
+): BlockType | undefined {
+  return undefined;
+}
+`;
+    const symbols = extractSymbolsFromSource(src, 'registration.ts');
+    expect(symbols).toHaveLength(1);
+    expect(symbols[0].kind).toBe('function');
+    expect(symbols[0].name).toBe('registerBlockType');
+    expect(symbols[0].signature).toContain('blockNameOrMetadata: string | BlockConfiguration');
+    expect(symbols[0].signature).toContain('settings?: Partial<BlockConfiguration>');
+    expect(symbols[0].signature).toContain(': BlockType | undefined');
+  });
+
+  it('ignores non-exported functions', () => {
+    const src = `
+function internal(): void {}
+export function external(): void {}
+`;
+    const symbols = extractSymbolsFromSource(src, 'foo.ts');
+    expect(symbols).toHaveLength(1);
+    expect(symbols[0].name).toBe('external');
+  });
+
+  it('extracts exported interface with properties and methods', () => {
+    const src = `
+export interface BlockVariation {
+  title: string;
+  scope?: BlockVariationScope[];
+  isActive?(blockAttributes: Record<string, unknown>): boolean;
+}
+`;
+    const symbols = extractSymbolsFromSource(src, 'types.ts');
+    expect(symbols).toHaveLength(1);
+    expect(symbols[0].kind).toBe('interface');
+    expect(symbols[0].name).toBe('BlockVariation');
+    expect(symbols[0].signature).toContain('title: string');
+    expect(symbols[0].signature).toContain('scope?: BlockVariationScope[]');
+  });
+
+  it('extracts exported type alias', () => {
+    const src = `export type Icon = string | ReactElement | ComponentType;`;
+    const symbols = extractSymbolsFromSource(src, 'types.ts');
+    expect(symbols).toHaveLength(1);
+    expect(symbols[0].kind).toBe('type');
+    expect(symbols[0].name).toBe('Icon');
+    expect(symbols[0].signature).toBe('Icon = string | ReactElement | ComponentType');
+  });
+
+  it('extracts exported const with explicit type', () => {
+    const src = `export const DEFAULT_BLOCK_NAME: string = 'core/paragraph';`;
+    const symbols = extractSymbolsFromSource(src, 'constants.ts');
+    expect(symbols).toHaveLength(1);
+    expect(symbols[0].kind).toBe('const');
+    expect(symbols[0].name).toBe('DEFAULT_BLOCK_NAME');
+    expect(symbols[0].signature).toContain('DEFAULT_BLOCK_NAME: string');
+  });
+
+  it('extracts arrow function const and infers signature', () => {
+    const src = `export const getBlockType = (name: string): BlockType | undefined => undefined;`;
+    const symbols = extractSymbolsFromSource(src, 'store.ts');
+    expect(symbols).toHaveLength(1);
+    expect(symbols[0].name).toBe('getBlockType');
+    expect(symbols[0].signature).toContain('(name: string) => BlockType | undefined');
+  });
+
+  it('extracts exported enum', () => {
+    const src = `export enum BlockVariationScope { Block = 'block', Inserter = 'inserter' }`;
+    const symbols = extractSymbolsFromSource(src, 'types.ts');
+    expect(symbols).toHaveLength(1);
+    expect(symbols[0].kind).toBe('enum');
+    expect(symbols[0].name).toBe('BlockVariationScope');
+  });
+
+  it('returns empty array for file with no exports', () => {
+    const src = `const x = 1; function foo() {}`;
+    expect(extractSymbolsFromSource(src, 'internal.ts')).toHaveLength(0);
+  });
+
+  it('handles rest parameters', () => {
+    const src = `export function log(...args: unknown[]): void {}`;
+    const symbols = extractSymbolsFromSource(src, 'utils.ts');
+    expect(symbols[0].signature).toContain('...args: unknown[]');
+  });
+});
+
+describe('formatSymbolsAsText', () => {
+  it('formats extracted files as structured text block', () => {
+    const files: ExtractedFile[] = [
+      {
+        repo: 'gutenberg',
+        path: 'packages/blocks/src/api/registration.ts',
+        symbols: [
+          { kind: 'function', name: 'registerBlockType', signature: 'registerBlockType(name: string): void' },
+          { kind: 'function', name: 'getBlockType', signature: 'getBlockType(name: string): BlockType | undefined' },
+        ],
+      },
+    ];
+
+    const text = formatSymbolsAsText(files);
+    expect(text).toContain('[gutenberg] packages/blocks/src/api/registration.ts');
+    expect(text).toContain('  registerBlockType(name: string): void');
+    expect(text).toContain('  getBlockType(name: string): BlockType | undefined');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(formatSymbolsAsText([])).toBe('');
+  });
+
+  it('separates multiple files with a blank line', () => {
+    const files: ExtractedFile[] = [
+      { repo: 'r', path: 'a.ts', symbols: [{ kind: 'const', name: 'A', signature: 'A: string' }] },
+      { repo: 'r', path: 'b.ts', symbols: [{ kind: 'const', name: 'B', signature: 'B: number' }] },
+    ];
+    const text = formatSymbolsAsText(files);
+    expect(text).toContain('\n\n');
+  });
+});

--- a/src/extractors/types.ts
+++ b/src/extractors/types.ts
@@ -1,0 +1,13 @@
+export type SymbolKind = 'function' | 'type' | 'interface' | 'const' | 'class' | 'enum';
+
+export type ExtractedSymbol = {
+  kind: SymbolKind;
+  name: string;
+  signature: string;
+};
+
+export type ExtractedFile = {
+  repo: string;
+  path: string;
+  symbols: ExtractedSymbol[];
+};

--- a/src/extractors/typescript.ts
+++ b/src/extractors/typescript.ts
@@ -1,0 +1,182 @@
+import ts from 'typescript';
+import type { CodeFile } from '../types/mapping.js';
+import type { CodeSource } from '../adapters/code-source/types.js';
+import type { ExtractedFile, ExtractedSymbol, SymbolKind } from './types.js';
+
+export type { ExtractedFile, ExtractedSymbol, SymbolKind } from './types.js';
+
+function nodeText(node: ts.Node, source: ts.SourceFile): string {
+  return node.getText(source);
+}
+
+function printType(node: ts.TypeNode | undefined, source: ts.SourceFile): string {
+  return node ? nodeText(node, source) : 'unknown';
+}
+
+function printParams(params: ts.NodeArray<ts.ParameterDeclaration>, source: ts.SourceFile): string {
+  return params
+    .map(p => {
+      const name = nodeText(p.name, source);
+      const optional = p.questionToken ? '?' : '';
+      const type = p.type ? `: ${nodeText(p.type, source)}` : '';
+      const rest = p.dotDotDotToken ? '...' : '';
+      return `${rest}${name}${optional}${type}`;
+    })
+    .join(', ');
+}
+
+function extractFromStatement(
+  stmt: ts.Statement,
+  source: ts.SourceFile,
+): ExtractedSymbol[] {
+  const symbols: ExtractedSymbol[] = [];
+
+  // export function foo(...) { }
+  // export async function foo(...) { }
+  if (ts.isFunctionDeclaration(stmt) && stmt.name) {
+    const name = stmt.name.text;
+    const params = printParams(stmt.parameters, source);
+    const ret = printType(stmt.type, source);
+    symbols.push({ kind: 'function', name, signature: `${name}(${params}): ${ret}` });
+    return symbols;
+  }
+
+  // export class Foo { }
+  if (ts.isClassDeclaration(stmt) && stmt.name) {
+    symbols.push({ kind: 'class', name: stmt.name.text, signature: stmt.name.text });
+    return symbols;
+  }
+
+  // export type Foo = ...
+  // export interface Foo { }
+  if (ts.isTypeAliasDeclaration(stmt)) {
+    const name = stmt.name.text;
+    const body = nodeText(stmt.type, source);
+    symbols.push({ kind: 'type', name, signature: `${name} = ${body}` });
+    return symbols;
+  }
+
+  if (ts.isInterfaceDeclaration(stmt)) {
+    const name = stmt.name.text;
+    const members = stmt.members.map(m => {
+      if (ts.isPropertySignature(m) && m.name) {
+        const propName = nodeText(m.name, source);
+        const optional = m.questionToken ? '?' : '';
+        const type = printType(m.type, source);
+        return `  ${propName}${optional}: ${type}`;
+      }
+      if (ts.isMethodSignature(m) && m.name) {
+        const methodName = nodeText(m.name, source);
+        const params = printParams(m.parameters, source);
+        const ret = printType(m.type, source);
+        return `  ${methodName}(${params}): ${ret}`;
+      }
+      return null;
+    }).filter(Boolean);
+    symbols.push({ kind: 'interface', name, signature: `${name} {\n${members.join('\n')}\n}` });
+    return symbols;
+  }
+
+  // export enum Foo { }
+  if (ts.isEnumDeclaration(stmt)) {
+    symbols.push({ kind: 'enum', name: stmt.name.text, signature: stmt.name.text });
+    return symbols;
+  }
+
+  // export const foo = ...
+  // export const foo: Type = ...
+  if (ts.isVariableStatement(stmt)) {
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name)) continue;
+      const name = decl.name.text;
+      const type = decl.type
+        ? nodeText(decl.type, source)
+        : decl.initializer
+          ? inferLiteralType(decl.initializer, source)
+          : 'unknown';
+      symbols.push({ kind: 'const', name, signature: `${name}: ${type}` });
+    }
+    return symbols;
+  }
+
+  // export { foo, bar } or export { foo as bar } from '...'
+  // These are re-exports — we note the name but can't resolve the signature here.
+  if (ts.isExportDeclaration(stmt) && stmt.exportClause && ts.isNamedExports(stmt.exportClause)) {
+    for (const el of stmt.exportClause.elements) {
+      const name = el.name.text;
+      symbols.push({ kind: 'const', name, signature: name });
+    }
+    return symbols;
+  }
+
+  return symbols;
+}
+
+function inferLiteralType(node: ts.Expression, source: ts.SourceFile): string {
+  if (ts.isStringLiteral(node)) return 'string';
+  if (ts.isNumericLiteral(node)) return 'number';
+  if (node.kind === ts.SyntaxKind.TrueKeyword || node.kind === ts.SyntaxKind.FalseKeyword) return 'boolean';
+  if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
+    const fn = node as ts.ArrowFunction | ts.FunctionExpression;
+    const params = printParams(fn.parameters, source);
+    const ret = fn.type ? nodeText(fn.type, source) : 'unknown';
+    return `(${params}) => ${ret}`;
+  }
+  return 'unknown';
+}
+
+function isExported(stmt: ts.Statement): boolean {
+  const mods = ts.canHaveModifiers(stmt) ? ts.getModifiers(stmt) : undefined;
+  return mods?.some(m => m.kind === ts.SyntaxKind.ExportKeyword) ?? false;
+}
+
+export function extractSymbolsFromSource(content: string, filePath: string): ExtractedSymbol[] {
+  const source = ts.createSourceFile(filePath, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const symbols: ExtractedSymbol[] = [];
+
+  for (const stmt of source.statements) {
+    if (!isExported(stmt)) continue;
+    symbols.push(...extractFromStatement(stmt, source));
+  }
+
+  return symbols;
+}
+
+export async function extractSymbolsFromFiles(
+  files: CodeFile[],
+  codeSources: Record<string, CodeSource>,
+): Promise<ExtractedFile[]> {
+  const results: ExtractedFile[] = [];
+
+  for (const file of files) {
+    const source = codeSources[file.repo];
+    if (!source) continue;
+
+    const ext = file.path.split('.').pop()?.toLowerCase() ?? '';
+    if (!['ts', 'tsx', 'js', 'jsx'].includes(ext)) continue;
+
+    try {
+      const content = await source.readFile(file.path);
+      const symbols = extractSymbolsFromSource(content, file.path);
+      if (symbols.length > 0) {
+        results.push({ repo: file.repo, path: file.path, symbols });
+      }
+    } catch {
+      // Skip unreadable files — callers handle missing results
+    }
+  }
+
+  return results;
+}
+
+export function formatSymbolsAsText(files: ExtractedFile[]): string {
+  if (files.length === 0) return '';
+
+  return files
+    .map(f => {
+      const header = `[${f.repo}] ${f.path}`;
+      const lines = f.symbols.map(s => `  ${s.signature}`);
+      return [header, ...lines].join('\n');
+    })
+    .join('\n\n');
+}

--- a/src/types/results.ts
+++ b/src/types/results.ts
@@ -70,7 +70,7 @@ export const RunResultsSchema = z.object({
     healthy:        z.number().int(),
     needsAttention: z.number().int(),
     critical:       z.number().int(),
-    notMapped:      z.number().int(),
+    notMapped:      z.number().int().default(0),
     issues: z.object({
       total:    z.number().int(),
       critical: z.number().int(),


### PR DESCRIPTION
  Implements extractSymbolsFromSource, extractSymbolsFromFiles, and
  formatSymbolsAsText as a standalone utility consumable by both the
  validator context assembler (slot 2 source) and the mapping generator.
  Moves typescript to runtime dependencies.