### PR TITLE
RALPH: minimal AI re-ranker for auto-map (#72)

### DIFF
--- a/scripts/auto-map.ts
+++ b/scripts/auto-map.ts
@@ -1,38 +1,49 @@
 /**
- * auto-map.ts — AI-free mapping bootstrap using symbol index + tree heuristics
+ * auto-map.ts — mapping bootstrap using symbol index + tree heuristics +
+ * (optional) AI re-ranker.
  *
  * Usage:
- *   npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write]
+ *   npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank]
  *
  * Builds a symbol index of all configured repos (cached by commit SHA),
  * cross-references the symbols named in the doc, and proposes a CodeTiers
- * mapping ranked by symbol coverage.
- *
- * Unlike bootstrap-mapping.ts, requires no ANTHROPIC_API_KEY.
+ * mapping ranked by symbol coverage. By default, the lexical top-N is then
+ * passed to an AI re-ranker that re-orders the candidates by semantic
+ * judgment and drops coincidental matches; `--no-rerank` skips this step
+ * and reproduces the pre-rerank lexical-only output.
  *
  * Flags:
  *   --config <path>   Config file (default: config/gutenberg-block-api.json)
  *   --write           Write result directly into the project mapping file
+ *   --no-rerank       Skip the AI re-ranker (lexical-only output)
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
+import Anthropic from '@anthropic-ai/sdk';
 import { loadConfig } from '../src/config/loader.js';
 import { createCodeSources } from '../src/adapters/index.js';
-import { ManifestEntrySchema, CodeTiersSchema, MappingSchema } from '../src/types/mapping.js';
+import { ManifestEntrySchema, MappingSchema } from '../src/types/mapping.js';
 import { extractDocSymbols } from '../src/adapters/validator/context-assembler.js';
 import {
   buildSymbolIndex,
   scoreFilesAcrossRepos,
-  findFilesByTreeHeuristic,
   type SymbolIndex,
 } from '../src/indexer/symbol-index.js';
+import { Reranker } from '../src/auto-map/rerank.js';
+import { buildTiersForSlug } from '../src/auto-map/orchestrator.js';
 
-function parseArgs(argv: string[]): { slug: string; configPath: string; write: boolean } {
+function parseArgs(argv: string[]): {
+  slug: string;
+  configPath: string;
+  write: boolean;
+  rerank: boolean;
+} {
   const args = argv.slice(2);
   let slug = '';
   let configPath = resolve('config/gutenberg-block-api.json');
   let write = false;
+  let rerank = true;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--config' && args[i + 1]) {
@@ -40,21 +51,23 @@ function parseArgs(argv: string[]): { slug: string; configPath: string; write: b
       i++;
     } else if (args[i] === '--write') {
       write = true;
+    } else if (args[i] === '--no-rerank') {
+      rerank = false;
     } else if (!slug && !args[i].startsWith('--')) {
       slug = args[i];
     }
   }
 
   if (!slug) {
-    console.error('Usage: npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write]');
+    console.error('Usage: npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank]');
     process.exit(1);
   }
 
-  return { slug, configPath, write };
+  return { slug, configPath, write, rerank };
 }
 
 async function main() {
-  const { slug, configPath, write } = parseArgs(process.argv);
+  const { slug, configPath, write, rerank } = parseArgs(process.argv);
   const config = await loadConfig(configPath);
 
   // 1. Fetch manifest and locate the entry for this slug
@@ -132,46 +145,33 @@ async function main() {
     ),
   );
 
-  // 5. Assemble tiers
-  //    primary   — top symbol-matched files (max 3, max 1 schema for diversity)
-  //    secondary — next best symbol-matched files (max 5)
-  //    context   — structurally related files via slug keyword matching (max 8)
+  // 5. Re-rank (optional) and assemble tiers.
   //
-  // The primary-tier schema cap exists because schemas accumulate matches
-  // on generic property names (`name`, `style`, `url`, `link`) shared across
-  // every schema in a corpus. Without the cap, schemas dominate all three
-  // primary slots even when the doc is not about any specific schema —
-  // pushing implementation files (the actual canon for many docs) out of
-  // primary. Allowing exactly one schema in primary surfaces the strongest
-  // schema candidate while leaving room for implementation files.
-  const selected = new Set<string>();
-  const isSchemaPath = (path: string): boolean => /(^|\/)schemas\/.*\.json$/.test(path);
-
-  function pickNext(n: number, maxSchemas: number = Infinity) {
-    const result: Array<{ repo: string; path: string }> = [];
-    let schemaCount = 0;
-    for (const f of scored) {
-      if (result.length >= n) break;
-      const key = `${f.repo}:${f.path}`;
-      if (selected.has(key)) continue;
-      if (isSchemaPath(f.path) && schemaCount >= maxSchemas) continue;
-      selected.add(key);
-      if (isSchemaPath(f.path)) schemaCount++;
-      result.push({ repo: f.repo, path: f.path });
+  // Default: AI re-ranker re-orders candidates by semantic judgment and
+  // drops coincidental matches (single-token English-word collisions,
+  // cross-schema property collisions). On API error / malformed output
+  // / missing API key, the Reranker emits a stderr warning and the
+  // orchestrator falls back to lexical-only output.
+  //
+  // `--no-rerank` skips the AI step entirely. Output is bit-identical to
+  // the pre-rerank lexical-only path.
+  let reranker: Reranker | null = null;
+  if (rerank) {
+    try {
+      reranker = new Reranker(config.validator.pass1Model, new Anthropic());
+    } catch (err) {
+      console.error(`AI re-rank failed: ${err instanceof Error ? err.message : String(err)}`);
+      reranker = null;
     }
-    return result;
   }
 
-  const primary = pickNext(3, 1);
-  const secondary = pickNext(5);
-
-  const contextCandidates = findFilesByTreeHeuristic(slug, allFilesByRepo, selected);
-  const context = contextCandidates.slice(0, 8).map(f => {
-    selected.add(`${f.repo}:${f.path}`);
-    return { repo: f.repo, path: f.path };
+  const tiers = await buildTiersForSlug({
+    docContent,
+    slug,
+    scored,
+    allFilesByRepo,
+    reranker,
   });
-
-  const tiers = CodeTiersSchema.parse({ primary, secondary, context });
 
   // 6. Output as JSON
   const output = { [slug]: tiers };

--- a/src/auto-map/__tests__/orchestrator.test.ts
+++ b/src/auto-map/__tests__/orchestrator.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
+
+import { buildTiersForSlug } from '../orchestrator.js';
+import { Reranker } from '../rerank.js';
+import type { ScoredFile } from '../../indexer/symbol-index.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAnthropicClient(responses: (Anthropic.Message | Error)[]): Anthropic {
+  let i = 0;
+  return {
+    messages: {
+      create: vi.fn(async () => {
+        const r = responses[i] ?? responses[responses.length - 1];
+        i++;
+        if (r instanceof Error) throw r;
+        return r;
+      }),
+    },
+  } as unknown as Anthropic;
+}
+
+function makeToolUseResponse(input: unknown): Anthropic.Message {
+  return {
+    id:           'msg',
+    type:         'message',
+    role:         'assistant',
+    model:        'claude-sonnet-4-6',
+    stop_reason:  'tool_use',
+    stop_sequence: null,
+    usage:        { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+    content: [
+      { type: 'tool_use', id: 'tu', name: 'report_rerank', input } as unknown as Anthropic.ToolUseBlock,
+    ],
+  } as unknown as Anthropic.Message;
+}
+
+// Schemas are deliberately placed at the top so the lexical-only path is
+// forced through the primary-tier diversity cap (max 1 schema).
+const SCORED: ScoredFile[] = [
+  { repo: 'gutenberg', path: 'schemas/json/block.json',                 score: 6.0, matchedSymbols: ['name', 'style']     },
+  { repo: 'gutenberg', path: 'schemas/json/theme.json',                 score: 5.5, matchedSymbols: ['name']              },
+  { repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js', score: 5.0, matchedSymbols: ['registerBlockType'] },
+  { repo: 'gutenberg', path: 'packages/blocks/src/api/parser.js',       score: 4.0, matchedSymbols: ['parse']             },
+  { repo: 'gutenberg', path: 'packages/deprecated/src/index.ts',        score: 3.0, matchedSymbols: ['deprecated']        },
+  { repo: 'gutenberg', path: 'packages/blocks/src/api/utils.ts',        score: 2.0, matchedSymbols: ['utils']             },
+];
+
+const ALL_FILES: Record<string, string[]> = {
+  gutenberg: [
+    'packages/blocks/src/api/registration.js',
+    'packages/blocks/src/api/parser.js',
+    'packages/blocks/src/api/utils.ts',
+    'packages/blocks/src/api/block-metadata.ts',
+    'packages/deprecated/src/index.ts',
+    'schemas/json/block.json',
+    'schemas/json/theme.json',
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// --no-rerank: lexical-only path (matches pre-rerank behaviour)
+// ---------------------------------------------------------------------------
+
+describe('orchestrator — --no-rerank (lexical-only)', () => {
+  it('produces tiers from pickNext + tree heuristic when reranker is null', async () => {
+    const tiers = await buildTiersForSlug({
+      docContent:     '# block-metadata',
+      slug:           'block-metadata',
+      scored:         SCORED,
+      allFilesByRepo: ALL_FILES,
+      reranker:       null,
+    });
+
+    // primary cap of 3 with at most 1 schema (the existing diversity rule)
+    expect(tiers.primary).toHaveLength(3);
+    expect(tiers.primary.map(f => f.path)).toContain('packages/blocks/src/api/registration.js');
+    const schemasInPrimary = tiers.primary.filter(f => /(^|\/)schemas\//.test(f.path));
+    expect(schemasInPrimary).toHaveLength(1);
+
+    // secondary up to 5
+    expect(tiers.secondary.length).toBeLessThanOrEqual(5);
+
+    // context populated by tree heuristic (slug-keyword match on `block-metadata`)
+    expect(tiers.context.length).toBeGreaterThan(0);
+    expect(tiers.context.map(f => f.path)).toContain('packages/blocks/src/api/block-metadata.ts');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rerank-on: tiers come from the rerank result
+// ---------------------------------------------------------------------------
+
+describe('orchestrator — rerank on, mocked LLM', () => {
+  it('projects rerank result into the locked CodeTiers shape (repo + path only)', async () => {
+    const toolInput = {
+      primary: [
+        { repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js', rationale: 'canonical impl', confidence: 0.95 },
+      ],
+      secondary: [
+        { repo: 'gutenberg', path: 'packages/blocks/src/api/parser.js', rationale: 'parser', confidence: 0.85 },
+      ],
+      context: [
+        { repo: 'gutenberg', path: 'packages/blocks/src/api/utils.ts', rationale: 'helpers', confidence: 0.75 },
+      ],
+      // The deprecated FP (issue #72 acceptance) is dropped, not in primary.
+      dropped: [
+        { repo: 'gutenberg', path: 'packages/deprecated/src/index.ts', reason: 'unrelated logger named `deprecated`' },
+        { repo: 'gutenberg', path: 'schemas/json/theme.json',          reason: 'cross-schema property collision (`name`)' },
+      ],
+    };
+    const client = makeAnthropicClient([makeToolUseResponse(toolInput)]);
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+
+    const tiers = await buildTiersForSlug({
+      docContent:     '# block-metadata',
+      slug:           'block-metadata',
+      scored:         SCORED,
+      allFilesByRepo: ALL_FILES,
+      reranker,
+    });
+
+    // The locked CodeTiers shape carries no rationale/confidence — only repo + path.
+    expect(tiers.primary).toEqual([{ repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js' }]);
+    expect(tiers.secondary).toEqual([{ repo: 'gutenberg', path: 'packages/blocks/src/api/parser.js' }]);
+    expect(tiers.context).toEqual([{ repo: 'gutenberg', path: 'packages/blocks/src/api/utils.ts' }]);
+    // Diagnosed FP is no longer in primary
+    expect(tiers.primary.map(f => f.path)).not.toContain('packages/deprecated/src/index.ts');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rerank-on but LLM fails: fallback to lexical-only
+// ---------------------------------------------------------------------------
+
+describe('orchestrator — rerank on but LLM fails', () => {
+  it('falls back to lexical-only tiers when the reranker returns null', async () => {
+    const client = makeAnthropicClient([new Error('SDK error')]);
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const tiers = await buildTiersForSlug({
+      docContent:     '# block-metadata',
+      slug:           'block-metadata',
+      scored:         SCORED,
+      allFilesByRepo: ALL_FILES,
+      reranker,
+    });
+
+    // Same as the --no-rerank path
+    expect(tiers.primary.map(f => f.path)).toContain('packages/blocks/src/api/registration.js');
+    expect(tiers.context.map(f => f.path)).toContain('packages/blocks/src/api/block-metadata.ts');
+    // The Reranker emitted the user-visible warning before falling back.
+    const allCalls = errSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(allCalls).toMatch(/AI re-rank failed/);
+
+    errSpy.mockRestore();
+  });
+});

--- a/src/auto-map/__tests__/rerank.test.ts
+++ b/src/auto-map/__tests__/rerank.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
+
+import { Reranker, RerankResultSchema, RERANK_TOOL } from '../rerank.js';
+import type { Candidate } from '../rerank.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAnthropicClient(responses: (Anthropic.Message | Error)[]): Anthropic {
+  let callCount = 0;
+  return {
+    messages: {
+      create: vi.fn(async () => {
+        const resp = responses[callCount] ?? responses[responses.length - 1];
+        callCount++;
+        if (resp instanceof Error) throw resp;
+        return resp;
+      }),
+    },
+  } as unknown as Anthropic;
+}
+
+function makeToolUseResponse(input: unknown): Anthropic.Message {
+  return {
+    id:           'msg_test',
+    type:         'message',
+    role:         'assistant',
+    model:        'claude-sonnet-4-6',
+    stop_reason:  'tool_use',
+    stop_sequence: null,
+    usage:        { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+    content: [
+      {
+        type:  'tool_use',
+        id:    'tu_1',
+        name:  'report_rerank',
+        input,
+      } as unknown as Anthropic.ToolUseBlock,
+    ],
+  } as unknown as Anthropic.Message;
+}
+
+function makeCandidate(repo: string, path: string, score: number, matchedSymbols: string[] = []): Candidate {
+  return { repo, path, score, matchedSymbols };
+}
+
+// ---------------------------------------------------------------------------
+// RerankResultSchema — Zod contract
+// ---------------------------------------------------------------------------
+
+describe('RerankResultSchema', () => {
+  it('accepts well-formed result with rationale + confidence per kept file and reason per dropped', () => {
+    const ok = RerankResultSchema.safeParse({
+      primary:   [{ repo: 'r', path: 'a.ts', rationale: 'r', confidence: 0.9 }],
+      secondary: [],
+      context:   [],
+      dropped:   [{ repo: 'r', path: 'b.ts', reason: 'noisy' }],
+    });
+    expect(ok.success).toBe(true);
+  });
+
+  it('rejects primary with more than 3 entries', () => {
+    const bad = RerankResultSchema.safeParse({
+      primary: Array.from({ length: 4 }, (_, i) => ({
+        repo: 'r', path: `${i}.ts`, rationale: 'r', confidence: 0.9,
+      })),
+      secondary: [], context: [], dropped: [],
+    });
+    expect(bad.success).toBe(false);
+  });
+
+  it('rejects confidence outside [0, 1]', () => {
+    const bad = RerankResultSchema.safeParse({
+      primary: [{ repo: 'r', path: 'a.ts', rationale: 'r', confidence: 1.5 }],
+      secondary: [], context: [], dropped: [],
+    });
+    expect(bad.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RERANK_TOOL — schema cap on tier sizes
+// ---------------------------------------------------------------------------
+
+describe('RERANK_TOOL schema', () => {
+  it('encodes tier caps structurally on the tool schema', () => {
+    const schema = RERANK_TOOL.input_schema as {
+      properties: {
+        primary:   { maxItems?: number };
+        secondary: { maxItems?: number };
+        context:   { maxItems?: number };
+      };
+    };
+    expect(schema.properties.primary.maxItems).toBe(3);
+    expect(schema.properties.secondary.maxItems).toBe(5);
+    expect(schema.properties.context.maxItems).toBe(8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reranker — happy path
+// ---------------------------------------------------------------------------
+
+describe('Reranker — happy path', () => {
+  it('returns the structured tool input on a well-formed response', async () => {
+    const toolInput = {
+      primary: [
+        { repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js', rationale: 'canonical impl', confidence: 0.95 },
+      ],
+      secondary: [
+        { repo: 'gutenberg', path: 'packages/blocks/src/api/parser.js', rationale: 'related parser', confidence: 0.8 },
+      ],
+      context: [
+        { repo: 'gutenberg', path: 'packages/blocks/src/api/utils.ts', rationale: 'helpers', confidence: 0.75 },
+      ],
+      dropped: [
+        { repo: 'gutenberg', path: 'packages/deprecated/src/index.ts', reason: 'unrelated logger named `deprecated`' },
+      ],
+    };
+    const client = makeAnthropicClient([makeToolUseResponse(toolInput)]);
+
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+    const result = await reranker.rerank({
+      doc:        '# block-metadata\n\nDocs about block metadata.',
+      slug:       'block-metadata',
+      candidates: [
+        makeCandidate('gutenberg', 'packages/blocks/src/api/registration.js', 5.0, ['registerBlockType']),
+        makeCandidate('gutenberg', 'packages/blocks/src/api/parser.js',       3.0, ['parse']),
+      ],
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.primary[0].path).toBe('packages/blocks/src/api/registration.js');
+    expect(result?.dropped[0].reason).toMatch(/deprecated/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reranker — failure modes return null sentinel
+// ---------------------------------------------------------------------------
+
+describe('Reranker — failure modes', () => {
+  it('returns null when the SDK throws', async () => {
+    const client = makeAnthropicClient([new Error('transient API failure')]);
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await reranker.rerank({
+      doc:        'doc',
+      slug:       'block-metadata',
+      candidates: [makeCandidate('r', 'a.ts', 1)],
+    });
+
+    expect(result).toBeNull();
+    warnSpy.mockRestore();
+  });
+
+  it('returns null when tool input fails schema validation', async () => {
+    const malformed = { primary: 'not an array', secondary: [], context: [], dropped: [] };
+    const client = makeAnthropicClient([makeToolUseResponse(malformed)]);
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await reranker.rerank({
+      doc:        'doc',
+      slug:       'block-metadata',
+      candidates: [makeCandidate('r', 'a.ts', 1)],
+    });
+
+    expect(result).toBeNull();
+    warnSpy.mockRestore();
+  });
+
+  it('returns null when the response carries no tool_use block', async () => {
+    const response = {
+      id:           'msg_test',
+      type:         'message',
+      role:         'assistant',
+      model:        'claude-sonnet-4-6',
+      stop_reason:  'end_turn',
+      stop_sequence: null,
+      usage:        { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+      content:      [{ type: 'text', text: 'no tool call here' } as unknown as Anthropic.TextBlock],
+    } as unknown as Anthropic.Message;
+
+    const client = makeAnthropicClient([response]);
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await reranker.rerank({
+      doc:        'doc',
+      slug:       'block-metadata',
+      candidates: [makeCandidate('r', 'a.ts', 1)],
+    });
+
+    expect(result).toBeNull();
+    warnSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reranker — SDK call shape (model + temperature + canonical order)
+// ---------------------------------------------------------------------------
+
+describe('Reranker — SDK call shape', () => {
+  it('passes the configured model and temperature 0 on every call', async () => {
+    const ok = makeToolUseResponse({
+      primary: [], secondary: [], context: [], dropped: [],
+    });
+    const client = makeAnthropicClient([ok]);
+    const createSpy = client.messages.create as Mock;
+
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+    await reranker.rerank({
+      doc:        'doc',
+      slug:       'block-metadata',
+      candidates: [makeCandidate('r', 'a.ts', 1)],
+    });
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(createSpy.mock.calls[0][0]).toMatchObject({
+      model:       'claude-sonnet-4-6',
+      temperature: 0,
+    });
+  });
+
+  it('serialises top-30 candidates in canonical order (score desc, then repo:path lex)', async () => {
+    const ok = makeToolUseResponse({
+      primary: [], secondary: [], context: [], dropped: [],
+    });
+    const client = makeAnthropicClient([ok]);
+    const createSpy = client.messages.create as Mock;
+
+    // Deliberately scrambled input order; tied scores forced to test the lex tiebreak.
+    const candidates: Candidate[] = [
+      makeCandidate('zeta',     'z.ts',  1.0, ['z']),
+      makeCandidate('alpha',    'a.ts',  5.0, ['a']),
+      makeCandidate('beta',     'b.ts',  5.0, ['b']),    // tied with alpha:a.ts on score
+      makeCandidate('alpha',    'b.ts',  5.0, ['b']),    // tied with above on score
+      makeCandidate('gutenberg', 'p.ts', 3.0, ['p']),
+    ];
+
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+    await reranker.rerank({
+      doc:        'doc',
+      slug:       'block-metadata',
+      candidates,
+    });
+
+    const userMsg = (createSpy.mock.calls[0][0] as { messages: { content: string }[] }).messages[0].content;
+    // canonical order: sort by score desc, then by `${repo}:${path}` lex asc
+    const orderedRepoPaths = [
+      'alpha:a.ts',     // 5.0
+      'alpha:b.ts',     // 5.0
+      'beta:b.ts',      // 5.0
+      'gutenberg:p.ts', // 3.0
+      'zeta:z.ts',      // 1.0
+    ];
+    let last = -1;
+    for (const rp of orderedRepoPaths) {
+      const idx = userMsg.indexOf(rp);
+      expect(idx).toBeGreaterThan(last);
+      last = idx;
+    }
+  });
+
+  it('caps the prompt at the top-30 candidates by score', async () => {
+    const ok = makeToolUseResponse({
+      primary: [], secondary: [], context: [], dropped: [],
+    });
+    const client = makeAnthropicClient([ok]);
+    const createSpy = client.messages.create as Mock;
+
+    const candidates: Candidate[] = Array.from({ length: 50 }, (_, i) =>
+      makeCandidate('r', `file-${String(i).padStart(2, '0')}.ts`, 100 - i, []),
+    );
+
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+    await reranker.rerank({ doc: 'doc', slug: 'x', candidates });
+
+    const userMsg = (createSpy.mock.calls[0][0] as { messages: { content: string }[] }).messages[0].content;
+    // Top 30 (highest scores) MUST appear; the 31st onwards MUST NOT.
+    expect(userMsg).toContain('file-00.ts');
+    expect(userMsg).toContain('file-29.ts');
+    expect(userMsg).not.toContain('file-30.ts');
+    expect(userMsg).not.toContain('file-49.ts');
+  });
+});

--- a/src/auto-map/orchestrator.ts
+++ b/src/auto-map/orchestrator.ts
@@ -1,0 +1,87 @@
+/**
+ * Orchestrator wiring for `scripts/auto-map.ts`.
+ *
+ * Composes: scored-files → (optional re-rank) → CodeTiers. Pulled out of the
+ * script so it can be exercised by a unit test without setting up the
+ * full clone/fetch pipeline.
+ *
+ * The lexical-only branch is byte-identical to the pre-rerank `auto-map.ts`
+ * tier-assembly logic (same `pickNext` + `findFilesByTreeHeuristic` mechanics,
+ * same primary schema cap of 1).
+ */
+import { CodeTiersSchema, type CodeTiers, type CodeFile } from '../types/mapping.js';
+import { findFilesByTreeHeuristic, type ScoredFile } from '../indexer/symbol-index.js';
+import type { Reranker, RerankResult } from './rerank.js';
+
+export type BuildTiersInput = {
+  docContent:     string;
+  slug:           string;
+  scored:         ScoredFile[];
+  allFilesByRepo: Record<string, string[]>;
+  // null = --no-rerank (skip the AI step entirely; lexical-only tiers).
+  // present = rerank is on; falls back to lexical-only on null result.
+  reranker:       Reranker | null;
+};
+
+export async function buildTiersForSlug(input: BuildTiersInput): Promise<CodeTiers> {
+  if (input.reranker) {
+    const result = await input.reranker.rerank({
+      doc:        input.docContent,
+      slug:       input.slug,
+      candidates: input.scored,
+    });
+    if (result) return rerankToCodeTiers(result);
+    // null = sentinel; the Reranker has already emitted a stderr warning.
+    // Fall through to the lexical-only path.
+  }
+  return lexicalTiers(input.scored, input.allFilesByRepo, input.slug);
+}
+
+// Project the rerank result down to the locked CodeTiers shape (repo + path).
+// Rationale, confidence, and dropped lists are slice-C concerns (audit file).
+function rerankToCodeTiers(result: RerankResult): CodeTiers {
+  const project = (xs: { repo: string; path: string }[]): CodeFile[] =>
+    xs.map(({ repo, path }) => ({ repo, path }));
+  return CodeTiersSchema.parse({
+    primary:   project(result.primary),
+    secondary: project(result.secondary),
+    context:   project(result.context),
+  });
+}
+
+// Pre-rerank assembly logic — preserved verbatim so `--no-rerank` is
+// bit-identical to historical auto-map output.
+function lexicalTiers(
+  scored: ScoredFile[],
+  allFilesByRepo: Record<string, string[]>,
+  slug: string,
+): CodeTiers {
+  const selected = new Set<string>();
+  const isSchemaPath = (path: string): boolean => /(^|\/)schemas\/.*\.json$/.test(path);
+
+  function pickNext(n: number, maxSchemas: number = Infinity): CodeFile[] {
+    const result: CodeFile[] = [];
+    let schemaCount = 0;
+    for (const f of scored) {
+      if (result.length >= n) break;
+      const key = `${f.repo}:${f.path}`;
+      if (selected.has(key)) continue;
+      if (isSchemaPath(f.path) && schemaCount >= maxSchemas) continue;
+      selected.add(key);
+      if (isSchemaPath(f.path)) schemaCount++;
+      result.push({ repo: f.repo, path: f.path });
+    }
+    return result;
+  }
+
+  const primary   = pickNext(3, 1);
+  const secondary = pickNext(5);
+
+  const contextCandidates = findFilesByTreeHeuristic(slug, allFilesByRepo, selected);
+  const context = contextCandidates.slice(0, 8).map(f => {
+    selected.add(`${f.repo}:${f.path}`);
+    return { repo: f.repo, path: f.path };
+  });
+
+  return CodeTiersSchema.parse({ primary, secondary, context });
+}

--- a/src/auto-map/rerank.ts
+++ b/src/auto-map/rerank.ts
@@ -1,0 +1,262 @@
+/**
+ * AI re-ranker for `scripts/auto-map.ts`.
+ *
+ * The lexical indexer (`src/indexer/symbol-index.ts`) is the retrieval layer:
+ * cheap, deterministic, and it returns a top-N candidate list. This module is
+ * the ranking layer: it asks an LLM to re-order the candidates by semantic
+ * judgment, drop coincidental matches, and attach a short rationale per kept
+ * file plus a reason per dropped file.
+ *
+ * Public surface is intentionally small — `rerank({ doc, slug, candidates })`
+ * returns a typed `RerankResult` or `null` (sentinel) on any failure mode
+ * (SDK error, missing API key, malformed tool input, no tool_use block in
+ * response). The orchestrator falls back to the lexical-only mapping on null
+ * and emits a clear stderr warning to the user.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Tier caps (mirror CodeTiersSchema in src/types/mapping.ts)
+// ---------------------------------------------------------------------------
+const PRIMARY_MAX   = 3;
+const SECONDARY_MAX = 5;
+const CONTEXT_MAX   = 8;
+
+// Top-N candidates passed to the model. Matches the PRD figure (#71). The
+// indexer's rest is dropped before serialisation so prompt size is bounded.
+const TOP_N_CANDIDATES = 30;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type Candidate = {
+  repo:           string;
+  path:           string;
+  score:          number;
+  matchedSymbols: string[];
+};
+
+const KeptFileSchema = z.object({
+  repo:       z.string(),
+  path:       z.string(),
+  rationale:  z.string(),
+  confidence: z.number().min(0).max(1),
+});
+
+const DroppedFileSchema = z.object({
+  repo:   z.string(),
+  path:   z.string(),
+  reason: z.string(),
+});
+
+export const RerankResultSchema = z.object({
+  primary:   z.array(KeptFileSchema).max(PRIMARY_MAX),
+  secondary: z.array(KeptFileSchema).max(SECONDARY_MAX),
+  context:   z.array(KeptFileSchema).max(CONTEXT_MAX),
+  dropped:   z.array(DroppedFileSchema),
+});
+
+export type RerankResult = z.infer<typeof RerankResultSchema>;
+export type KeptFile     = z.infer<typeof KeptFileSchema>;
+export type DroppedFile  = z.infer<typeof DroppedFileSchema>;
+
+// ---------------------------------------------------------------------------
+// Tool schema
+// ---------------------------------------------------------------------------
+
+export const RERANK_TOOL: Anthropic.Tool = {
+  name: 'report_rerank',
+  description:
+    'Report the re-ranked auto-map result: which candidate files belong in primary / secondary / context, with a one-line rationale and confidence per kept file, plus a parallel list of dropped files with a one-line reason each.',
+  input_schema: {
+    type: 'object' as const,
+    required: ['primary', 'secondary', 'context', 'dropped'],
+    properties: {
+      primary: {
+        type: 'array',
+        maxItems: PRIMARY_MAX,
+        items: {
+          type: 'object',
+          required: ['repo', 'path', 'rationale', 'confidence'],
+          properties: {
+            repo:       { type: 'string' },
+            path:       { type: 'string' },
+            rationale:  { type: 'string' },
+            confidence: { type: 'number', minimum: 0, maximum: 1 },
+          },
+        },
+      },
+      secondary: {
+        type: 'array',
+        maxItems: SECONDARY_MAX,
+        items: {
+          type: 'object',
+          required: ['repo', 'path', 'rationale', 'confidence'],
+          properties: {
+            repo:       { type: 'string' },
+            path:       { type: 'string' },
+            rationale:  { type: 'string' },
+            confidence: { type: 'number', minimum: 0, maximum: 1 },
+          },
+        },
+      },
+      context: {
+        type: 'array',
+        maxItems: CONTEXT_MAX,
+        items: {
+          type: 'object',
+          required: ['repo', 'path', 'rationale', 'confidence'],
+          properties: {
+            repo:       { type: 'string' },
+            path:       { type: 'string' },
+            rationale:  { type: 'string' },
+            confidence: { type: 'number', minimum: 0, maximum: 1 },
+          },
+        },
+      },
+      dropped: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['repo', 'path', 'reason'],
+          properties: {
+            repo:   { type: 'string' },
+            path:   { type: 'string' },
+            reason: { type: 'string' },
+          },
+        },
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// System prompt
+// ---------------------------------------------------------------------------
+
+const SYSTEM_PROMPT = `You are an AI re-ranker for documentation-vs-code mapping. Given a documentation page and a ranked list of candidate source files (lexical retrieval — symbol-name overlap), classify each candidate file into one of:
+
+  - primary   (max 3): the canonical implementation files for the doc's subject. The reader should read these first to understand the doc.
+  - secondary (max 5): files that meaningfully implement, parse, validate, or test the same subject. Useful for cross-checking the doc.
+  - context   (max 8): related files that establish surrounding behaviour (helpers, types, integration points). Not authoritative on their own.
+  - dropped:  files that match lexically but are NOT about this doc's subject (English-word collisions, cross-schema property collisions, generic identifiers). Each dropped file MUST carry a one-line reason naming the noise pattern.
+
+Each kept file carries a one-line rationale (what the file is and why this tier) and a confidence in [0, 1]:
+  - 0.9–1.0: the file is unambiguously canonical for this doc.
+  - 0.7–0.9: the file is clearly related but not the single canonical source.
+  - 0.5–0.7: plausibly related but the reviewer should double-check.
+  - < 0.5:   keep only if no better candidate exists; flag for human review.
+
+Drop, do not keep at low confidence, when:
+  - the only match is a single English word that happens to be a code identifier (e.g. "deprecated" matches a logging utility because the file exports a function literally called \`deprecated\`),
+  - the only match is a generic JSON-schema property name shared across multiple unrelated schemas (\`name\`, \`style\`, \`title\`, \`version\`),
+  - the file is in a fixtures, examples, stories, or icon directory and matches only generic identifiers.
+
+Use the \`report_rerank\` tool to return your result. Do not include files that were not in the candidate list.`;
+
+// ---------------------------------------------------------------------------
+// Reranker
+// ---------------------------------------------------------------------------
+
+export type RerankInput = {
+  doc:        string;
+  slug:       string;
+  candidates: Candidate[];
+};
+
+export class Reranker {
+  private readonly model:       string;
+  private readonly anthropic:   Anthropic;
+  private readonly temperature: number;
+
+  constructor(model: string, anthropic: Anthropic, options: { temperature?: number } = {}) {
+    this.model       = model;
+    this.anthropic   = anthropic;
+    this.temperature = options.temperature ?? 0;
+  }
+
+  async rerank(input: RerankInput): Promise<RerankResult | null> {
+    const userContent = buildUserContent(input);
+
+    let response: Anthropic.Message;
+    try {
+      response = await this.anthropic.messages.create({
+        model:       this.model,
+        max_tokens:  4096,
+        temperature: this.temperature,
+        system: [
+          {
+            type:          'text',
+            text:          SYSTEM_PROMPT,
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+        messages:    [{ role: 'user', content: userContent }],
+        tools:       [RERANK_TOOL],
+        tool_choice: { type: 'tool', name: 'report_rerank' },
+      });
+    } catch (err) {
+      console.error(`AI re-rank failed: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    }
+
+    for (const block of response.content) {
+      if (block.type !== 'tool_use' || block.name !== 'report_rerank') continue;
+      const parsed = RerankResultSchema.safeParse(block.input);
+      if (!parsed.success) {
+        console.error(`AI re-rank failed: tool input did not match schema: ${parsed.error.toString()}`);
+        return null;
+      }
+      return parsed.data;
+    }
+
+    console.error('AI re-rank failed: response carried no report_rerank tool_use block');
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Canonical order + prompt assembly
+// ---------------------------------------------------------------------------
+
+// Top-N in canonical order: score desc, then `repo:path` lex asc. Ties broken
+// deterministically so the cache key (slice B) and the prompt itself are
+// reproducible regardless of upstream iteration order.
+function canonicalOrder(candidates: Candidate[]): Candidate[] {
+  return [...candidates]
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      const ka = `${a.repo}:${a.path}`;
+      const kb = `${b.repo}:${b.path}`;
+      return ka.localeCompare(kb);
+    })
+    .slice(0, TOP_N_CANDIDATES);
+}
+
+function buildUserContent({ doc, slug, candidates }: RerankInput): string {
+  const ordered = canonicalOrder(candidates);
+  const rows = ordered.map(c => {
+    const symbols = c.matchedSymbols.length > 0
+      ? ` (matched: ${c.matchedSymbols.slice(0, 8).join(', ')})`
+      : '';
+    return `- ${c.repo}:${c.path}  score=${c.score.toFixed(2)}${symbols}`;
+  }).join('\n');
+
+  return `## Documentation slug: ${slug}
+
+## Documentation content
+
+${doc}
+
+---
+
+## Candidate files (top ${ordered.length}, lexical retrieval — sorted by score desc)
+
+${rows || '(no candidates)'}
+
+---
+
+Re-rank these candidates into primary / secondary / context / dropped using the \`report_rerank\` tool.`;
+}


### PR DESCRIPTION
## Summary

Adds the slice-A vertical for issue #71's AI re-ranker PRD: a `Reranker`
deep module that re-orders `auto-map.ts`'s lexical top-30 candidates via an
LLM tool-use call, plus a `--no-rerank` flag that bypasses the AI step
entirely. The re-ranker returns rationale + confidence per kept file and
reason per dropped file inside its own `RerankResult` schema; the
orchestrator projects that down to the locked `CodeTiers` shape (repo +
path) — slice C will introduce the audit side channel that surfaces the
dropped tier and the rationale/confidence pairs.

On SDK error, missing API key, malformed tool input, or no `tool_use` block
in the response, the `Reranker` returns `null` and emits an
`AI re-rank failed: …` stderr warning; the orchestrator falls back to the
pre-rerank lexical-only path. This is failure-mode mitigation, not silent
degradation — the user always sees the warning.

The locked Zod schemas in `src/types/mapping.ts` (`CodeFile`, `CodeTiers`,
`Mapping`) are untouched. `RerankResult` is its own schema living inside
the new `src/auto-map/` module.

Closes #72

## Changes

- `scripts/auto-map.ts` — adds `--no-rerank` flag, constructs the `Reranker` (default-on), composes through `buildTiersForSlug`.
- `src/auto-map/rerank.ts` — new module: `Reranker` class + `RerankResultSchema` + `RERANK_TOOL` + canonical-order serializer.
- `src/auto-map/orchestrator.ts` — new module: `buildTiersForSlug` composes scored-files → (optional) rerank → `CodeTiers`. The lexical-only branch is preserved verbatim from the pre-rerank script.
- `src/auto-map/__tests__/rerank.test.ts` — happy path, sentinel-on-SDK-error, sentinel-on-malformed-tool-input, sentinel-on-no-tool-use, model + temperature 0 passed to SDK, top-30 cap, canonical order pinned.
- `src/auto-map/__tests__/orchestrator.test.ts` — `--no-rerank` lexical path; rerank-on path projecting result into locked `CodeTiers`; rerank-on-but-LLM-fails fallback to lexical with stderr warning visible.

## How to test

1. `git fetch origin && git checkout ralph/72-rerank-slice-a`
2. `npm install`
3. `npm test` — should be green; the new tests in `src/auto-map/__tests__/` pin:
   - `Reranker` happy path returns the structured tool input as `RerankResult`.
   - `Reranker` returns `null` on SDK throw, malformed tool input, missing `tool_use` block.
   - SDK is always called with the configured model and `temperature: 0`.
   - The user message lists the top-30 candidates in canonical order (score desc, then `repo:path` lex asc).
   - `--no-rerank` (`reranker: null`) produces tiers via the legacy `pickNext` + `findFilesByTreeHeuristic` path.
   - Rerank-on path projects `RerankResult` into the locked `CodeTiers` shape (repo + path only — rationale/confidence stripped).
   - Rerank-on-but-failure path falls back to lexical and emits `AI re-rank failed: …` on stderr.
4. `npm run typecheck` — clean.
5. (Optional, requires `ANTHROPIC_API_KEY` and network — operator-side only) `npx tsx scripts/auto-map.ts block-metadata --config config/gutenberg-block-api.json` should produce a re-ranked mapping where `packages/deprecated/src/index.ts` is no longer in primary; `npx tsx scripts/auto-map.ts block-metadata --config config/gutenberg-block-api.json --no-rerank` should match pre-PR `main` output bit-for-bit.

Expected outcome: green CI, narrow diff confined to `scripts/auto-map.ts` and `src/auto-map/**`, and the `--no-rerank` path is byte-identical to the pre-rerank lexical assembly logic.

## Out of scope

- Cache (slice B, #73) — re-running the same auto-map invocation will today make a fresh LLM call. The cache module is the next slice.
- Audit file + `--explain` (slice C, #74) — `RerankResult` carries rationale/confidence/dropped, but they are dropped on the floor when projecting to `CodeTiers`. Slice C will persist them.
- `--review` flag (slice D, #75).
- The locked `CodeFile` / `CodeTiers` / `Mapping` schemas in `src/types/mapping.ts` — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
