### PR TITLE
feat(validator): wire AST symbol extractor into context assembler

### DIFF
--- a/.github/workflows/claude-opus.yml
+++ b/.github/workflows/claude-opus.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run Claude Code (Opus)
         id: claude-opus
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.111
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: '@claude-opus'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.111
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           base_branch: ${{ steps.pr-branch.outputs.branch }}

--- a/scripts/test-context-assembly.ts
+++ b/scripts/test-context-assembly.ts
@@ -1,0 +1,69 @@
+/**
+ * test-context-assembly.ts — prints the assembled Claude prompt for one doc.
+ *
+ * Usage:
+ *   npx tsx scripts/test-context-assembly.ts [slug]
+ *
+ * Defaults to the first doc in the manifest if no slug is provided.
+ * No API calls to Claude — zero cost.
+ */
+
+import { readFileSync } from 'fs';
+import { loadConfig } from '../src/config/loader.js';
+import { createDocSource, createCodeSources } from '../src/adapters/index.js';
+import { MappingSchema } from '../src/types/mapping.js';
+import { assembleContext, formatContextForClaude } from '../src/adapters/validator/context-assembler.js';
+import { formatSymbolsAsText } from '../src/extractors/typescript.js';
+
+const targetSlug = process.argv[2];
+const config = await loadConfig('config/gutenberg-block-api.json');
+
+const docSource = createDocSource(config);
+const codeSources = createCodeSources(config);
+const mapping = MappingSchema.parse(JSON.parse(readFileSync(config.mappingPath, 'utf-8')));
+
+console.error('Fetching docs...');
+const results = await docSource.fetchDocs();
+const docs = results.flatMap(r => r.ok ? [r.doc] : []);
+
+const doc = targetSlug
+  ? docs.find(d => d.slug === targetSlug)
+  : docs.find(d => mapping[d.slug] !== undefined);
+
+if (!doc) {
+  console.error(`Slug "${targetSlug}" not found. Available: ${docs.map(d => d.slug).join(', ')}`);
+  process.exit(1);
+}
+
+const codeTiers = mapping[doc.slug];
+if (!codeTiers) {
+  console.error(`No mapping for slug "${doc.slug}"`);
+  process.exit(1);
+}
+
+console.error(`Assembling context for: ${doc.slug}`);
+const assembled = await assembleContext(doc, codeTiers, codeSources);
+
+const symbolsText = formatSymbolsAsText(assembled.extractedSymbols);
+const symbolsSection = symbolsText
+  ? `\n\n---\n\n## Exported API symbols\n\n${symbolsText}`
+  : '';
+
+const userMessage = `## Documentation: ${doc.title}
+
+URL: ${doc.sourceUrl}
+
+${doc.content}${symbolsSection}
+
+---
+
+## Source Code
+
+${formatContextForClaude(assembled.fileBlocks) || '(No source files were available for this document.)'}`;
+
+console.log(userMessage);
+console.error(`\n--- Stats ---`);
+console.error(`Symbols extracted: ${assembled.extractedSymbols.reduce((n, f) => n + f.symbols.length, 0)} from ${assembled.extractedSymbols.length} file(s)`);
+console.error(`File blocks: ${assembled.fileBlocks.length}`);
+console.error(`Estimated tokens: ${assembled.estimatedTokens}`);
+console.error(`Missing symbols: ${assembled.missingSymbols.length}`);

--- a/src/adapters/validator/claude.ts
+++ b/src/adapters/validator/claude.ts
@@ -6,6 +6,7 @@ import type { DocResult, Issue } from '../../types/results.js';
 import type { CodeSource } from '../code-source/types.js';
 import type { Validator } from './types.js';
 import { assembleContext, formatContextForClaude } from './context-assembler.js';
+import { formatSymbolsAsText } from '../../extractors/typescript.js';
 import { scoreDoc } from '../../health-scorer.js';
 import { fingerprintIssue } from '../../history.js';
 
@@ -280,6 +281,10 @@ export class ClaudeValidator implements Validator {
 
     // Build user message content
     const codeContext = formatContextForClaude(assembled.fileBlocks);
+    const symbolsText = formatSymbolsAsText(assembled.extractedSymbols);
+    const symbolsSection = symbolsText
+      ? `\n\n---\n\n## Exported API symbols\n\n${symbolsText}`
+      : '';
     const missingSymbolsHint = assembled.missingSymbols.length > 0
       ? `\n\n## Potentially removed APIs\n\nThe following identifiers appear in the doc but were not found in any source file. Investigate each as a possible \`nonexistent-name\` issue:\n\n${assembled.missingSymbols.map(s => `- \`${s}\``).join('\n')}`
       : '';
@@ -287,7 +292,7 @@ export class ClaudeValidator implements Validator {
 
 URL: ${doc.sourceUrl}
 
-${doc.content}
+${doc.content}${symbolsSection}
 
 ---
 

--- a/src/adapters/validator/context-assembler.ts
+++ b/src/adapters/validator/context-assembler.ts
@@ -2,6 +2,10 @@ import type { Doc } from '../doc-source/types.js';
 import type { CodeTiers, CodeFile } from '../../types/mapping.js';
 import type { DocResult } from '../../types/results.js';
 import type { CodeSource } from '../code-source/types.js';
+import { extractSymbolsFromFiles } from '../../extractors/typescript.js';
+import type { ExtractedFile } from '../../extractors/types.js';
+
+export type { ExtractedFile };
 
 const TOKEN_BUDGET = 50_000;
 
@@ -18,6 +22,7 @@ export type AssembledContext = {
   estimatedTokens: number;
   diagnostics: string[];
   missingSymbols: string[];
+  extractedSymbols: ExtractedFile[];
 };
 
 function inferLanguage(filePath: string): string {
@@ -125,6 +130,13 @@ export async function assembleContext(
     }
   }
 
+  const allMappedFiles = [
+    ...codeTiers.primary,
+    ...codeTiers.secondary,
+    ...codeTiers.context,
+  ];
+  const extractedSymbols = await extractSymbolsFromFiles(allMappedFiles, codeSources);
+
   const symbols = extractDocSymbols(doc.content);
   const missingSymbols = findMissingSymbols(symbols, fileBlocks);
 
@@ -134,5 +146,6 @@ export async function assembleContext(
     estimatedTokens: cumulativeTokens,
     diagnostics,
     missingSymbols,
+    extractedSymbols,
   };
 }


### PR DESCRIPTION
  Injects extracted API symbols as a dedicated ## Exported API symbols
  section in the Claude prompt (slot 2), between doc content and source
  code. Covers all mapped tiers. Section is omitted when no symbols
  are found.