### PR TITLE
Add symbol-index-based auto-mapping (AI-free bootstrap)

### DIFF
--- a/scripts/auto-map.ts
+++ b/scripts/auto-map.ts
@@ -1,0 +1,188 @@
+/**
+ * auto-map.ts — AI-free mapping bootstrap using symbol index + tree heuristics
+ *
+ * Usage:
+ *   npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write]
+ *
+ * Builds a symbol index of all configured repos (cached by commit SHA),
+ * cross-references the symbols named in the doc, and proposes a CodeTiers
+ * mapping ranked by symbol coverage.
+ *
+ * Unlike bootstrap-mapping.ts, requires no ANTHROPIC_API_KEY.
+ *
+ * Flags:
+ *   --config <path>   Config file (default: config/gutenberg-block-api.json)
+ *   --write           Write result directly into the project mapping file
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+import { loadConfig } from '../src/config/loader.js';
+import { createCodeSources } from '../src/adapters/index.js';
+import { ManifestEntrySchema, CodeTiersSchema, MappingSchema } from '../src/types/mapping.js';
+import { extractDocSymbols } from '../src/adapters/validator/context-assembler.js';
+import {
+  buildSymbolIndex,
+  scoreFilesAcrossRepos,
+  findFilesByTreeHeuristic,
+  type SymbolIndex,
+} from '../src/indexer/symbol-index.js';
+
+function parseArgs(argv: string[]): { slug: string; configPath: string; write: boolean } {
+  const args = argv.slice(2);
+  let slug = '';
+  let configPath = resolve('config/gutenberg-block-api.json');
+  let write = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--config' && args[i + 1]) {
+      configPath = resolve(args[i + 1]);
+      i++;
+    } else if (args[i] === '--write') {
+      write = true;
+    } else if (!slug && !args[i].startsWith('--')) {
+      slug = args[i];
+    }
+  }
+
+  if (!slug) {
+    console.error('Usage: npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write]');
+    process.exit(1);
+  }
+
+  return { slug, configPath, write };
+}
+
+async function main() {
+  const { slug, configPath, write } = parseArgs(process.argv);
+  const config = await loadConfig(configPath);
+
+  // 1. Fetch manifest and locate the entry for this slug
+  const manifestRes = await fetch(config.docSource.manifestUrl);
+  if (!manifestRes.ok) {
+    console.error(`Failed to fetch manifest: HTTP ${manifestRes.status}`);
+    process.exit(1);
+  }
+
+  const rawEntries = (await manifestRes.json()) as unknown[];
+  const resolvedEntries = rawEntries.flatMap((raw: unknown) => {
+    if (typeof raw !== 'object' || raw === null) return [];
+    const entry = raw as Record<string, unknown>;
+    if (typeof entry.markdown_source === 'string') {
+      entry.markdown_source = new URL(
+        entry.markdown_source,
+        config.docSource.manifestUrl,
+      ).href;
+    }
+    const parsed = ManifestEntrySchema.safeParse(entry);
+    return parsed.success ? [parsed.data] : [];
+  });
+
+  const entry = resolvedEntries.find(e => e.slug === slug);
+  if (!entry) {
+    console.error(
+      `Slug "${slug}" not found. Available: ${resolvedEntries.map(e => e.slug).join(', ')}`,
+    );
+    process.exit(1);
+  }
+
+  // 2. Fetch doc content and extract referenced symbols
+  const docRes = await fetch(entry.markdown_source);
+  if (!docRes.ok) {
+    console.error(`Failed to fetch doc: HTTP ${docRes.status}`);
+    process.exit(1);
+  }
+  const docContent = await docRes.text();
+  const docSymbols = extractDocSymbols(docContent);
+
+  console.error(
+    `Found ${docSymbols.length} symbols in doc: ${docSymbols.slice(0, 10).join(', ')}${docSymbols.length > 10 ? '...' : ''}`,
+  );
+
+  // 3. Build symbol indexes for all configured repos (cached by commit SHA)
+  const codeSources = createCodeSources(config);
+  const indexes: Record<string, SymbolIndex> = {};
+  const allFilesByRepo: Record<string, string[]> = {};
+
+  for (const [repoId, cs] of Object.entries(codeSources)) {
+    process.stderr.write(`Building symbol index for "${repoId}"... `);
+    let lastPct = -1;
+
+    indexes[repoId] = await buildSymbolIndex(repoId, cs, {
+      onProgress(done, total) {
+        const pct = Math.floor((done / total) * 100);
+        if (pct >= lastPct + 10) {
+          process.stderr.write(`${pct}%... `);
+          lastPct = pct;
+        }
+      },
+    });
+
+    process.stderr.write('done\n');
+    allFilesByRepo[repoId] = await cs.listDir('.');
+  }
+
+  // 4. Score all files by how many doc symbols they define or fire
+  const scored = scoreFilesAcrossRepos(docSymbols, indexes);
+
+  console.error('\nTop matches by symbol coverage:');
+  scored.slice(0, 10).forEach(f =>
+    console.error(
+      `  [${f.repo}] ${f.path}  score=${f.score}  (${f.matchedSymbols.slice(0, 5).join(', ')})`,
+    ),
+  );
+
+  // 5. Assemble tiers
+  //    primary   — top symbol-matched files (max 3)
+  //    secondary — next best symbol-matched files (max 5)
+  //    context   — structurally related files via slug keyword matching (max 8)
+  const selected = new Set<string>();
+
+  function pickNext(n: number) {
+    return scored
+      .filter(f => !selected.has(`${f.repo}:${f.path}`))
+      .slice(0, n)
+      .map(f => {
+        selected.add(`${f.repo}:${f.path}`);
+        return { repo: f.repo, path: f.path };
+      });
+  }
+
+  const primary = pickNext(3);
+  const secondary = pickNext(5);
+
+  const contextCandidates = findFilesByTreeHeuristic(slug, allFilesByRepo, selected);
+  const context = contextCandidates.slice(0, 8).map(f => {
+    selected.add(`${f.repo}:${f.path}`);
+    return { repo: f.repo, path: f.path };
+  });
+
+  const tiers = CodeTiersSchema.parse({ primary, secondary, context });
+
+  // 6. Output as JSON
+  const output = { [slug]: tiers };
+  console.log(JSON.stringify(output, null, 2));
+
+  if (write) {
+    let existing: Record<string, unknown> = {};
+    try {
+      existing = MappingSchema.parse(
+        JSON.parse(readFileSync(config.mappingPath, 'utf-8')),
+      );
+    } catch {
+      // mapping file may not exist yet; start fresh
+    }
+    const merged = { ...existing, ...output };
+    writeFileSync(config.mappingPath, JSON.stringify(merged, null, 2) + '\n');
+    console.error(`\nWrote mapping for "${slug}" to ${config.mappingPath}`);
+  } else {
+    console.error(
+      `\nReview the above and merge into ${config.mappingPath}, or re-run with --write`,
+    );
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/auto-map.ts
+++ b/scripts/auto-map.ts
@@ -15,7 +15,7 @@
  *   --write           Write result directly into the project mapping file
  */
 
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
 import { loadConfig } from '../src/config/loader.js';
 import { createCodeSources } from '../src/adapters/index.js';
@@ -119,7 +119,7 @@ async function main() {
     });
 
     process.stderr.write('done\n');
-    allFilesByRepo[repoId] = await cs.listDir('.');
+    allFilesByRepo[repoId] = indexes[repoId].files;
   }
 
   // 4. Score all files by how many doc symbols they define or fire
@@ -165,12 +165,15 @@ async function main() {
 
   if (write) {
     let existing: Record<string, unknown> = {};
-    try {
+    if (existsSync(config.mappingPath)) {
       existing = MappingSchema.parse(
         JSON.parse(readFileSync(config.mappingPath, 'utf-8')),
       );
-    } catch {
-      // mapping file may not exist yet; start fresh
+    }
+    if (slug in existing) {
+      process.stderr.write(
+        `\nWarning: mapping for "${slug}" already exists and will be overwritten.\n`,
+      );
     }
     const merged = { ...existing, ...output };
     writeFileSync(config.mappingPath, JSON.stringify(merged, null, 2) + '\n');

--- a/src/indexer/__tests__/symbol-index.test.ts
+++ b/src/indexer/__tests__/symbol-index.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildSymbolIndex,
+  scoreFilesAcrossRepos,
+  findFilesByTreeHeuristic,
+  type SymbolIndex,
+} from '../symbol-index.js';
+import type { CodeSource } from '../../adapters/code-source/types.js';
+
+// --- helpers ---
+
+function makeSource(files: Record<string, string>): CodeSource {
+  return {
+    readFile: async (path: string) => {
+      const content = files[path];
+      if (content === undefined) throw new Error(`mock: file not found: ${path}`);
+      return content;
+    },
+    listDir: async () => Object.keys(files),
+    getCommitSha: async () => 'test-sha-001',
+  };
+}
+
+function makeIndex(
+  repoId: string,
+  symbols: Record<string, string[]>,
+  hooks: Record<string, string[]> = {},
+): SymbolIndex {
+  return { repoId, commitSha: 'sha', builtAt: '2025-01-01T00:00:00Z', symbols, hooks };
+}
+
+// --- buildSymbolIndex ---
+
+describe('buildSymbolIndex', () => {
+  it('extracts exported TypeScript symbols', async () => {
+    const source = makeSource({
+      'src/registration.ts': 'export function registerBlockType(name: string) {}',
+      'src/utils.ts': 'function internalHelper() {}',  // not exported
+    });
+
+    const index = await buildSymbolIndex('test-repo', source, { cacheDir: null });
+
+    expect(index.symbols['registerBlockType']).toEqual(['src/registration.ts']);
+    expect(index.symbols['internalHelper']).toBeUndefined();
+  });
+
+  it('extracts WordPress hooks', async () => {
+    const source = makeSource({
+      'src/hooks.ts': "applyFilters('blocks.registerBlockType', settings, name);",
+    });
+
+    const index = await buildSymbolIndex('test-repo', source, { cacheDir: null });
+
+    expect(index.hooks['blocks.registerBlockType']).toEqual(['src/hooks.ts']);
+  });
+
+  it('extracts PHP symbols', async () => {
+    const source = makeSource({
+      'src/blocks.php': '<?php function register_block_type($name, $args = []) {}',
+    });
+
+    const index = await buildSymbolIndex('test-repo', source, { cacheDir: null });
+
+    expect(index.symbols['register_block_type']).toEqual(['src/blocks.php']);
+  });
+
+  it('skips build/dist/coverage paths', async () => {
+    const source = makeSource({
+      'build/index.js': 'export function generated() {}',
+      'dist/bundle.js': 'export function bundled() {}',
+      'coverage/lcov.ts': 'export function covered() {}',
+      'src/real.ts': 'export function real() {}',
+    });
+
+    const index = await buildSymbolIndex('test-repo', source, { cacheDir: null });
+
+    expect(index.symbols['generated']).toBeUndefined();
+    expect(index.symbols['bundled']).toBeUndefined();
+    expect(index.symbols['covered']).toBeUndefined();
+    expect(index.symbols['real']).toEqual(['src/real.ts']);
+  });
+
+  it('skips non-indexable file extensions', async () => {
+    const source = makeSource({
+      'README.md': 'Some docs',
+      'config.json': '{}',
+      'src/main.ts': 'export const x = 1;',
+    });
+
+    const index = await buildSymbolIndex('test-repo', source, { cacheDir: null });
+
+    expect(Object.keys(index.symbols)).toEqual(['x']);
+  });
+
+  it('populates metadata fields', async () => {
+    const source = makeSource({ 'src/a.ts': 'export const a = 1;' });
+    const index = await buildSymbolIndex('my-repo', source, { cacheDir: null });
+
+    expect(index.repoId).toBe('my-repo');
+    expect(index.commitSha).toBe('test-sha-001');
+    expect(typeof index.builtAt).toBe('string');
+  });
+
+  it('uses disk cache on second call with same sha', async () => {
+    const { mkdtempSync } = await import('fs');
+    const { tmpdir } = await import('os');
+    const cacheDir = mkdtempSync(`${tmpdir()}/symbol-index-test-`);
+
+    const source = makeSource({ 'src/a.ts': 'export function alpha() {}' });
+
+    const first  = await buildSymbolIndex('cached-repo', source, { cacheDir });
+    const second = await buildSymbolIndex('cached-repo', source, { cacheDir });
+
+    // Both runs must produce the same result
+    expect(second.symbols).toEqual(first.symbols);
+    expect(second.builtAt).toBe(first.builtAt); // identical timestamp proves cache was used
+  });
+});
+
+// --- scoreFilesAcrossRepos ---
+
+describe('scoreFilesAcrossRepos', () => {
+  const indexes = {
+    gutenberg: makeIndex('gutenberg', {
+      registerBlockType: ['packages/blocks/src/registration.js'],
+      BlockAttributes:   ['packages/blocks/src/types.ts'],
+      getBlockType: [
+        'packages/blocks/src/store/selectors.js',
+        'packages/blocks/src/registration.js',
+      ],
+    }, {
+      'blocks.registerBlockType': ['packages/blocks/src/registration.js'],
+    }),
+  };
+
+  it('scores files by symbol match count', () => {
+    const scores = scoreFilesAcrossRepos(['registerBlockType', 'getBlockType'], indexes);
+
+    const top = scores[0];
+    expect(top.path).toBe('packages/blocks/src/registration.js');
+    // registerBlockType + getBlockType = 2 symbol matches
+    expect(top.score).toBe(2);
+  });
+
+  it('includes matched symbol names in result', () => {
+    const scores = scoreFilesAcrossRepos(['registerBlockType'], indexes);
+    const match = scores.find(s => s.path === 'packages/blocks/src/registration.js');
+    expect(match?.matchedSymbols).toContain('registerBlockType');
+  });
+
+  it('counts hook matches', () => {
+    const scores = scoreFilesAcrossRepos(['blocks.registerBlockType'], indexes);
+    expect(scores.length).toBeGreaterThan(0);
+    expect(scores[0].path).toBe('packages/blocks/src/registration.js');
+  });
+
+  it('returns empty array for unknown symbols', () => {
+    const scores = scoreFilesAcrossRepos(['completelymissingidentifier'], indexes);
+    expect(scores).toEqual([]);
+  });
+
+  it('handles multiple repos independently', () => {
+    const multiIndexes = {
+      ...indexes,
+      'wordpress-develop': makeIndex('wordpress-develop', {
+        register_block_type: ['src/wp-includes/blocks.php'],
+      }),
+    };
+
+    const scores = scoreFilesAcrossRepos(
+      ['registerBlockType', 'register_block_type'],
+      multiIndexes,
+    );
+
+    const repos = new Set(scores.map(s => s.repo));
+    expect(repos.has('gutenberg')).toBe(true);
+    expect(repos.has('wordpress-develop')).toBe(true);
+  });
+
+  it('sorts results descending by score', () => {
+    const scores = scoreFilesAcrossRepos(
+      ['registerBlockType', 'BlockAttributes', 'getBlockType'],
+      indexes,
+    );
+
+    for (let i = 1; i < scores.length; i++) {
+      expect(scores[i].score).toBeLessThanOrEqual(scores[i - 1].score);
+    }
+  });
+});
+
+// --- findFilesByTreeHeuristic ---
+
+describe('findFilesByTreeHeuristic', () => {
+  const files = {
+    gutenberg: [
+      'packages/blocks/src/registration.js',
+      'packages/blocks/src/attributes.ts',
+      'packages/blocks/src/metadata.ts',
+      'packages/blocks/src/index.ts',
+      'packages/editor/src/components/post-meta/index.js',
+    ],
+  };
+
+  it('finds files whose path matches a keyword from the slug', () => {
+    const results = findFilesByTreeHeuristic('block-attributes', files, new Set());
+    const paths = results.map(r => r.path);
+    expect(paths).toContain('packages/blocks/src/attributes.ts');
+  });
+
+  it('finds files matching multi-keyword slug', () => {
+    const results = findFilesByTreeHeuristic('block-metadata', files, new Set());
+    const paths = results.map(r => r.path);
+    expect(paths).toContain('packages/blocks/src/metadata.ts');
+  });
+
+  it('respects the exclude set', () => {
+    const exclude = new Set(['gutenberg:packages/blocks/src/attributes.ts']);
+    const results = findFilesByTreeHeuristic('block-attributes', files, exclude);
+    const paths = results.map(r => r.path);
+    expect(paths).not.toContain('packages/blocks/src/attributes.ts');
+  });
+
+  it('returns empty array when no keywords meet the length threshold', () => {
+    // All parts < 5 chars: "use", "api" → nothing
+    const results = findFilesByTreeHeuristic('use-api', files, new Set());
+    expect(results).toEqual([]);
+  });
+
+  it('sorts shallower paths first', () => {
+    const deepFiles = {
+      gutenberg: [
+        'packages/blocks/src/registration/index.ts',
+        'packages/blocks/src/registration.ts',
+      ],
+    };
+    const results = findFilesByTreeHeuristic('block-registration', deepFiles, new Set());
+    if (results.length >= 2) {
+      expect(results[0].path.split('/').length).toBeLessThanOrEqual(
+        results[1].path.split('/').length,
+      );
+    }
+  });
+
+  it('skips build/dist/coverage paths', () => {
+    const withBuild = {
+      gutenberg: [
+        ...files.gutenberg,
+        'build/attributes.js',
+        'dist/attributes.js',
+      ],
+    };
+    const results = findFilesByTreeHeuristic('block-attributes', withBuild, new Set());
+    const paths = results.map(r => r.path);
+    expect(paths).not.toContain('build/attributes.js');
+    expect(paths).not.toContain('dist/attributes.js');
+  });
+});

--- a/src/indexer/__tests__/symbol-index.test.ts
+++ b/src/indexer/__tests__/symbol-index.test.ts
@@ -25,8 +25,9 @@ function makeIndex(
   repoId: string,
   symbols: Record<string, string[]>,
   hooks: Record<string, string[]> = {},
+  files: string[] = [],
 ): SymbolIndex {
-  return { repoId, commitSha: 'sha', builtAt: '2025-01-01T00:00:00Z', symbols, hooks };
+  return { repoId, commitSha: 'sha', builtAt: '2025-01-01T00:00:00Z', files, symbols, hooks };
 }
 
 // --- buildSymbolIndex ---
@@ -101,6 +102,46 @@ describe('buildSymbolIndex', () => {
     expect(typeof index.builtAt).toBe('string');
   });
 
+  it('populates files with the full repo file list', async () => {
+    const source = makeSource({
+      'src/a.ts': 'export const a = 1;',
+      'README.md': '# Docs',
+    });
+    const index = await buildSymbolIndex('my-repo', source, { cacheDir: null });
+
+    expect(index.files).toContain('src/a.ts');
+    expect(index.files).toContain('README.md');
+  });
+
+  it('skips __tests__ directory paths', async () => {
+    const source = makeSource({
+      'src/__tests__/registration.test.ts': 'export function registerBlockType() {}',
+      'src/registration.ts': 'export function registerBlockType() {}',
+    });
+
+    const index = await buildSymbolIndex('test-repo', source, { cacheDir: null });
+
+    // The test file symbol should not appear; only the production file
+    const paths = index.symbols['registerBlockType'] ?? [];
+    expect(paths).not.toContain('src/__tests__/registration.test.ts');
+    expect(paths).toContain('src/registration.ts');
+  });
+
+  it('skips *.test.ts and *.spec.ts files', async () => {
+    const source = makeSource({
+      'src/utils.test.ts': 'export function helperFn() {}',
+      'src/utils.spec.ts': 'export function helperFn() {}',
+      'src/utils.ts': 'export function helperFn() {}',
+    });
+
+    const index = await buildSymbolIndex('test-repo', source, { cacheDir: null });
+
+    const paths = index.symbols['helperFn'] ?? [];
+    expect(paths).not.toContain('src/utils.test.ts');
+    expect(paths).not.toContain('src/utils.spec.ts');
+    expect(paths).toContain('src/utils.ts');
+  });
+
   it('uses disk cache on second call with same sha', async () => {
     const { mkdtempSync } = await import('fs');
     const { tmpdir } = await import('os');
@@ -114,6 +155,24 @@ describe('buildSymbolIndex', () => {
     // Both runs must produce the same result
     expect(second.symbols).toEqual(first.symbols);
     expect(second.builtAt).toBe(first.builtAt); // identical timestamp proves cache was used
+  });
+
+  it('treats a cache file missing required fields as a miss', async () => {
+    const { mkdtempSync, writeFileSync } = await import('fs');
+    const { tmpdir } = await import('os');
+    const { join } = await import('path');
+    const cacheDir = mkdtempSync(`${tmpdir()}/symbol-index-test-stale-`);
+
+    // Write a stale cache file that lacks the `files` field (simulates old format)
+    const staleCache = { repoId: 'stale-repo', commitSha: 'test-sha-001', builtAt: '2024-01-01T00:00:00Z', symbols: {}, hooks: {} };
+    writeFileSync(join(cacheDir, 'stale-repo-test-sha-001.json'), JSON.stringify(staleCache));
+
+    const source = makeSource({ 'src/a.ts': 'export function alpha() {}' });
+    const index = await buildSymbolIndex('stale-repo', source, { cacheDir });
+
+    // Should have rebuilt (not used stale cache) so files field is present
+    expect(index.files).toContain('src/a.ts');
+    expect(index.symbols['alpha']).toEqual(['src/a.ts']);
   });
 });
 

--- a/src/indexer/symbol-index.ts
+++ b/src/indexer/symbol-index.ts
@@ -1,0 +1,205 @@
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import pLimit from 'p-limit';
+import { extractSymbolsFromSource } from '../extractors/typescript.js';
+import { extractPhpSymbolsFromSource } from '../extractors/php.js';
+import { extractHooksFromSource } from '../extractors/hooks.js';
+import type { CodeSource } from '../adapters/code-source/types.js';
+
+export type SymbolIndex = {
+  repoId: string;
+  commitSha: string;
+  builtAt: string;
+  // exported symbol name → file paths that define it
+  symbols: Record<string, string[]>;
+  // hook name → file paths that fire it
+  hooks: Record<string, string[]>;
+};
+
+export type ScoredFile = {
+  repo: string;
+  path: string;
+  score: number;
+  matchedSymbols: string[];
+};
+
+const INDEXABLE_EXTS = new Set(['ts', 'tsx', 'js', 'jsx', 'php']);
+
+// Build artifacts and generated output are not authoritative sources.
+// node_modules/.git/vendor are already excluded by GitCloneSource.listDir.
+const SKIP_PATTERNS = [/(^|\/)build\//, /(^|\/)dist\//, /(^|\/)coverage\//];
+
+function shouldSkip(path: string): boolean {
+  return SKIP_PATTERNS.some(p => p.test(path));
+}
+
+function cachePath(cacheDir: string, repoId: string, sha: string): string {
+  return join(cacheDir, `${repoId}-${sha}.json`);
+}
+
+function loadCached(cacheDir: string, repoId: string, sha: string): SymbolIndex | null {
+  const p = cachePath(cacheDir, repoId, sha);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, 'utf-8')) as SymbolIndex;
+  } catch {
+    return null;
+  }
+}
+
+function saveCache(cacheDir: string, index: SymbolIndex): void {
+  mkdirSync(cacheDir, { recursive: true });
+  writeFileSync(cachePath(cacheDir, index.repoId, index.commitSha), JSON.stringify(index));
+}
+
+function defaultCacheDir(): string {
+  return join(process.cwd(), 'tmp', 'symbol-index-cache');
+}
+
+export type BuildOptions = {
+  // Pass null to disable disk caching (useful in tests).
+  cacheDir?: string | null;
+  concurrency?: number;
+  onProgress?: (processed: number, total: number) => void;
+};
+
+export async function buildSymbolIndex(
+  repoId: string,
+  codeSource: CodeSource,
+  options: BuildOptions = {},
+): Promise<SymbolIndex> {
+  const { cacheDir = defaultCacheDir(), concurrency = 8, onProgress } = options;
+
+  const commitSha = await codeSource.getCommitSha();
+
+  if (cacheDir) {
+    const cached = loadCached(cacheDir, repoId, commitSha);
+    if (cached) return cached;
+  }
+
+  const allFiles = await codeSource.listDir('.');
+  const indexable = allFiles.filter(f => {
+    const ext = f.split('.').pop()?.toLowerCase() ?? '';
+    return INDEXABLE_EXTS.has(ext) && !shouldSkip(f);
+  });
+
+  const symbols: Record<string, string[]> = {};
+  const hooks: Record<string, string[]> = {};
+  const limit = pLimit(concurrency);
+  let processed = 0;
+
+  await Promise.all(
+    indexable.map(filePath =>
+      limit(async () => {
+        try {
+          const content = await codeSource.readFile(filePath);
+          const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
+
+          const fileSymbols =
+            ext === 'php'
+              ? extractPhpSymbolsFromSource(content, filePath)
+              : extractSymbolsFromSource(content, filePath);
+
+          for (const sym of fileSymbols) {
+            (symbols[sym.name] ??= []).push(filePath);
+          }
+
+          for (const hook of extractHooksFromSource(content, filePath)) {
+            (hooks[hook.name] ??= []).push(filePath);
+          }
+        } catch {
+          // unreadable files are skipped silently
+        }
+
+        processed++;
+        onProgress?.(processed, indexable.length);
+      }),
+    ),
+  );
+
+  const index: SymbolIndex = {
+    repoId,
+    commitSha,
+    builtAt: new Date().toISOString(),
+    symbols,
+    hooks,
+  };
+
+  if (cacheDir) saveCache(cacheDir, index);
+  return index;
+}
+
+// Score each file across all repos by the number of doc symbols it defines or fires.
+// Returns a list sorted descending by score.
+export function scoreFilesAcrossRepos(
+  docSymbols: string[],
+  indexes: Record<string, SymbolIndex>,
+): ScoredFile[] {
+  const scores = new Map<string, ScoredFile>();
+
+  for (const [repoId, index] of Object.entries(indexes)) {
+    for (const sym of docSymbols) {
+      const filePaths = [
+        ...(index.symbols[sym] ?? []),
+        ...(index.hooks[sym] ?? []),
+      ];
+      for (const filePath of filePaths) {
+        const key = `${repoId}:${filePath}`;
+        const entry = scores.get(key) ?? {
+          repo: repoId,
+          path: filePath,
+          score: 0,
+          matchedSymbols: [],
+        };
+        entry.score++;
+        entry.matchedSymbols.push(sym);
+        scores.set(key, entry);
+      }
+    }
+  }
+
+  return [...scores.values()].sort((a, b) => b.score - a.score);
+}
+
+// Words so common in this domain that they add no selectivity to path matching.
+const COMMON_SLUG_WORDS = new Set([
+  'block', 'blocks', 'with', 'from', 'that', 'this', 'into', 'over',
+  'about', 'after', 'before', 'using', 'your', 'their', 'when', 'each',
+]);
+
+// Find files whose path contains keywords derived from the doc slug.
+// Used to populate the context tier with structurally related files that
+// the symbol index may not surface (e.g. no exported symbol by that name).
+// Results are sorted shallow-first (fewer path segments = more authoritative).
+export function findFilesByTreeHeuristic(
+  slug: string,
+  allFilesByRepo: Record<string, string[]>,
+  exclude: Set<string>,
+): Array<{ repo: string; path: string }> {
+  const keywords = slug
+    .split(/[-_/\s]/)
+    .filter(k => k.length >= 5 && !COMMON_SLUG_WORDS.has(k));
+
+  if (keywords.length === 0) return [];
+
+  const results: Array<{ repo: string; path: string }> = [];
+
+  for (const [repoId, files] of Object.entries(allFilesByRepo)) {
+    for (const filePath of files) {
+      if (exclude.has(`${repoId}:${filePath}`)) continue;
+
+      const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
+      if (!INDEXABLE_EXTS.has(ext) || shouldSkip(filePath)) continue;
+
+      const lower = filePath.toLowerCase();
+      if (keywords.some(k => lower.includes(k.toLowerCase()))) {
+        results.push({ repo: repoId, path: filePath });
+      }
+    }
+  }
+
+  return results.sort((a, b) => {
+    const depthDiff = a.path.split('/').length - b.path.split('/').length;
+    return depthDiff !== 0 ? depthDiff : a.path.localeCompare(b.path);
+  });
+}

--- a/src/indexer/symbol-index.ts
+++ b/src/indexer/symbol-index.ts
@@ -10,6 +10,8 @@ export type SymbolIndex = {
   repoId: string;
   commitSha: string;
   builtAt: string;
+  // all files found in the repo (unfiltered by extension)
+  files: string[];
   // exported symbol name → file paths that define it
   symbols: Record<string, string[]>;
   // hook name → file paths that fire it
@@ -27,7 +29,14 @@ const INDEXABLE_EXTS = new Set(['ts', 'tsx', 'js', 'jsx', 'php']);
 
 // Build artifacts and generated output are not authoritative sources.
 // node_modules/.git/vendor are already excluded by GitCloneSource.listDir.
-const SKIP_PATTERNS = [/(^|\/)build\//, /(^|\/)dist\//, /(^|\/)coverage\//];
+const SKIP_PATTERNS = [
+  /(^|\/)build\//,
+  /(^|\/)dist\//,
+  /(^|\/)coverage\//,
+  /(^|\/)__tests__\//,
+  /(^|\/)[^/]+\.test\.[jt]sx?$/,
+  /(^|\/)[^/]+\.spec\.[jt]sx?$/,
+];
 
 function shouldSkip(path: string): boolean {
   return SKIP_PATTERNS.some(p => p.test(path));
@@ -41,7 +50,10 @@ function loadCached(cacheDir: string, repoId: string, sha: string): SymbolIndex 
   const p = cachePath(cacheDir, repoId, sha);
   if (!existsSync(p)) return null;
   try {
-    return JSON.parse(readFileSync(p, 'utf-8')) as SymbolIndex;
+    const raw = JSON.parse(readFileSync(p, 'utf-8')) as Partial<SymbolIndex>;
+    // Treat caches written by older versions (missing fields) as a miss.
+    if (!raw.symbols || !raw.hooks || !raw.files) return null;
+    return raw as SymbolIndex;
   } catch {
     return null;
   }
@@ -121,6 +133,7 @@ export async function buildSymbolIndex(
     repoId,
     commitSha,
     builtAt: new Date().toISOString(),
+    files: allFiles,
     symbols,
     hooks,
   };


### PR DESCRIPTION
## Summary

- **`src/indexer/symbol-index.ts`** — new module with three pure APIs:
  - `buildSymbolIndex(repoId, codeSource)` — iterates all TS/JS/PHP files in a repo via AST extractors, builds a `symbols` map (exported name → files) and `hooks` map (hook name → files). Result cached to disk keyed by commit SHA — subsequent calls on the same commit are instant.
  - `scoreFilesAcrossRepos(docSymbols, indexes)` — cross-references backtick identifiers from a doc against all repo indexes, returns files ranked by match count.
  - `findFilesByTreeHeuristic(slug, allFilesByRepo, exclude)` — keyword matching on file paths for context-tier candidates when no symbol match exists.

- **`scripts/auto-map.ts`** — new CLI script:
  ```
  npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write]
  ```
  Requires no `ANTHROPIC_API_KEY`. Phase 1 (symbol scoring) fills primary + secondary tiers; Phase 2 (tree heuristic) fills context tier. `--write` merges directly into the mapping file.

- **`src/indexer/__tests__/symbol-index.test.ts`** — 19 tests covering symbol extraction, hook extraction, PHP symbols, cache behaviour, skip patterns, scoring across multiple repos, and tree heuristic edge cases.

## Motivation

The previous `bootstrap-mapping.ts` asks Claude to guess file paths from a directory listing — it sees path names but not code. This approach inverts that: it reads all code first, builds a symbol index, then maps the doc's own referenced identifiers directly to the files that define them. A doc that mentions `` `registerBlockType` `` will reliably surface `packages/blocks/src/registration.js` without any model call.

## What stays unchanged

`bootstrap-mapping.ts` and the manual JSON mapping file remain. The new script is additive — the human-review step and AI-fallback layer are still available for cases where symbol coverage is thin.

## Test plan

- [ ] `npm test` — all 229 tests pass
- [ ] `npx tsx scripts/auto-map.ts block-metadata` — inspect top matches and verify they align with the doc's referenced symbols
- [ ] `npx tsx scripts/auto-map.ts block-metadata --write` — verify mapping file is updated correctly
- [ ] Re-run with same slug — verify cache hit (no progress output, instant result)

https://claude.ai/code/session_016ngfbtrPgXQaMDsTnTws1F

---
_Generated by [Claude Code](https://claude.ai/code/session_016ngfbtrPgXQaMDsTnTws1F)_