### PR TITLE
RALPH: pin sampling metadata in pipeline-level test (#68)

### DIFF
--- a/src/__tests__/pipeline.test.ts
+++ b/src/__tests__/pipeline.test.ts
@@ -87,6 +87,7 @@ vi.mock('../adapters/index.js', () => ({
 // Import AFTER vi.mock so the mock is active.
 const { runPipeline } = await import('../pipeline.js');
 const { RunResultsSchema } = await import('../types/results.js');
+const { ConfigSchema } = await import('../config/schema.js');
 
 const minimalConfig: Config = {
   project: { name: 'Test' },
@@ -126,5 +127,36 @@ describe('runPipeline — validator failure isolation', () => {
 
     // Run-level shape must still be a valid RunResults
     expect(() => RunResultsSchema.parse(result)).not.toThrow();
+  });
+});
+
+describe('runPipeline — validator sampling metadata', () => {
+  it('surfaces config.validator.temperature and samples in result.sampling', async () => {
+    const config: Config = {
+      ...minimalConfig,
+      validator: { ...minimalConfig.validator, temperature: 0.7, samples: 3 },
+    };
+
+    const result = await runPipeline(config);
+
+    expect(result.sampling).toEqual({ temperature: 0.7, samples: 3 });
+  });
+
+  it('reflects schema defaults (temperature: 0, samples: 1) when omitted from the raw config', async () => {
+    // Round-trip through ConfigSchema.parse so defaults are applied the same
+    // way they are when the CLI loads a config file that omits these fields.
+    const parsed = ConfigSchema.parse({
+      project:     minimalConfig.project,
+      docSource:   minimalConfig.docSource,
+      codeSources: minimalConfig.codeSources,
+      mappingPath: minimalConfig.mappingPath,
+      outputDir:   minimalConfig.outputDir,
+      validator:   { type: 'claude' },  // intentionally omit temperature & samples
+      pricing:     minimalConfig.pricing,
+    });
+
+    const result = await runPipeline(parsed);
+
+    expect(result.sampling).toEqual({ temperature: 0, samples: 1 });
   });
 });


### PR DESCRIPTION
## Summary

Closes the remaining wiring on #68 by pinning the sampling metadata that the human already landed in commit f6cb498. The schema (`RunSamplingSchema`) and pipeline write site already populate `result.sampling` from `config.validator.{temperature,samples}` — this PR adds the pipeline-level tests called out in the issue's last open acceptance criterion.

Two cases are covered:

1. Explicit values flow through verbatim (`temperature: 0.7, samples: 3`).
2. When the raw config omits the fields, the schema's defaults (`0`, `1`) are applied — verified by round-tripping through `ConfigSchema.parse()` so the test mirrors how the CLI loads a config file.

Verified the assertions are load-bearing by temporarily forcing `sampling` to `{ temperature: 999, samples: 999 }` in `pipeline.ts`; both new tests failed with the expected diff before being reverted.

Closes #68

## Changes

- `src/__tests__/pipeline.test.ts` — adds `describe('runPipeline — validator sampling metadata')` with two `it` blocks (explicit values + schema-default round-trip). Reuses the existing `vi.mock` adapter setup; imports `ConfigSchema` after the mock so the default-application path uses the real schema.

## How to test

1. `git fetch origin && git checkout ralph/68-pipeline-sampling-test`
2. `npm install`
3. `npm test` — should be green; total count goes from 245 → 247. The two new tests under "runPipeline — validator sampling metadata" prove `result.sampling` reflects `config.validator.{temperature,samples}` for both explicit and default-applied configs.
4. `npm run typecheck` — clean.
5. (Optional regression check) Open `src/pipeline.ts`, replace the `sampling` object's values with literal numbers (e.g. `temperature: 999, samples: 999`), re-run `npx vitest run src/__tests__/pipeline.test.ts`, and confirm both new tests fail with the expected diff. Revert the change before merging.

Expected outcome: `npm test` reports 247 tests passing, including the two new `validator sampling metadata` cases.

## Out of scope

- Any change to `src/types/results.ts` — the `RunSamplingSchema` already exists from the human-landed commit f6cb498. No locked-contract edits in this PR.
- Any change to `examples/results.schema.json` — already regenerated by the human in f6cb498. Not touched here.
- Any change to `examples/mock-results.json` — already populated in f6cb498. Not touched here.
- Dashboard-side surfacing of the new `sampling` block (issue body explicitly lists this as out of scope).
