### PR TITLE
deterministic + N-sample validator (#56)

### DIFF
--- a/src/__tests__/pipeline.test.ts
+++ b/src/__tests__/pipeline.test.ts
@@ -104,7 +104,7 @@ const minimalConfig: Config = {
   },
   mappingPath: 'mappings/test.json',
   outputDir: '/tmp/wp-docs-health-monitor-pipeline-test',
-  validator: { type: 'claude', pass1Model: 'claude-sonnet-4-6', pass2Model: 'claude-sonnet-4-6' },
+  validator: { type: 'claude', pass1Model: 'claude-sonnet-4-6', pass2Model: 'claude-sonnet-4-6', temperature: 0, samples: 1 },
   pricing: { inputPerMtok: 3, outputPerMtok: 15, cacheWritePerMtok: 3.75, cacheReadPerMtok: 0.30 },
 };
 

--- a/src/adapters/__tests__/index.test.ts
+++ b/src/adapters/__tests__/index.test.ts
@@ -33,7 +33,7 @@ function makeDocSourceConfig(type: string): Config {
     },
     mappingPath: 'mappings/test.json',
     outputDir: './out',
-    validator: { type: 'claude', pass1Model: 'claude-sonnet-4-6', pass2Model: 'claude-sonnet-4-6' },
+    validator: { type: 'claude', pass1Model: 'claude-sonnet-4-6', pass2Model: 'claude-sonnet-4-6', temperature: 0, samples: 1 },
     pricing: { inputPerMtok: 3, outputPerMtok: 15, cacheWritePerMtok: 3.75, cacheReadPerMtok: 0.30 },
   };
 }

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -47,7 +47,7 @@ export function createDocCodeMapper(config: Config, codeSources: Record<string, 
 }
 
 export function createValidator(config: Config): Validator {
-  const { type, pass1Model, pass2Model, systemPromptExtension } = config.validator;
+  const { type, pass1Model, pass2Model, systemPromptExtension, temperature, samples } = config.validator;
   if (type === 'claude') {
     const anthropic = new Anthropic();
     let promptExtension: string | undefined;
@@ -58,7 +58,7 @@ export function createValidator(config: Config): Validator {
         throw new Error(`Could not read systemPromptExtension "${systemPromptExtension}": ${(err as Error).message}`);
       }
     }
-    return new ClaudeValidator(pass1Model, pass2Model, anthropic, promptExtension);
+    return new ClaudeValidator(pass1Model, pass2Model, anthropic, promptExtension, { temperature, samples });
   }
   throw new NotImplementedError(type);
 }

--- a/src/adapters/validator/__tests__/claude.test.ts
+++ b/src/adapters/validator/__tests__/claude.test.ts
@@ -731,3 +731,219 @@ describe('ClaudeValidator — Pass 2 fetch_code tool', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// ClaudeValidator — temperature plumbing (issue #56)
+// ---------------------------------------------------------------------------
+
+describe('ClaudeValidator — temperature plumbing', () => {
+  it('passes the configured temperature on every messages.create call (Pass 1, Pass 2, retry)', async () => {
+    const fileContent = 'function registerBlockType(name, settings) {}';
+    const codeSays = 'function registerBlockType(name, settings)';
+
+    const pass1Response = makeReportFindingsResponse([
+      { ...BASE_ISSUE, severity: 'critical', evidence: { ...BASE_ISSUE.evidence, codeSays } },
+    ], []);
+    // Pass 2 returns a weak suggestion → triggers a retry (third call).
+    const pass2WeakResponse = makeReportFindingsResponse([
+      {
+        ...BASE_ISSUE,
+        severity:   'critical',
+        evidence:   { ...BASE_ISSUE.evidence, codeSays },
+        confidence: 0.8,
+        suggestion: 'fix the description',
+      },
+    ], []);
+    const retryResponse = makeReportFindingsResponse([
+      {
+        ...BASE_ISSUE,
+        severity:   'critical',
+        evidence:   { ...BASE_ISSUE.evidence, codeSays },
+        confidence: 0.8,
+        suggestion: 'Update `registerBlockType` to document the new `metadata` overload',
+      },
+    ], []);
+
+    const client = makeAnthropicClient([pass1Response, pass2WeakResponse, retryResponse]);
+    const createSpy = client.messages.create as Mock;
+    const codeSources = makeCodeSources(fileContent);
+
+    const validator = new ClaudeValidator(
+      'claude-sonnet-4-6',
+      'claude-sonnet-4-6',
+      client,
+      undefined,
+      { temperature: 0 },
+    );
+    await validator.validateDoc(makeDoc(), makeCodeTiers(), codeSources);
+
+    expect(createSpy).toHaveBeenCalledTimes(3);
+    for (const call of createSpy.mock.calls) {
+      expect(call[0]).toMatchObject({ temperature: 0 });
+    }
+  });
+
+  it('defaults temperature to 0 when no option is provided', async () => {
+    const fileContent = 'function registerBlockType(name, settings) {}';
+    const codeSays = 'function registerBlockType(name, settings)';
+
+    const pass1Response = makeReportFindingsResponse([
+      { ...BASE_ISSUE, evidence: { ...BASE_ISSUE.evidence, codeSays } },
+    ], []);
+    const pass2Response = makeReportFindingsResponse([
+      { ...BASE_ISSUE, evidence: { ...BASE_ISSUE.evidence, codeSays }, confidence: 0.9 },
+    ], []);
+
+    const client = makeAnthropicClient([pass1Response, pass2Response]);
+    const createSpy = client.messages.create as Mock;
+
+    const validator = new ClaudeValidator('claude-sonnet-4-6', 'claude-sonnet-4-6', client);
+    await validator.validateDoc(makeDoc(), makeCodeTiers(), makeCodeSources(fileContent));
+
+    expect(createSpy.mock.calls.length).toBeGreaterThan(0);
+    for (const call of createSpy.mock.calls) {
+      expect(call[0].temperature).toBe(0);
+    }
+  });
+
+  it('honours a non-zero temperature when explicitly configured', async () => {
+    const pass1Response = makeReportFindingsResponse([], []);
+    const client = makeAnthropicClient([pass1Response]);
+    const createSpy = client.messages.create as Mock;
+
+    const validator = new ClaudeValidator(
+      'claude-sonnet-4-6',
+      'claude-sonnet-4-6',
+      client,
+      undefined,
+      { temperature: 0.7 },
+    );
+    await validator.validateDoc(makeDoc(), makeCodeTiers(), makeCodeSources());
+
+    expect(createSpy.mock.calls[0][0].temperature).toBe(0.7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ClaudeValidator — N-sample Pass 1 with fingerprint dedup (issue #56)
+// ---------------------------------------------------------------------------
+
+describe('ClaudeValidator — N-sample Pass 1', () => {
+  it('runs Pass 1 N times when samples > 1 and unions candidates by fingerprint', async () => {
+    const fileContent = 'function registerBlockType(name, settings) {}';
+    const codeSays = 'function registerBlockType(name, settings)';
+
+    // Sample 1 returns issue A (type-signature) only.
+    const pass1Sample1 = makeReportFindingsResponse([
+      { ...BASE_ISSUE, type: 'type-signature', evidence: { ...BASE_ISSUE.evidence, codeSays } },
+    ], ['Doc accurately describes the API']);
+
+    // Sample 2 returns issue A again (same type+codeFile+codeRepo → same fingerprint)
+    // PLUS a different issue B (deprecated-api → different fingerprint).
+    const pass1Sample2 = makeReportFindingsResponse([
+      { ...BASE_ISSUE, type: 'type-signature', evidence: { ...BASE_ISSUE.evidence, codeSays } },
+      {
+        ...BASE_ISSUE,
+        type:     'deprecated-api',
+        evidence: { ...BASE_ISSUE.evidence, codeSays, docSays: 'The `name` parameter is required.' },
+      },
+    ], ['Doc accurately describes the API']);
+
+    // Sample 3 returns nothing new.
+    const pass1Sample3 = makeReportFindingsResponse([], []);
+
+    // Each unique candidate must be verified at most once by Pass 2 → 2 calls.
+    const pass2A = makeReportFindingsResponse([
+      {
+        ...BASE_ISSUE,
+        type:       'type-signature',
+        evidence:   { ...BASE_ISSUE.evidence, codeSays },
+        confidence: 0.9,
+        suggestion: 'Update `registerBlockType` to document the new `metadata` overload',
+      },
+    ], []);
+    const pass2B = makeReportFindingsResponse([
+      {
+        ...BASE_ISSUE,
+        type:       'deprecated-api',
+        evidence:   { ...BASE_ISSUE.evidence, codeSays },
+        confidence: 0.9,
+        suggestion: 'Mark `registerBlockType` deprecated in favour of `wp.blocks.register`',
+      },
+    ], []);
+
+    const client = makeAnthropicClient([pass1Sample1, pass1Sample2, pass1Sample3, pass2A, pass2B]);
+    const createSpy = client.messages.create as Mock;
+
+    const validator = new ClaudeValidator(
+      'claude-sonnet-4-6',
+      'claude-sonnet-4-6',
+      client,
+      undefined,
+      { samples: 3 },
+    );
+    const result = await validator.validateDoc(
+      makeDoc(),
+      makeCodeTiers(),
+      makeCodeSources(fileContent),
+    );
+
+    // 3 Pass-1 calls + 2 Pass-2 calls (one per unique candidate, not per sample sighting).
+    expect(createSpy).toHaveBeenCalledTimes(5);
+    // Both unique findings survive.
+    expect(result.issues).toHaveLength(2);
+    const types = result.issues.map(i => i.type).sort();
+    expect(types).toEqual(['deprecated-api', 'type-signature']);
+  });
+
+  it('still produces a valid DocResult when one Pass-1 sample throws', async () => {
+    const fileContent = 'function registerBlockType(name, settings) {}';
+    const codeSays = 'function registerBlockType(name, settings)';
+
+    const goodPass1 = makeReportFindingsResponse([
+      { ...BASE_ISSUE, evidence: { ...BASE_ISSUE.evidence, codeSays } },
+    ], []);
+    const pass2Response = makeReportFindingsResponse([
+      { ...BASE_ISSUE, evidence: { ...BASE_ISSUE.evidence, codeSays }, confidence: 0.9 },
+    ], []);
+
+    let callCount = 0;
+    const client = {
+      messages: {
+        create: vi.fn(async () => {
+          callCount++;
+          if (callCount === 1) throw new Error('transient API error');
+          if (callCount === 2) return goodPass1;
+          return pass2Response;
+        }),
+      },
+    } as unknown as Anthropic;
+
+    const validator = new ClaudeValidator(
+      'claude-sonnet-4-6',
+      'claude-sonnet-4-6',
+      client,
+      undefined,
+      { samples: 2 },
+    );
+    const result = await validator.validateDoc(
+      makeDoc(),
+      makeCodeTiers(),
+      makeCodeSources(fileContent),
+    );
+
+    // The surviving sample's findings are kept; the failed sample is reported in diagnostics.
+    expect(result.issues).toHaveLength(1);
+    expect(result.diagnostics.some(d => /Pass 1 sample 1\/2 failed/.test(d))).toBe(true);
+  });
+
+  it('rejects samples < 1 at construction time', () => {
+    const client = makeAnthropicClient([makeReportFindingsResponse([], [])]);
+    expect(
+      () =>
+        new ClaudeValidator('claude-sonnet-4-6', 'claude-sonnet-4-6', client, undefined, {
+          samples: 0,
+        }),
+    ).toThrow(/samples must be an integer >= 1/);
+  });
+});

--- a/src/adapters/validator/claude.ts
+++ b/src/adapters/validator/claude.ts
@@ -240,21 +240,46 @@ export type CostAccumulator = {
 // ClaudeValidator
 // ---------------------------------------------------------------------------
 
+export type ClaudeValidatorOptions = {
+  // Sampling temperature for all three messages.create call sites
+  // (Pass 1, Pass 2 agentic loop, weak-suggestion retry). Default 0 ⇒
+  // deterministic runs.
+  temperature?: number;
+  // Number of Pass 1 samples per doc. samples > 1 trades cost for recall:
+  // candidates are unioned across samples by fingerprint before the
+  // verbatim check / Pass 2, so each unique candidate is verified once.
+  samples?: number;
+};
+
 export class ClaudeValidator implements Validator {
   private readonly pass1Model: string;
   private readonly pass2Model: string;
   private readonly anthropic: Anthropic;
   private readonly systemPrompt: string;
+  private readonly temperature: number;
+  private readonly samples: number;
   readonly costAccumulator: CostAccumulator = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
   droppedHallucinations = 0;
 
-  constructor(pass1Model: string, pass2Model: string, anthropic: Anthropic, promptExtension?: string) {
+  constructor(
+    pass1Model: string,
+    pass2Model: string,
+    anthropic: Anthropic,
+    promptExtension?: string,
+    options: ClaudeValidatorOptions = {},
+  ) {
     this.pass1Model = pass1Model;
     this.pass2Model = pass2Model;
     this.anthropic = anthropic;
     this.systemPrompt = promptExtension?.trim()
       ? `${SYSTEM_PROMPT}\n\n## Site-specific rules\n\n${promptExtension}`
       : SYSTEM_PROMPT;
+    this.temperature = options.temperature ?? 0;
+    const requestedSamples = options.samples ?? 1;
+    if (!Number.isInteger(requestedSamples) || requestedSamples < 1) {
+      throw new Error(`ClaudeValidator: samples must be an integer >= 1 (got ${requestedSamples})`);
+    }
+    this.samples = requestedSamples;
   }
 
   async validateDoc(
@@ -279,17 +304,56 @@ export class ClaudeValidator implements Validator {
     // Build user message content
     const userContent = ClaudeValidator.buildUserContent(doc, assembled, {});
 
-    // Pass 1: get initial issues and positives
+    // Pass 1: get initial issues and positives. When `samples > 1` we run
+    // Pass 1 N times and union candidates by `fingerprintIssue` *before*
+    // the verbatim check / Pass 2 — each unique candidate is verified once.
+    // Trades cost for recall (issue #56). With samples=1 the path collapses
+    // to the historical single-call shape and is byte-identical to it.
     let pass1Issues: RawIssue[] = [];
     let positives: string[] = [];
 
-    try {
-      const pass1Result = await this.runPass1(userContent);
-      pass1Issues = pass1Result.issues;
-      positives = pass1Result.positives.slice(0, 3);
-    } catch (err) {
-      diagnostics.push(`Pass 1 failed: ${String(err)}`);
-      return this.buildDocResult(doc, [], positives, assembled.relatedCode, diagnostics, commitSha);
+    if (this.samples === 1) {
+      try {
+        const pass1Result = await this.runPass1(userContent);
+        pass1Issues = pass1Result.issues;
+        positives = pass1Result.positives.slice(0, 3);
+      } catch (err) {
+        diagnostics.push(`Pass 1 failed: ${String(err)}`);
+        return this.buildDocResult(doc, [], positives, assembled.relatedCode, diagnostics, commitSha);
+      }
+    } else {
+      const seenFingerprints = new Set<string>();
+      const aggregatedPositives: string[] = [];
+      let succeededSamples = 0;
+      for (let i = 0; i < this.samples; i++) {
+        let pass1Result: ReportFindingsInput;
+        try {
+          pass1Result = await this.runPass1(userContent);
+        } catch (err) {
+          diagnostics.push(`Pass 1 sample ${i + 1}/${this.samples} failed: ${String(err)}`);
+          continue;
+        }
+        succeededSamples++;
+        for (const candidate of pass1Result.issues) {
+          const fp = fingerprintIssue(
+            doc.slug,
+            candidate.type,
+            candidate.evidence.codeRepo,
+            candidate.evidence.codeFile,
+          );
+          if (!seenFingerprints.has(fp)) {
+            seenFingerprints.add(fp);
+            pass1Issues.push(candidate);
+          }
+        }
+        for (const p of pass1Result.positives) {
+          if (!aggregatedPositives.includes(p)) aggregatedPositives.push(p);
+        }
+      }
+      if (succeededSamples === 0) {
+        return this.buildDocResult(doc, [], [], assembled.relatedCode, diagnostics, commitSha);
+      }
+      positives = aggregatedPositives.slice(0, 3);
     }
 
     // Verbatim check — both docSays and codeSays must be real quotes.
@@ -466,15 +530,18 @@ ${sourceCodeBlock}${missingSymbolsHint}`;
 
   private async runPass1(
     userContent: string,
-    temperature?: number,
+    temperatureOverride?: number,
   ): Promise<ReportFindingsInput> {
+    // Per-call override (used by `runPass1Only` experiments) wins over the
+    // instance default (set from config.validator.temperature, default 0).
+    const temperature = temperatureOverride ?? this.temperature;
     const response = await this.anthropic.messages.create({
       model:      this.pass1Model,
       // 8192 sized for up to PASS1_MAX_ISSUES issues × structured
       // suggestion (~500 tokens each) + positives + slack. 4096 was
       // tight on multi-issue docs and contributed to truncation.
       max_tokens: 8192,
-      ...(temperature !== undefined ? { temperature } : {}),
+      temperature,
       system: [
         {
           type:          'text',
@@ -560,8 +627,9 @@ ${JSON.stringify(candidate, null, 2)}`,
     // Agentic loop: allow Claude to call fetch_code before report_findings
     for (let turn = 0; turn < 10; turn++) {
       const response = await this.anthropic.messages.create({
-        model:      this.pass2Model,
-        max_tokens: 2048,
+        model:       this.pass2Model,
+        max_tokens:  2048,
+        temperature: this.temperature,
         system: [
           {
             type:          'text',
@@ -677,8 +745,9 @@ ${JSON.stringify(candidate, null, 2)}`,
     ];
 
     const response = await this.anthropic.messages.create({
-      model:      this.pass2Model,
-      max_tokens: 1024,
+      model:       this.pass2Model,
+      max_tokens:  1024,
+      temperature: this.temperature,
       system: [
         {
           type:          'text',

--- a/src/config/__tests__/schema.test.ts
+++ b/src/config/__tests__/schema.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+
+import { ConfigSchema } from '../schema.js';
+
+const baseRaw = {
+  project:     { name: 'Test' },
+  docSource:   {
+    type:        'manifest-url' as const,
+    manifestUrl: 'https://example.com/manifest.json',
+    parentSlug:  'block-api',
+  },
+  codeSources: {
+    gutenberg: { type: 'git-clone' as const, repoUrl: 'https://github.com/WordPress/gutenberg.git', ref: 'trunk' },
+  },
+  mappingPath: 'mappings/test.json',
+  outputDir:   './out',
+  validator:   { type: 'claude' as const, pass1Model: 'm', pass2Model: 'm' },
+};
+
+describe('ConfigSchema — validator.temperature / validator.samples (issue #56)', () => {
+  it('defaults temperature to 0 and samples to 1 when both are omitted', () => {
+    const parsed = ConfigSchema.parse(baseRaw);
+    expect(parsed.validator.temperature).toBe(0);
+    expect(parsed.validator.samples).toBe(1);
+  });
+
+  it('accepts an explicit temperature override', () => {
+    const parsed = ConfigSchema.parse({
+      ...baseRaw,
+      validator: { ...baseRaw.validator, temperature: 0.7 },
+    });
+    expect(parsed.validator.temperature).toBe(0.7);
+  });
+
+  it('accepts an explicit samples override', () => {
+    const parsed = ConfigSchema.parse({
+      ...baseRaw,
+      validator: { ...baseRaw.validator, samples: 3 },
+    });
+    expect(parsed.validator.samples).toBe(3);
+  });
+
+  it('rejects samples < 1', () => {
+    const result = ConfigSchema.safeParse({
+      ...baseRaw,
+      validator: { ...baseRaw.validator, samples: 0 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-integer samples', () => {
+    const result = ConfigSchema.safeParse({
+      ...baseRaw,
+      validator: { ...baseRaw.validator, samples: 1.5 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-finite temperature', () => {
+    const result = ConfigSchema.safeParse({
+      ...baseRaw,
+      validator: { ...baseRaw.validator, temperature: Number.POSITIVE_INFINITY },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -26,6 +26,12 @@ export const ConfigSchema = z.object({
     pass1Model:             z.string().default('claude-sonnet-4-6'),
     pass2Model:             z.string().default('claude-sonnet-4-6'),
     systemPromptExtension:  z.string().optional(), // path to a .md file with site-specific prompt rules
+    // Determinism + recall controls. See issue #56.
+    //   `temperature: 0` makes Pass 1 / Pass 2 reproducible run-to-run.
+    //   `samples > 1` runs Pass 1 N times and unions candidates by
+    //   fingerprint before Pass 2 — trades cost for recall.
+    temperature:            z.number().finite().default(0),
+    samples:                z.number().int().min(1).default(1),
   }),
   // Token pricing in USD per million tokens. Defaults match Sonnet 4.6 rates.
   // Check https://www.anthropic.com/pricing for current values and update as needed.

--- a/src/types/__tests__/schemas.test.ts
+++ b/src/types/__tests__/schemas.test.ts
@@ -44,7 +44,7 @@ const minimalConfig: Config = {
   },
   mappingPath: 'mappings/test.json',
   outputDir: '/tmp/wp-docs-health-monitor-test',
-  validator: { type: 'claude', pass1Model: 'claude-sonnet-4-6', pass2Model: 'claude-sonnet-4-6' },
+  validator: { type: 'claude', pass1Model: 'claude-sonnet-4-6', pass2Model: 'claude-sonnet-4-6', temperature: 0, samples: 1 },
   pricing: { inputPerMtok: 3, outputPerMtok: 15, cacheWritePerMtok: 3.75, cacheReadPerMtok: 0.30 },
 };
 


### PR DESCRIPTION
Set explicit temperature on all three validator `messages.create` call sites (Pass 1, Pass 2 agentic loop, weak-suggestion retry). Default `0` makes runs reproducible. Add `config.validator.samples` (default `1`); when `> 1`, `runPass1` fires N times per doc and unique candidates are unioned by `fingerprintIssue` *before* the verbatim check / Pass 2 so each is verified once. Pipeline error stance preserved: a failed sample lands as a diagnostic instead of aborting the doc.

Closes #56

## Acceptance criteria

- [x] All three `messages.create` calls pass an explicit `temperature` derived from config.
- [x] `samples=1, temperature=0` → byte-identical Pass 1 path (single-sample short-circuit retains the historical shape).
- [x] `samples=3` issues 3 Pass-1 calls per doc and one Pass-2 call per *unique* candidate (verified by mock).
- [x] Issues from any sample appear in the final results, deduped by fingerprint.
- [x] Schema rejects `samples < 1` and non-finite `temperature`.
- [x] `npm run typecheck` and `npm test` both pass (245 tests).
- [x] Failed sample → `diagnostics` entry, never an exception.
- [x] No change to `src/types/` (locked contracts).
- [x] `examples/results.schema.json` not touched (no `RunResultsSchema` change).

## Files changed
- `src/config/schema.ts`
- `src/adapters/index.ts`
- `src/adapters/validator/claude.ts`
- `src/adapters/validator/__tests__/claude.test.ts`
- `src/config/__tests__/schema.test.ts`
- `src/__tests__/pipeline.test.ts`
- `src/adapters/__tests__/index.test.ts`
- `src/types/__tests__/schemas.test.ts`