### PR TITLE
feat(indexer): index JSON schemas + file weighting + IDF + diversity cap

### DIFF
--- a/scripts/auto-map.ts
+++ b/scripts/auto-map.ts
@@ -125,30 +125,44 @@ async function main() {
   // 4. Score all files by how many doc symbols they define or fire
   const scored = scoreFilesAcrossRepos(docSymbols, indexes);
 
-  console.error('\nTop matches by symbol coverage:');
+  console.error('\nTop matches by symbol coverage (IDF-weighted, file-weighted):');
   scored.slice(0, 10).forEach(f =>
     console.error(
-      `  [${f.repo}] ${f.path}  score=${f.score}  (${f.matchedSymbols.slice(0, 5).join(', ')})`,
+      `  [${f.repo}] ${f.path}  score=${f.score.toFixed(2)}  (${f.matchedSymbols.slice(0, 5).join(', ')})`,
     ),
   );
 
   // 5. Assemble tiers
-  //    primary   — top symbol-matched files (max 3)
+  //    primary   — top symbol-matched files (max 3, max 1 schema for diversity)
   //    secondary — next best symbol-matched files (max 5)
   //    context   — structurally related files via slug keyword matching (max 8)
+  //
+  // The primary-tier schema cap exists because schemas accumulate matches
+  // on generic property names (`name`, `style`, `url`, `link`) shared across
+  // every schema in a corpus. Without the cap, schemas dominate all three
+  // primary slots even when the doc is not about any specific schema —
+  // pushing implementation files (the actual canon for many docs) out of
+  // primary. Allowing exactly one schema in primary surfaces the strongest
+  // schema candidate while leaving room for implementation files.
   const selected = new Set<string>();
+  const isSchemaPath = (path: string): boolean => /(^|\/)schemas\/.*\.json$/.test(path);
 
-  function pickNext(n: number) {
-    return scored
-      .filter(f => !selected.has(`${f.repo}:${f.path}`))
-      .slice(0, n)
-      .map(f => {
-        selected.add(`${f.repo}:${f.path}`);
-        return { repo: f.repo, path: f.path };
-      });
+  function pickNext(n: number, maxSchemas: number = Infinity) {
+    const result: Array<{ repo: string; path: string }> = [];
+    let schemaCount = 0;
+    for (const f of scored) {
+      if (result.length >= n) break;
+      const key = `${f.repo}:${f.path}`;
+      if (selected.has(key)) continue;
+      if (isSchemaPath(f.path) && schemaCount >= maxSchemas) continue;
+      selected.add(key);
+      if (isSchemaPath(f.path)) schemaCount++;
+      result.push({ repo: f.repo, path: f.path });
+    }
+    return result;
   }
 
-  const primary = pickNext(3);
+  const primary = pickNext(3, 1);
   const secondary = pickNext(5);
 
   const contextCandidates = findFilesByTreeHeuristic(slug, allFilesByRepo, selected);

--- a/src/extractors/__tests__/json-schema.test.ts
+++ b/src/extractors/__tests__/json-schema.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { extractJsonSchemaSymbolsFromSource } from '../json-schema.js';
+
+function names(content: string): string[] {
+  return extractJsonSchemaSymbolsFromSource(content, 'test.json').map(s => s.name);
+}
+
+describe('extractJsonSchemaSymbolsFromSource', () => {
+  it('extracts top-level property names', () => {
+    const schema = JSON.stringify({
+      $schema: 'https://json-schema.org/draft-07/schema#',
+      properties: {
+        apiVersion: { type: 'integer' },
+        name:       { type: 'string' },
+        title:      { type: 'string' },
+      },
+    });
+    expect(names(schema).sort()).toEqual(['apiVersion', 'name', 'title']);
+  });
+
+  it('extracts nested property names', () => {
+    const schema = JSON.stringify({
+      properties: {
+        supports: {
+          type: 'object',
+          properties: {
+            color: {
+              type: 'object',
+              properties: {
+                gradient: { type: 'boolean' },
+                background: { type: 'boolean' },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(names(schema)).toEqual(
+      expect.arrayContaining(['supports', 'color', 'gradient', 'background']),
+    );
+  });
+
+  it('extracts string enum values', () => {
+    const schema = JSON.stringify({
+      properties: {
+        category: {
+          enum: ['text', 'media', 'design', 'widgets', 'theme', 'embed'],
+        },
+      },
+    });
+    expect(names(schema)).toEqual(
+      expect.arrayContaining(['category', 'text', 'media', 'design', 'widgets', 'theme', 'embed']),
+    );
+  });
+
+  it('skips non-string enum values', () => {
+    const schema = JSON.stringify({
+      properties: {
+        version: { enum: [1, 2, 3, true, null] },
+      },
+    });
+    expect(names(schema)).toEqual(['version']);
+  });
+
+  it('extracts definitions (draft-07)', () => {
+    const schema = JSON.stringify({
+      definitions: {
+        BlockSupports: { type: 'object' },
+        AttributeSpec: { type: 'object' },
+      },
+      properties: {
+        supports: { $ref: '#/definitions/BlockSupports' },
+      },
+    });
+    expect(names(schema)).toEqual(
+      expect.arrayContaining(['BlockSupports', 'AttributeSpec', 'supports']),
+    );
+  });
+
+  it('extracts $defs (2019-09 / 2020-12)', () => {
+    const schema = JSON.stringify({
+      $defs: {
+        ColorOrigin: { type: 'string' },
+      },
+      properties: {
+        origin: { $ref: '#/$defs/ColorOrigin' },
+      },
+    });
+    expect(names(schema)).toEqual(expect.arrayContaining(['ColorOrigin', 'origin']));
+  });
+
+  it('recurses into oneOf / anyOf / allOf', () => {
+    const schema = JSON.stringify({
+      properties: {
+        value: {
+          oneOf: [
+            { properties: { stringValue: {} } },
+            { anyOf: [{ properties: { numberValue: {} } }] },
+            { allOf: [{ properties: { booleanValue: {} } }] },
+          ],
+        },
+      },
+    });
+    expect(names(schema)).toEqual(
+      expect.arrayContaining(['value', 'stringValue', 'numberValue', 'booleanValue']),
+    );
+  });
+
+  it('walks items in array schemas', () => {
+    const schema = JSON.stringify({
+      properties: {
+        variations: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              isDefault: { type: 'boolean' },
+              scope:     { type: 'array' },
+            },
+          },
+        },
+      },
+    });
+    expect(names(schema)).toEqual(
+      expect.arrayContaining(['variations', 'isDefault', 'scope']),
+    );
+  });
+
+  it('walks patternProperties values', () => {
+    const schema = JSON.stringify({
+      patternProperties: {
+        '^[a-z]+$': {
+          properties: { localValue: {} },
+        },
+      },
+    });
+    expect(names(schema)).toEqual(['localValue']);
+  });
+
+  it('returns empty array on malformed JSON', () => {
+    expect(extractJsonSchemaSymbolsFromSource('not { valid json', 'broken.json')).toEqual([]);
+  });
+
+  it('returns empty array on non-object root (string, number, array)', () => {
+    expect(extractJsonSchemaSymbolsFromSource('"just a string"', 'x.json')).toEqual([]);
+    expect(extractJsonSchemaSymbolsFromSource('42', 'x.json')).toEqual([]);
+    expect(extractJsonSchemaSymbolsFromSource('[1,2,3]', 'x.json')).toEqual([]);
+  });
+
+  it('deduplicates symbols seen at multiple paths', () => {
+    const schema = JSON.stringify({
+      properties: {
+        a: { properties: { color: {} } },
+        b: { properties: { color: {} } },
+      },
+    });
+    const result = names(schema);
+    const colorCount = result.filter(n => n === 'color').length;
+    expect(colorCount).toBe(1);
+  });
+
+  it('marks every emitted symbol with kind=schema-property', () => {
+    const schema = JSON.stringify({
+      properties: { foo: {} },
+      definitions: { Bar: {} },
+    });
+    const symbols = extractJsonSchemaSymbolsFromSource(schema, 'x.json');
+    for (const s of symbols) expect(s.kind).toBe('schema-property');
+  });
+});

--- a/src/extractors/json-schema.ts
+++ b/src/extractors/json-schema.ts
@@ -1,0 +1,93 @@
+import type { ExtractedSymbol } from './types.js';
+
+type AnyObject = Record<string, unknown>;
+
+// Walks a parsed JSON Schema (draft-07, 2019-09, or 2020-12) and emits one
+// ExtractedSymbol per discoverable name: property keys, definition / $defs
+// keys, and string-valued enum members. Used by the symbol indexer to make
+// schema files first-class for cross-doc relevance scoring — without this,
+// schema-anchored docs (block.json, theme.json) cannot surface their canonical
+// contract via the symbol index.
+//
+// Intentionally NOT extracted: $ref values (paths, not symbol names),
+// type primitives ("string", "number", "boolean"), const literals (those
+// belong to the doc's value space, not to the symbol space).
+export function extractJsonSchemaSymbolsFromSource(
+  content: string,
+  _filePath: string,
+): ExtractedSymbol[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return [];
+  }
+  if (typeof parsed !== 'object' || parsed === null) return [];
+
+  const seen = new Set<string>();
+  const symbols: ExtractedSymbol[] = [];
+
+  function emit(name: string, signature: string): void {
+    if (!name || seen.has(name)) return;
+    seen.add(name);
+    symbols.push({ kind: 'schema-property', name, signature });
+  }
+
+  function walkChildren(arr: unknown): void {
+    if (!Array.isArray(arr)) return;
+    for (const item of arr) walk(item);
+  }
+
+  function walk(node: unknown): void {
+    if (typeof node !== 'object' || node === null) return;
+    const obj = node as AnyObject;
+
+    if (obj.properties && typeof obj.properties === 'object') {
+      const props = obj.properties as AnyObject;
+      for (const propName of Object.keys(props)) {
+        emit(propName, `property: ${propName}`);
+        walk(props[propName]);
+      }
+    }
+
+    if (obj.definitions && typeof obj.definitions === 'object') {
+      const defs = obj.definitions as AnyObject;
+      for (const defName of Object.keys(defs)) {
+        emit(defName, `definition: ${defName}`);
+        walk(defs[defName]);
+      }
+    }
+
+    if (obj.$defs && typeof obj.$defs === 'object') {
+      const defs = obj.$defs as AnyObject;
+      for (const defName of Object.keys(defs)) {
+        emit(defName, `definition: ${defName}`);
+        walk(defs[defName]);
+      }
+    }
+
+    if (Array.isArray(obj.enum)) {
+      for (const v of obj.enum) {
+        if (typeof v === 'string' && v.length > 0) {
+          emit(v, `enum-value: ${v}`);
+        }
+      }
+    }
+
+    walkChildren(obj.oneOf);
+    walkChildren(obj.anyOf);
+    walkChildren(obj.allOf);
+
+    if (obj.items) walk(obj.items);
+    if (obj.additionalProperties && typeof obj.additionalProperties === 'object') {
+      walk(obj.additionalProperties);
+    }
+    if (obj.patternProperties && typeof obj.patternProperties === 'object') {
+      const pp = obj.patternProperties as AnyObject;
+      for (const v of Object.values(pp)) walk(v);
+    }
+  }
+
+  walk(parsed);
+  return symbols;
+}

--- a/src/extractors/types.ts
+++ b/src/extractors/types.ts
@@ -1,4 +1,14 @@
-export type SymbolKind = 'function' | 'type' | 'interface' | 'const' | 'class' | 'enum';
+export type SymbolKind =
+  | 'function'
+  | 'type'
+  | 'interface'
+  | 'const'
+  | 'class'
+  | 'enum'
+  // Schema-derived names: properties, $defs/definitions, enum string values
+  // emitted by the JSON-schema extractor. Indexed for relevance scoring; not
+  // rendered as exported API surface.
+  | 'schema-property';
 
 export type JSDocInfo = {
   description?: string;

--- a/src/indexer/__tests__/symbol-index.test.ts
+++ b/src/indexer/__tests__/symbol-index.test.ts
@@ -21,13 +21,40 @@ function makeSource(files: Record<string, string>): CodeSource {
   };
 }
 
+// Test helper. Computes IDF from the supplied occurrences using a generous
+// default indexedFileCount so per-symbol IDF stays positive in the small
+// fixtures these tests use.
 function makeIndex(
   repoId: string,
   symbols: Record<string, string[]>,
   hooks: Record<string, string[]> = {},
   files: string[] = [],
+  indexedFileCount?: number,
 ): SymbolIndex {
-  return { repoId, commitSha: 'sha', builtAt: '2025-01-01T00:00:00Z', files, symbols, hooks };
+  const allOccurrencePaths = new Set<string>([
+    ...Object.values(symbols).flat(),
+    ...Object.values(hooks).flat(),
+    ...files,
+  ]);
+  const total = indexedFileCount ?? Math.max(allOccurrencePaths.size, 8);
+  const idfFor = (m: Record<string, string[]>): Record<string, number> => {
+    const out: Record<string, number> = {};
+    for (const [name, paths] of Object.entries(m)) {
+      out[name] = Math.max(0, Math.log((total + 1) / (paths.length + 1)));
+    }
+    return out;
+  };
+  return {
+    repoId,
+    commitSha: 'sha',
+    builtAt: '2025-01-01T00:00:00Z',
+    files,
+    symbols,
+    hooks,
+    symbolIdf: idfFor(symbols),
+    hookIdf: idfFor(hooks),
+    indexedFileCount: total,
+  };
 }
 
 // --- buildSymbolIndex ---
@@ -163,16 +190,57 @@ describe('buildSymbolIndex', () => {
     const { join } = await import('path');
     const cacheDir = mkdtempSync(`${tmpdir()}/symbol-index-test-stale-`);
 
-    // Write a stale cache file that lacks the `files` field (simulates old format)
-    const staleCache = { repoId: 'stale-repo', commitSha: 'test-sha-001', builtAt: '2024-01-01T00:00:00Z', symbols: {}, hooks: {} };
-    writeFileSync(join(cacheDir, 'stale-repo-test-sha-001.json'), JSON.stringify(staleCache));
+    // Write a stale cache file under the current versioned filename, missing
+    // the symbolIdf / indexedFileCount fields the new schema requires.
+    const staleCache = {
+      repoId:    'stale-repo',
+      commitSha: 'test-sha-001',
+      builtAt:   '2024-01-01T00:00:00Z',
+      files:     ['src/a.ts'],
+      symbols:   { alpha: ['src/a.ts'] },
+      hooks:     {},
+    };
+    writeFileSync(
+      join(cacheDir, 'stale-repo-test-sha-001-v2.json'),
+      JSON.stringify(staleCache),
+    );
 
     const source = makeSource({ 'src/a.ts': 'export function alpha() {}' });
     const index = await buildSymbolIndex('stale-repo', source, { cacheDir });
 
-    // Should have rebuilt (not used stale cache) so files field is present
-    expect(index.files).toContain('src/a.ts');
+    // Should have rebuilt (not used stale cache) so the new fields are present
+    expect(index.symbolIdf['alpha']).toBeGreaterThanOrEqual(0);
+    expect(typeof index.indexedFileCount).toBe('number');
     expect(index.symbols['alpha']).toEqual(['src/a.ts']);
+  });
+
+  it('indexes JSON schema files under schemas/ but skips other JSON files', async () => {
+    const source = makeSource({
+      'schemas/json/block.json': JSON.stringify({
+        properties: {
+          apiVersion: { type: 'integer' },
+          attributes: {
+            type: 'object',
+            properties: { source: { enum: ['attribute', 'text'] } },
+          },
+        },
+      }),
+      'package.json':            '{"name":"x","scripts":{"build":"tsc"}}',
+      'tsconfig.json':           '{"compilerOptions":{"strict":true}}',
+      'src/main.ts':             'export const main = 1;',
+    });
+
+    const index = await buildSymbolIndex('test-repo', source, { cacheDir: null });
+
+    // Schema properties are indexed, with their file path
+    expect(index.symbols['apiVersion']).toEqual(['schemas/json/block.json']);
+    expect(index.symbols['attributes']).toContain('schemas/json/block.json');
+    expect(index.symbols['source']).toContain('schemas/json/block.json');
+    // Enum string values are indexed too
+    expect(index.symbols['attribute']).toContain('schemas/json/block.json');
+    // package.json / tsconfig.json should be skipped (not in schemas/)
+    expect(index.symbols['build']).toBeUndefined();
+    expect(index.symbols['compilerOptions']).toBeUndefined();
   });
 });
 
@@ -192,13 +260,15 @@ describe('scoreFilesAcrossRepos', () => {
     }),
   };
 
-  it('scores files by symbol match count', () => {
+  it('ranks files higher when they match more doc symbols', () => {
     const scores = scoreFilesAcrossRepos(['registerBlockType', 'getBlockType'], indexes);
 
     const top = scores[0];
     expect(top.path).toBe('packages/blocks/src/registration.js');
-    // registerBlockType + getBlockType = 2 symbol matches
-    expect(top.score).toBe(2);
+    expect(top.score).toBeGreaterThan(0);
+    if (scores.length > 1) {
+      expect(top.score).toBeGreaterThan(scores[1].score);
+    }
   });
 
   it('includes matched symbol names in result', () => {
@@ -245,6 +315,90 @@ describe('scoreFilesAcrossRepos', () => {
     for (let i = 1; i < scores.length; i++) {
       expect(scores[i].score).toBeLessThanOrEqual(scores[i - 1].score);
     }
+  });
+
+  it('boosts schema files over implementation files for the same symbol', () => {
+    const idx = {
+      gutenberg: makeIndex(
+        'gutenberg',
+        {
+          color: [
+            'schemas/json/theme.json',
+            'packages/components/src/color-picker/index.js',
+          ],
+        },
+      ),
+    };
+    const scores = scoreFilesAcrossRepos(['color'], idx);
+    expect(scores[0].path).toBe('schemas/json/theme.json');
+    expect(scores[0].score).toBeGreaterThan(scores[1].score);
+  });
+
+  it('demotes story files vs equivalent implementation files', () => {
+    const idx = {
+      gutenberg: makeIndex(
+        'gutenberg',
+        {
+          name: [
+            'packages/blocks/src/api/registration.ts',
+            'packages/components/src/menu/stories/index.story.tsx',
+          ],
+        },
+      ),
+    };
+    const scores = scoreFilesAcrossRepos(['name'], idx);
+    expect(scores[0].path).toBe('packages/blocks/src/api/registration.ts');
+    expect(scores[1].path).toBe('packages/components/src/menu/stories/index.story.tsx');
+    expect(scores[0].score).toBeGreaterThan(scores[1].score * 5);
+  });
+
+  it('boosts types.ts and *.d.ts for surface contracts', () => {
+    const idx = {
+      gutenberg: makeIndex(
+        'gutenberg',
+        {
+          BlockConfiguration: [
+            'packages/blocks/src/types.ts',
+            'packages/blocks/src/api/registration.ts',
+          ],
+          ComponentProps: [
+            'packages/components/src/index.d.ts',
+            'packages/components/src/component.ts',
+          ],
+        },
+      ),
+    };
+    const typesScore = scoreFilesAcrossRepos(['BlockConfiguration'], idx)
+      .find(s => s.path.endsWith('types.ts'))!;
+    const regScore = scoreFilesAcrossRepos(['BlockConfiguration'], idx)
+      .find(s => s.path.endsWith('registration.ts'))!;
+    expect(typesScore.score).toBeGreaterThan(regScore.score);
+
+    const dtsScore = scoreFilesAcrossRepos(['ComponentProps'], idx)
+      .find(s => s.path.endsWith('.d.ts'))!;
+    const componentScore = scoreFilesAcrossRepos(['ComponentProps'], idx)
+      .find(s => s.path.endsWith('component.ts'))!;
+    expect(dtsScore.score).toBeGreaterThan(componentScore.score);
+  });
+
+  it('weights rare symbols higher than common ones (IDF)', () => {
+    // commonSymbol appears in many files; rareSymbol in one. Per IDF, the
+    // single file matching rareSymbol should outscore any single file that
+    // only matches commonSymbol.
+    const fileList = Array.from({ length: 50 }, (_, i) => `packages/x/src/file-${i}.ts`);
+    const symbols: Record<string, string[]> = {
+      commonSymbol: fileList,
+      rareSymbol:   ['packages/x/src/special.ts'],
+    };
+    const idx = {
+      gutenberg: makeIndex('gutenberg', symbols, {}, [], 100),
+    };
+
+    const scores = scoreFilesAcrossRepos(['commonSymbol', 'rareSymbol'], idx);
+
+    const rareScore = scores.find(s => s.path === 'packages/x/src/special.ts')!;
+    const commonScores = scores.filter(s => s.path.startsWith('packages/x/src/file-'));
+    expect(rareScore.score).toBeGreaterThan(commonScores[0].score);
   });
 });
 

--- a/src/indexer/symbol-index.ts
+++ b/src/indexer/symbol-index.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import pLimit from 'p-limit';
 import { extractSymbolsFromSource } from '../extractors/typescript.js';
 import { extractPhpSymbolsFromSource } from '../extractors/php.js';
+import { extractJsonSchemaSymbolsFromSource } from '../extractors/json-schema.js';
 import { extractHooksFromSource } from '../extractors/hooks.js';
 import type { CodeSource } from '../adapters/code-source/types.js';
 
@@ -16,6 +17,16 @@ export type SymbolIndex = {
   symbols: Record<string, string[]>;
   // hook name → file paths that fire it
   hooks: Record<string, string[]>;
+  // Inverse-document-frequency for each symbol/hook name across the indexed
+  // file set. Higher = the name is more selective. Computed once at build
+  // time and consulted by scoreFilesAcrossRepos so generic symbols (`name`,
+  // `style`, `icon`) contribute less to relevance than rare ones.
+  symbolIdf: Record<string, number>;
+  hookIdf: Record<string, number>;
+  // Total number of files actually indexed (used in IDF and not always equal
+  // to `files.length` — `files` includes everything listed in the repo,
+  // including `.json` files that are not in `schemas/`).
+  indexedFileCount: number;
 };
 
 export type ScoredFile = {
@@ -25,7 +36,11 @@ export type ScoredFile = {
   matchedSymbols: string[];
 };
 
-const INDEXABLE_EXTS = new Set(['ts', 'tsx', 'js', 'jsx', 'php']);
+// Cache schema version. Bump when the on-disk SymbolIndex shape changes so
+// older caches are treated as misses rather than crashing the loader.
+const CACHE_VERSION = 2;
+
+const INDEXABLE_EXTS = new Set(['ts', 'tsx', 'js', 'jsx', 'php', 'json']);
 
 // Build artifacts and generated output are not authoritative sources.
 // node_modules/.git/vendor are already excluded by GitCloneSource.listDir.
@@ -38,12 +53,66 @@ const SKIP_PATTERNS = [
   /(^|\/)[^/]+\.spec\.[jt]sx?$/,
 ];
 
+// JSON files are noisy by default (package.json, tsconfig.json, lockfiles,
+// fixtures) — only index those under a schemas/ directory, where they hold
+// authoritative property/definition names worth surfacing.
+function shouldExtractJson(path: string): boolean {
+  return /(^|\/)schemas\/.*\.json$/.test(path);
+}
+
 function shouldSkip(path: string): boolean {
-  return SKIP_PATTERNS.some(p => p.test(path));
+  if (SKIP_PATTERNS.some(p => p.test(path))) return true;
+  if (path.endsWith('.json') && !shouldExtractJson(path)) return true;
+  return false;
+}
+
+// Path-based weight applied per match in scoreFilesAcrossRepos. Schemas and
+// dedicated TypeScript surface-contract files are the most authoritative for
+// docs-vs-code drift checks; story/icon/fixture files match a lot of generic
+// symbols (`name`, `style`, `icon`) without being authoritative for any doc
+// claim, so they are heavily demoted.
+//
+// Multiplicative weighting (rather than dropping these files from the index
+// entirely) keeps the index complete: a story file may still be useful as
+// corroboration for a niche claim, just not as a primary mapping target.
+export function getFileWeight(path: string): number {
+  // Schema files are boosted because schema-anchored docs treat them as the
+  // canonical contract — but only modestly. A larger boost (5×) was tried and
+  // caused unrelated schemas (theme.json, wp-env.json) to dominate primary
+  // tiers for docs they had nothing to do with: any two schemas in the same
+  // corpus share generic property names (`name`, `style`, `url`, `link`),
+  // and a heavy boost amplified that coincidence past real implementation
+  // matches. 2× keeps schemas competitive without crowding out implementation.
+  if (/(^|\/)schemas\/.*\.json$/.test(path))               return 2.0;
+  if (/\.d\.ts$/.test(path))                               return 2.0;
+  if (/(^|\/)types\.ts$/.test(path))                       return 2.0;
+  if (/\.story\.[jt]sx?$/.test(path))                      return 0.1;
+  if (/(^|\/)stories\//.test(path))                        return 0.1;
+  if (/(^|\/)icons?\//.test(path))                         return 0.1;
+  if (/(^|\/)icon\.[jt]sx?$/.test(path))                   return 0.1;
+  if (/(^|\/)(fixtures|__fixtures__)\//.test(path))        return 0.1;
+  if (/(^|\/)examples?\//.test(path))                      return 0.5;
+  return 1.0;
+}
+
+function computeIdf(
+  occurrences: Record<string, string[]>,
+  totalFiles: number,
+): Record<string, number> {
+  const idf: Record<string, number> = {};
+  for (const [name, files] of Object.entries(occurrences)) {
+    // +1 in numerator and denominator to keep IDF well-behaved when a symbol
+    // occurs in every file. Clamp at 0 in case of inconsistent inputs (a
+    // symbol referencing more files than indexedFileCount, e.g. when a test
+    // helper builds an index with a low explicit total). The exact additive
+    // smoothing matters less than its monotonicity: rarer = higher score.
+    idf[name] = Math.max(0, Math.log((totalFiles + 1) / (files.length + 1)));
+  }
+  return idf;
 }
 
 function cachePath(cacheDir: string, repoId: string, sha: string): string {
-  return join(cacheDir, `${repoId}-${sha}.json`);
+  return join(cacheDir, `${repoId}-${sha}-v${CACHE_VERSION}.json`);
 }
 
 function loadCached(cacheDir: string, repoId: string, sha: string): SymbolIndex | null {
@@ -52,7 +121,16 @@ function loadCached(cacheDir: string, repoId: string, sha: string): SymbolIndex 
   try {
     const raw = JSON.parse(readFileSync(p, 'utf-8')) as Partial<SymbolIndex>;
     // Treat caches written by older versions (missing fields) as a miss.
-    if (!raw.symbols || !raw.hooks || !raw.files) return null;
+    if (
+      !raw.symbols ||
+      !raw.hooks ||
+      !raw.files ||
+      !raw.symbolIdf ||
+      !raw.hookIdf ||
+      typeof raw.indexedFileCount !== 'number'
+    ) {
+      return null;
+    }
     return raw as SymbolIndex;
   } catch {
     return null;
@@ -107,17 +185,24 @@ export async function buildSymbolIndex(
           const content = await codeSource.readFile(filePath);
           const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
 
-          const fileSymbols =
-            ext === 'php'
-              ? extractPhpSymbolsFromSource(content, filePath)
-              : extractSymbolsFromSource(content, filePath);
+          let fileSymbols;
+          if (ext === 'json') {
+            fileSymbols = extractJsonSchemaSymbolsFromSource(content, filePath);
+          } else if (ext === 'php') {
+            fileSymbols = extractPhpSymbolsFromSource(content, filePath);
+          } else {
+            fileSymbols = extractSymbolsFromSource(content, filePath);
+          }
 
           for (const sym of fileSymbols) {
             (symbols[sym.name] ??= []).push(filePath);
           }
 
-          for (const hook of extractHooksFromSource(content, filePath)) {
-            (hooks[hook.name] ??= []).push(filePath);
+          // Hook firing sites only exist in code, not in JSON schemas.
+          if (ext !== 'json') {
+            for (const hook of extractHooksFromSource(content, filePath)) {
+              (hooks[hook.name] ??= []).push(filePath);
+            }
           }
         } catch {
           // unreadable files are skipped silently
@@ -129,6 +214,10 @@ export async function buildSymbolIndex(
     ),
   );
 
+  const indexedFileCount = indexable.length;
+  const symbolIdf = computeIdf(symbols, indexedFileCount);
+  const hookIdf = computeIdf(hooks, indexedFileCount);
+
   const index: SymbolIndex = {
     repoId,
     commitSha,
@@ -136,37 +225,62 @@ export async function buildSymbolIndex(
     files: allFiles,
     symbols,
     hooks,
+    symbolIdf,
+    hookIdf,
+    indexedFileCount,
   };
 
   if (cacheDir) saveCache(cacheDir, index);
   return index;
 }
 
-// Score each file across all repos by the number of doc symbols it defines or fires.
-// Returns a list sorted descending by score.
+// Score each file across all repos by the IDF-weighted, file-weight-adjusted
+// match count of doc symbols it defines or fires. Returns a list sorted
+// descending by score.
+//
+// score(file) = sum_over_matched_symbols( fileWeight(file) * idf(symbol) )
+//
+// fileWeight demotes story/icon/fixture noise and boosts schema and surface-
+// contract files; idf demotes generic symbol matches (`name`, `style`) so a
+// schema property mentioned once in the corpus outweighs a generic word
+// mentioned in hundreds of files.
 export function scoreFilesAcrossRepos(
   docSymbols: string[],
   indexes: Record<string, SymbolIndex>,
 ): ScoredFile[] {
   const scores = new Map<string, ScoredFile>();
 
+  function addMatch(
+    repoId: string,
+    filePath: string,
+    sym: string,
+    weight: number,
+    idf: number,
+  ): void {
+    const key = `${repoId}:${filePath}`;
+    const entry = scores.get(key) ?? {
+      repo: repoId,
+      path: filePath,
+      score: 0,
+      matchedSymbols: [],
+    };
+    entry.score += weight * idf;
+    entry.matchedSymbols.push(sym);
+    scores.set(key, entry);
+  }
+
   for (const [repoId, index] of Object.entries(indexes)) {
     for (const sym of docSymbols) {
-      const filePaths = [
-        ...(index.symbols[sym] ?? []),
-        ...(index.hooks[sym] ?? []),
-      ];
-      for (const filePath of filePaths) {
-        const key = `${repoId}:${filePath}`;
-        const entry = scores.get(key) ?? {
-          repo: repoId,
-          path: filePath,
-          score: 0,
-          matchedSymbols: [],
-        };
-        entry.score++;
-        entry.matchedSymbols.push(sym);
-        scores.set(key, entry);
+      const symbolFiles = index.symbols[sym] ?? [];
+      const hookFiles = index.hooks[sym] ?? [];
+      const symIdf = index.symbolIdf[sym] ?? 0;
+      const hkIdf = index.hookIdf[sym] ?? 0;
+
+      for (const filePath of symbolFiles) {
+        addMatch(repoId, filePath, sym, getFileWeight(filePath), symIdf);
+      }
+      for (const filePath of hookFiles) {
+        addMatch(repoId, filePath, sym, getFileWeight(filePath), hkIdf);
       }
     }
   }


### PR DESCRIPTION
## Summary

Cherry-pick of commit `454cef3` from the stale `feat/auto-map-improvements` branch. Just the indexer quality improvements — none of that branch's other (unrelated) refactors.

Turns the AI-free auto-mapper from "0/3 correct primary on `block-metadata`" into "canonical authority in primary tier on all 5 sampled Gutenberg slugs".

Unblocks #66 (AI re-ranker) — without `'json'` in `INDEXABLE_EXTS`, `schemas/json/block.json` never enters the candidate list, so the re-ranker can't promote it.

## What changes

- **JSON schemas indexed** under `schemas/` paths (new `src/extractors/json-schema.ts`).
- **File weighting**: schemas 2×, `types.ts` / `*.d.ts` 2×, stories/icons/fixtures 0.1×.
- **IDF** at index-build time so rare matches outrank generic ones (`name`, `style`).
- **Diversity cap**: max 1 schema in primary tier (in `scripts/auto-map.ts`).
- Cache schema bumped to v2 — first run after merge rebuilds the symbol index (~few minutes on Gutenberg).

## Test plan

- [x] `npm run typecheck` — green.
- [x] `npm test` — 265 / 265 pass (19 files).
- [x] Smoke: `npx tsx scripts/auto-map.ts block-metadata --config config/gutenberg-block-api.json` → `schemas/json/block.json` in primary slot 1, score 503.93.
- [ ] Optional: same smoke on `block-bindings`, `block-patterns`, `block-transforms`, `block-variations` — canonical authority should appear in primary for each.

## Out of scope (deferred to follow-ups)

- AI re-ranker (#66) — separate PR after this lands. The `packages/deprecated/src/index.ts` and cross-schema collision FPs visible in the smoke test are exactly what that re-ranker is designed to fix.
- Promoting the file-weight table to config — wait until the second-site experiment shows weight patterns repeat across corpora.
- Slug-aware boost adjustment for docs whose canonical authority is implementation, not schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)