### PR TITLE
feat(validator): filter Source Code section to tests, schemas, and PHP

### DIFF
--- a/scripts/test-context-assembly.ts
+++ b/scripts/test-context-assembly.ts
@@ -59,11 +59,11 @@ ${doc.content}${symbolsSection}
 
 ## Source Code
 
-${formatContextForClaude(assembled.fileBlocks) || '(No source files were available for this document.)'}`;
+${formatContextForClaude(assembled.sourceCodeBlocks) || '(No source files were available for this document.)'}`;
 
 console.log(userMessage);
 console.error(`\n--- Stats ---`);
 console.error(`Symbols extracted: ${assembled.extractedSymbols.reduce((n, f) => n + f.symbols.length, 0)} from ${assembled.extractedSymbols.length} file(s)`);
-console.error(`File blocks: ${assembled.fileBlocks.length}`);
+console.error(`Source code files: ${assembled.sourceCodeBlocks.length} of ${assembled.fileBlocks.length} total mapped`);
 console.error(`Estimated tokens: ${assembled.estimatedTokens}`);
 console.error(`Missing symbols: ${assembled.missingSymbols.length}`);

--- a/src/adapters/validator/claude.ts
+++ b/src/adapters/validator/claude.ts
@@ -280,7 +280,7 @@ export class ClaudeValidator implements Validator {
     }
 
     // Build user message content
-    const codeContext = formatContextForClaude(assembled.fileBlocks);
+    const codeContext = formatContextForClaude(assembled.sourceCodeBlocks);
     const symbolsText = formatSymbolsAsText(assembled.extractedSymbols);
     const symbolsSection = symbolsText
       ? `\n\n---\n\n## Exported API symbols\n\n${symbolsText}`

--- a/src/adapters/validator/context-assembler.ts
+++ b/src/adapters/validator/context-assembler.ts
@@ -18,6 +18,7 @@ type FileBlock = {
 
 export type AssembledContext = {
   fileBlocks: FileBlock[];
+  sourceCodeBlocks: FileBlock[];
   relatedCode: DocResult['relatedCode'];
   estimatedTokens: number;
   diagnostics: string[];
@@ -50,6 +51,16 @@ function inferLanguage(filePath: string): string {
 
 function estimateTokens(content: string): number {
   return Math.ceil(content.length / 4);
+}
+
+// Tests, schemas, and PHP files go into ## Source Code.
+// TS/JS/TSX/JSX implementation files are covered by the symbols section.
+export function isSourceCodeFile(filePath: string): boolean {
+  const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
+  if (ext === 'php') return true;
+  if (ext === 'json') return true;
+  if (/\/tests?\/|\.test\.|\.spec\./.test(filePath)) return true;
+  return false;
 }
 
 // Extract backtick-wrapped identifiers from doc markdown (e.g. `registerBlockType`)
@@ -137,11 +148,14 @@ export async function assembleContext(
   ];
   const extractedSymbols = await extractSymbolsFromFiles(allMappedFiles, codeSources);
 
+  const sourceCodeBlocks = fileBlocks.filter(fb => isSourceCodeFile(fb.path));
+
   const symbols = extractDocSymbols(doc.content);
   const missingSymbols = findMissingSymbols(symbols, fileBlocks);
 
   return {
     fileBlocks,
+    sourceCodeBlocks,
     relatedCode,
     estimatedTokens: cumulativeTokens,
     diagnostics,


### PR DESCRIPTION
  TS/JS implementation files are now covered by the Exported API symbols
  section. Source Code is restricted to test files, JSON schemas, and PHP
  files, which provide behavioral contracts and value constraints that
  symbols cannot capture. Implementation files remain in the mapping for
  symbol extraction.