### PR TITLE
fix(ci): remove custom prompt from Claude Code action so default review path runs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,8 +54,11 @@ jobs:
           additional_permissions: |
             actions: read
 
-          prompt: |
-            ${{ steps.pr-branch.outputs.branch != '' && format('IMPORTANT: This review is for PR branch `{0}`. When generating any "Fix this" links, always append `&branch={0}` to the claude.ai/code URL so the fix targets the correct branch instead of main. Example format: https://claude.ai/code?q=<task>&repo=<owner/repo>&branch={0}', steps.pr-branch.outputs.branch) || '' }}
-
-            Perform the task described in the triggering comment.
+          # No `prompt:` set on purpose — the action's default mode reads the
+          # triggering comment, drives the review, and posts the result via
+          # its built-in `mcp__github__update_claude_comment` tool. Setting
+          # a custom `prompt:` was previously suppressing that auto-post path
+          # (Claude tried alternatives that the sandbox denied — observed as
+          # `permission_denials_count: 12` and "No buffered inline comments"
+          # in past runs of PR #51, #52, #53, #54, #55, #58).
 


### PR DESCRIPTION


  The Claude Code workflow was wrapping anthropics/claude-code-action@v1.0.111
  with a custom `prompt:` block. In v1 of the action, providing a custom
  `prompt:` overrides the default review-and-post flow — Claude becomes
  responsible for posting comments itself, but the sandbox does not expose
  the `gh` / `curl` paths Claude tries by default.

  Effect, observed across PR #51, #52, #53, #54, #55, #58: the trigger
  comment was posted by `Agent Review Trigger`, the Claude Code job ran
  to completion (success, ~3 minutes, ~$0.50/run), but every run logged
  `permission_denials_count: 12` and `No buffered inline comments`, so the
  review never appeared on the PR.

  Removing the `prompt:` parameter restores the action's default mode,
  which uses the built-in `mcp__github__update_claude_comment` tool to
  post the review buffered inline. The branch resolver step is kept
  because `base_branch` still needs the PR head ref.

  Tradeoff acknowledged: we lose the custom hint about appending
  `&branch=…` to claude.ai/code "Fix this" links so they target the PR
  branch instead of main. If that hint is worth preserving, the follow-up
  is to re-introduce `prompt:` together with an explicit instruction to
  use `mcp__github__update_claude_comment` (and matching `--allowed-tools`
  in `claude_args`).

  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>