### PR TITLE
RALPH: re-ranker cache for determinism + cost (#73)

### DIFF
--- a/scripts/auto-map.ts
+++ b/scripts/auto-map.ts
@@ -31,6 +31,7 @@ import {
   type SymbolIndex,
 } from '../src/indexer/symbol-index.js';
 import { Reranker } from '../src/auto-map/rerank.js';
+import { RerankCache } from '../src/auto-map/rerank-cache.js';
 import { buildTiersForSlug } from '../src/auto-map/orchestrator.js';
 
 function parseArgs(argv: string[]): {
@@ -165,12 +166,17 @@ async function main() {
     }
   }
 
+  // Cache is always on when re-rank is on (no `--no-cache` flag — cost is
+  // negligible and identical re-runs should be free + bit-identical).
+  const cache = reranker ? new RerankCache() : null;
+
   const tiers = await buildTiersForSlug({
     docContent,
     slug,
     scored,
     allFilesByRepo,
     reranker,
+    cache,
   });
 
   // 6. Output as JSON

--- a/src/auto-map/__tests__/orchestrator.test.ts
+++ b/src/auto-map/__tests__/orchestrator.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import type Anthropic from '@anthropic-ai/sdk';
 
 import { buildTiersForSlug } from '../orchestrator.js';
 import { Reranker } from '../rerank.js';
+import { RerankCache } from '../rerank-cache.js';
 import type { ScoredFile } from '../../indexer/symbol-index.js';
 
 // ---------------------------------------------------------------------------
@@ -129,6 +133,105 @@ describe('orchestrator — rerank on, mocked LLM', () => {
     expect(tiers.context).toEqual([{ repo: 'gutenberg', path: 'packages/blocks/src/api/utils.ts' }]);
     // Diagnosed FP is no longer in primary
     expect(tiers.primary.map(f => f.path)).not.toContain('packages/deprecated/src/index.ts');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rerank-on with cache: second invocation is a cache hit (no LLM call)
+// ---------------------------------------------------------------------------
+
+describe('orchestrator — cache hit skips the LLM call', () => {
+  it('makes exactly one LLM call across two consecutive invocations on identical inputs', async () => {
+    const toolInput = {
+      primary:   [{ repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js', rationale: 'canonical impl', confidence: 0.95 }],
+      secondary: [{ repo: 'gutenberg', path: 'packages/blocks/src/api/parser.js',       rationale: 'parser',         confidence: 0.85 }],
+      context:   [{ repo: 'gutenberg', path: 'packages/blocks/src/api/utils.ts',        rationale: 'helpers',        confidence: 0.75 }],
+      dropped:   [{ repo: 'gutenberg', path: 'packages/deprecated/src/index.ts',        reason:    'unrelated logger named `deprecated`' }],
+    };
+    const client = makeAnthropicClient([makeToolUseResponse(toolInput)]);
+    const createSpy = client.messages.create as ReturnType<typeof vi.fn>;
+
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+    const cache    = new RerankCache(mkdtempSync(join(tmpdir(), 'orch-cache-test-')));
+
+    const inputs = {
+      docContent:     '# block-metadata',
+      slug:           'block-metadata',
+      scored:         SCORED,
+      allFilesByRepo: ALL_FILES,
+      reranker,
+      cache,
+    };
+
+    const t1 = await buildTiersForSlug(inputs);
+    const t2 = await buildTiersForSlug(inputs);
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    // Both invocations produce the same tiers projected from the cached result.
+    expect(t2).toEqual(t1);
+    expect(t1.primary).toEqual([{ repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js' }]);
+  });
+
+  it('produces a fresh LLM call when the cache is null (caching disabled)', async () => {
+    const toolInput = {
+      primary: [], secondary: [], context: [], dropped: [],
+    };
+    // Two responses queued — if the orchestrator only made one LLM call we'd
+    // still see it pinned by toHaveBeenCalledTimes(2) below.
+    const client = makeAnthropicClient([
+      makeToolUseResponse(toolInput),
+      makeToolUseResponse(toolInput),
+    ]);
+    const createSpy = client.messages.create as ReturnType<typeof vi.fn>;
+
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+
+    const inputs = {
+      docContent:     '# block-metadata',
+      slug:           'block-metadata',
+      scored:         SCORED,
+      allFilesByRepo: ALL_FILES,
+      reranker,
+      cache:          null,
+    };
+
+    await buildTiersForSlug(inputs);
+    await buildTiersForSlug(inputs);
+
+    expect(createSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not store a sentinel result on rerank failure (next run still calls LLM)', async () => {
+    const toolInput = {
+      primary: [], secondary: [], context: [], dropped: [],
+    };
+    // First call throws (sentinel returned, fallback to lexical), second
+    // call succeeds with valid input.
+    const client = makeAnthropicClient([
+      new Error('transient API failure'),
+      makeToolUseResponse(toolInput),
+    ]);
+    const createSpy = client.messages.create as ReturnType<typeof vi.fn>;
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+    const cache    = new RerankCache(mkdtempSync(join(tmpdir(), 'orch-cache-fail-')));
+
+    const inputs = {
+      docContent:     '# block-metadata',
+      slug:           'block-metadata',
+      scored:         SCORED,
+      allFilesByRepo: ALL_FILES,
+      reranker,
+      cache,
+    };
+
+    await buildTiersForSlug(inputs);
+    await buildTiersForSlug(inputs);
+
+    // Cache miss + miss (sentinel not stored) means the LLM was called twice.
+    expect(createSpy).toHaveBeenCalledTimes(2);
+    errSpy.mockRestore();
   });
 });
 

--- a/src/auto-map/__tests__/rerank-cache.test.ts
+++ b/src/auto-map/__tests__/rerank-cache.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, readdirSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  RerankCache,
+  RERANK_CACHE_VERSION,
+} from '../rerank-cache.js';
+import type { Candidate, RerankResult } from '../rerank.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tmpCacheDir(): string {
+  return mkdtempSync(join(tmpdir(), 'rerank-cache-test-'));
+}
+
+function makeCandidate(repo: string, path: string, score: number, matchedSymbols: string[] = []): Candidate {
+  return { repo, path, score, matchedSymbols };
+}
+
+const SAMPLE_RESULT: RerankResult = {
+  primary: [
+    { repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js', rationale: 'canonical impl', confidence: 0.95 },
+  ],
+  secondary: [
+    { repo: 'gutenberg', path: 'packages/blocks/src/api/parser.js', rationale: 'parser', confidence: 0.85 },
+  ],
+  context: [
+    { repo: 'gutenberg', path: 'packages/blocks/src/api/utils.ts', rationale: 'helpers', confidence: 0.7 },
+  ],
+  dropped: [
+    { repo: 'gutenberg', path: 'packages/deprecated/src/index.ts', reason: 'unrelated logger named `deprecated`' },
+  ],
+};
+
+const SAMPLE_DOC = '# block-metadata\n\nDocs about block metadata.';
+const SAMPLE_MODEL = 'claude-sonnet-4-6';
+
+const SAMPLE_CANDIDATES: Candidate[] = [
+  makeCandidate('gutenberg', 'packages/blocks/src/api/registration.js', 5.0, ['registerBlockType']),
+  makeCandidate('gutenberg', 'packages/blocks/src/api/parser.js',       3.0, ['parse']),
+  makeCandidate('gutenberg', 'packages/deprecated/src/index.ts',        1.0, ['deprecated']),
+];
+
+// ---------------------------------------------------------------------------
+// get / put round-trip
+// ---------------------------------------------------------------------------
+
+describe('RerankCache — get/put round-trip', () => {
+  it('returns null for a missing key', () => {
+    const cache = new RerankCache(tmpCacheDir());
+    const key = cache.keyFor({ docContent: SAMPLE_DOC, candidates: SAMPLE_CANDIDATES, model: SAMPLE_MODEL });
+    expect(cache.get(key)).toBeNull();
+  });
+
+  it('round-trips a stored RerankResult', () => {
+    const cache = new RerankCache(tmpCacheDir());
+    const key = cache.keyFor({ docContent: SAMPLE_DOC, candidates: SAMPLE_CANDIDATES, model: SAMPLE_MODEL });
+    cache.put(key, SAMPLE_RESULT);
+
+    const recovered = cache.get(key);
+    expect(recovered).toEqual(SAMPLE_RESULT);
+  });
+
+  it('creates the cache directory on first put', () => {
+    const dir = join(tmpCacheDir(), 'nested-not-yet-created');
+    expect(existsSync(dir)).toBe(false);
+
+    const cache = new RerankCache(dir);
+    const key = cache.keyFor({ docContent: SAMPLE_DOC, candidates: SAMPLE_CANDIDATES, model: SAMPLE_MODEL });
+    cache.put(key, SAMPLE_RESULT);
+
+    expect(existsSync(dir)).toBe(true);
+    expect(readdirSync(dir).length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Key derivation — what changes the key, what doesn't
+// ---------------------------------------------------------------------------
+
+describe('RerankCache — key derivation', () => {
+  it('produces different keys for different doc content (cache miss across docs)', () => {
+    const cache = new RerankCache(tmpCacheDir());
+    const k1 = cache.keyFor({ docContent: 'doc A', candidates: SAMPLE_CANDIDATES, model: SAMPLE_MODEL });
+    const k2 = cache.keyFor({ docContent: 'doc B', candidates: SAMPLE_CANDIDATES, model: SAMPLE_MODEL });
+    expect(k1).not.toBe(k2);
+
+    cache.put(k1, SAMPLE_RESULT);
+    expect(cache.get(k2)).toBeNull();
+  });
+
+  it('produces the same key when candidates are reordered (canonical sort)', () => {
+    const cache = new RerankCache(tmpCacheDir());
+
+    const ordered = [...SAMPLE_CANDIDATES];
+    const scrambled = [SAMPLE_CANDIDATES[2], SAMPLE_CANDIDATES[0], SAMPLE_CANDIDATES[1]];
+
+    const k1 = cache.keyFor({ docContent: SAMPLE_DOC, candidates: ordered,   model: SAMPLE_MODEL });
+    const k2 = cache.keyFor({ docContent: SAMPLE_DOC, candidates: scrambled, model: SAMPLE_MODEL });
+    expect(k1).toBe(k2);
+  });
+
+  it('produces the same key when score-tied candidates appear in different orders (lex tiebreak)', () => {
+    const cache = new RerankCache(tmpCacheDir());
+
+    const a: Candidate[] = [
+      makeCandidate('alpha', 'a.ts', 5.0),
+      makeCandidate('beta',  'b.ts', 5.0),
+      makeCandidate('alpha', 'b.ts', 5.0),
+    ];
+    const b: Candidate[] = [
+      makeCandidate('beta',  'b.ts', 5.0),
+      makeCandidate('alpha', 'b.ts', 5.0),
+      makeCandidate('alpha', 'a.ts', 5.0),
+    ];
+
+    const ka = cache.keyFor({ docContent: SAMPLE_DOC, candidates: a, model: SAMPLE_MODEL });
+    const kb = cache.keyFor({ docContent: SAMPLE_DOC, candidates: b, model: SAMPLE_MODEL });
+    expect(ka).toBe(kb);
+  });
+
+  it('produces different keys for different model names', () => {
+    const cache = new RerankCache(tmpCacheDir());
+    const k1 = cache.keyFor({ docContent: SAMPLE_DOC, candidates: SAMPLE_CANDIDATES, model: 'claude-sonnet-4-6' });
+    const k2 = cache.keyFor({ docContent: SAMPLE_DOC, candidates: SAMPLE_CANDIDATES, model: 'claude-opus-4-7' });
+    expect(k1).not.toBe(k2);
+  });
+
+  it('produces different keys when a candidate is added/removed', () => {
+    const cache = new RerankCache(tmpCacheDir());
+    const k1 = cache.keyFor({ docContent: SAMPLE_DOC, candidates: SAMPLE_CANDIDATES, model: SAMPLE_MODEL });
+    const k2 = cache.keyFor({
+      docContent: SAMPLE_DOC,
+      candidates: [...SAMPLE_CANDIDATES, makeCandidate('gutenberg', 'extra.ts', 0.5)],
+      model:      SAMPLE_MODEL,
+    });
+    expect(k1).not.toBe(k2);
+  });
+
+  it('uses a 16-char hex key (filename-friendly)', () => {
+    const cache = new RerankCache(tmpCacheDir());
+    const key = cache.keyFor({ docContent: SAMPLE_DOC, candidates: SAMPLE_CANDIDATES, model: SAMPLE_MODEL });
+    expect(key).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Version handling — bumping invalidates older entries
+// ---------------------------------------------------------------------------
+
+describe('RerankCache — version invalidation', () => {
+  it('treats a cache file with a different version field as a miss', () => {
+    const dir = tmpCacheDir();
+    const cache = new RerankCache(dir);
+    const key = cache.keyFor({ docContent: SAMPLE_DOC, candidates: SAMPLE_CANDIDATES, model: SAMPLE_MODEL });
+
+    // Hand-write a stale cache file under the same key but with a wrong version.
+    writeFileSync(
+      join(dir, `${key}.json`),
+      JSON.stringify({ version: RERANK_CACHE_VERSION + 99, result: SAMPLE_RESULT }),
+    );
+
+    expect(cache.get(key)).toBeNull();
+  });
+
+  it('treats a malformed cache file as a miss without throwing', () => {
+    const dir = tmpCacheDir();
+    const cache = new RerankCache(dir);
+    const key = cache.keyFor({ docContent: SAMPLE_DOC, candidates: SAMPLE_CANDIDATES, model: SAMPLE_MODEL });
+
+    writeFileSync(join(dir, `${key}.json`), '{ this is not valid json');
+
+    expect(cache.get(key)).toBeNull();
+  });
+
+  it('treats a cache file with a result that fails schema validation as a miss', () => {
+    const dir = tmpCacheDir();
+    const cache = new RerankCache(dir);
+    const key = cache.keyFor({ docContent: SAMPLE_DOC, candidates: SAMPLE_CANDIDATES, model: SAMPLE_MODEL });
+
+    writeFileSync(
+      join(dir, `${key}.json`),
+      JSON.stringify({
+        version: RERANK_CACHE_VERSION,
+        result:  { primary: 'not an array', secondary: [], context: [], dropped: [] },
+      }),
+    );
+
+    expect(cache.get(key)).toBeNull();
+  });
+});

--- a/src/auto-map/orchestrator.ts
+++ b/src/auto-map/orchestrator.ts
@@ -12,6 +12,7 @@
 import { CodeTiersSchema, type CodeTiers, type CodeFile } from '../types/mapping.js';
 import { findFilesByTreeHeuristic, type ScoredFile } from '../indexer/symbol-index.js';
 import type { Reranker, RerankResult } from './rerank.js';
+import type { RerankCache } from './rerank-cache.js';
 
 export type BuildTiersInput = {
   docContent:     string;
@@ -21,20 +22,47 @@ export type BuildTiersInput = {
   // null = --no-rerank (skip the AI step entirely; lexical-only tiers).
   // present = rerank is on; falls back to lexical-only on null result.
   reranker:       Reranker | null;
+  // Optional content-addressed cache. When supplied alongside a reranker,
+  // the orchestrator wraps lookup → call-on-miss → store around the LLM call:
+  // a hit skips the LLM entirely. `null` / `undefined` disables caching.
+  cache?:         RerankCache | null;
 };
 
 export async function buildTiersForSlug(input: BuildTiersInput): Promise<CodeTiers> {
   if (input.reranker) {
-    const result = await input.reranker.rerank({
-      doc:        input.docContent,
-      slug:       input.slug,
-      candidates: input.scored,
-    });
+    const result = await rerankWithCache(input.reranker, input.cache ?? null, input);
     if (result) return rerankToCodeTiers(result);
     // null = sentinel; the Reranker has already emitted a stderr warning.
     // Fall through to the lexical-only path.
   }
   return lexicalTiers(input.scored, input.allFilesByRepo, input.slug);
+}
+
+// Cache key is derived from docContent + canonically-sorted candidates +
+// model. Slug is intentionally NOT in the key — the doc content already
+// encodes it, and including it would split the cache for renamed slugs that
+// kept identical doc bodies.
+async function rerankWithCache(
+  reranker: Reranker,
+  cache:    RerankCache | null,
+  input:    BuildTiersInput,
+): Promise<RerankResult | null> {
+  const key = cache?.keyFor({
+    docContent: input.docContent,
+    candidates: input.scored,
+    model:      reranker.model,
+  });
+  if (cache && key) {
+    const hit = cache.get(key);
+    if (hit) return hit;
+  }
+  const result = await reranker.rerank({
+    doc:        input.docContent,
+    slug:       input.slug,
+    candidates: input.scored,
+  });
+  if (result && cache && key) cache.put(key, result);
+  return result;
 }
 
 // Project the rerank result down to the locked CodeTiers shape (repo + path).

--- a/src/auto-map/rerank-cache.ts
+++ b/src/auto-map/rerank-cache.ts
@@ -1,0 +1,95 @@
+/**
+ * Content-addressed disk cache for the AI re-ranker.
+ *
+ * Cache key is `sha256(docContent + sortedCandidates + model)`, truncated to
+ * 16 hex chars for filename hygiene. Re-running auto-map on the same corpus
+ * with the same doc, the same candidate list (regardless of input order), and
+ * the same model is bit-identical and free.
+ *
+ * Disk layout mirrors `tmp/symbol-index-cache/`: one JSON file per key under
+ * the configured cache directory (default `tmp/auto-map-rerank-cache/`). Each
+ * file carries a `version` field; when this module's `RERANK_CACHE_VERSION`
+ * changes, older entries are treated as misses rather than crashing the
+ * loader. Malformed or schema-mismatched files are also treated as misses.
+ */
+import { createHash } from 'crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+import {
+  RerankResultSchema,
+  type Candidate,
+  type RerankResult,
+} from './rerank.js';
+
+// Bump when the on-disk envelope or the RerankResult shape changes.
+export const RERANK_CACHE_VERSION = 1;
+
+export type RerankCacheKeyInput = {
+  docContent: string;
+  candidates: Candidate[];
+  model:      string;
+};
+
+function defaultCacheDir(): string {
+  return join(process.cwd(), 'tmp', 'auto-map-rerank-cache');
+}
+
+// Canonical candidate order: score desc, then `repo:path` lex asc. Matches
+// the canonicalOrder() used inside the Reranker prompt — same input, same
+// hash, regardless of upstream iteration order.
+function canonicalCandidates(candidates: Candidate[]): Candidate[] {
+  return [...candidates].sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return `${a.repo}:${a.path}`.localeCompare(`${b.repo}:${b.path}`);
+  });
+}
+
+export class RerankCache {
+  private readonly cacheDir: string;
+
+  constructor(cacheDir: string = defaultCacheDir()) {
+    this.cacheDir = cacheDir;
+  }
+
+  keyFor(input: RerankCacheKeyInput): string {
+    const ordered = canonicalCandidates(input.candidates).map(c => ({
+      repo:           c.repo,
+      path:           c.path,
+      score:          c.score,
+      matchedSymbols: c.matchedSymbols,
+    }));
+    const payload = JSON.stringify({
+      doc:        input.docContent,
+      candidates: ordered,
+      model:      input.model,
+    });
+    return createHash('sha256').update(payload).digest('hex').slice(0, 16);
+  }
+
+  get(key: string): RerankResult | null {
+    const path = this.pathFor(key);
+    if (!existsSync(path)) return null;
+    let raw: unknown;
+    try {
+      raw = JSON.parse(readFileSync(path, 'utf-8'));
+    } catch {
+      return null;
+    }
+    if (typeof raw !== 'object' || raw === null) return null;
+    const envelope = raw as { version?: unknown; result?: unknown };
+    if (envelope.version !== RERANK_CACHE_VERSION) return null;
+    const parsed = RerankResultSchema.safeParse(envelope.result);
+    return parsed.success ? parsed.data : null;
+  }
+
+  put(key: string, result: RerankResult): void {
+    mkdirSync(this.cacheDir, { recursive: true });
+    const envelope = { version: RERANK_CACHE_VERSION, result };
+    writeFileSync(this.pathFor(key), JSON.stringify(envelope));
+  }
+
+  private pathFor(key: string): string {
+    return join(this.cacheDir, `${key}.json`);
+  }
+}

--- a/src/auto-map/rerank.ts
+++ b/src/auto-map/rerank.ts
@@ -167,7 +167,7 @@ export type RerankInput = {
 };
 
 export class Reranker {
-  private readonly model:       string;
+  public  readonly model:       string;
   private readonly anthropic:   Anthropic;
   private readonly temperature: number;
 


### PR DESCRIPTION
## Summary

Adds a content-addressed disk cache around the AI re-ranker introduced in slice A (#72). Cache key is `sha256(docContent + sortedCandidates + model)` — re-running auto-map on the same corpus with the same doc, the same candidate list (regardless of input order), and the same resolved model is bit-identical and free. `--no-rerank` continues to bypass both re-ranker and cache (no `--no-cache` flag — cost is negligible and identical re-runs should always be free).

The cache is a deep module (`get(key) → RerankResult | null`, `put(key, result) → void`); the orchestrator wires `lookup → call-on-miss → store` around the LLM call. Disk layout mirrors `tmp/symbol-index-cache/`: one JSON file per key under `tmp/auto-map-rerank-cache/`, each carrying a `version` field so bumps invalidate older entries instead of crashing the loader. Malformed/schema-mismatched files are also treated as misses.

Closes #73

## Changes

- `src/auto-map/rerank-cache.ts` — new `RerankCache` class (key derivation + get/put + version-checked envelope).
- `src/auto-map/__tests__/rerank-cache.test.ts` — 12 unit tests against a temp dir: missing-key, round-trip, dir-on-first-use, doc-sensitivity, candidate-order-insensitivity (canonical sort), score-tied lex tiebreak, model-sensitivity, candidate-add/remove, 16-char hex shape, version mismatch, malformed JSON, schema-failure-on-recovery.
- `src/auto-map/orchestrator.ts` — adds optional `cache?: RerankCache | null` to `BuildTiersInput`. When supplied with a reranker, the orchestrator consults the cache before calling the LLM and stores non-null results after.
- `src/auto-map/__tests__/orchestrator.test.ts` — three new orchestrator-level tests: cache hit skips the second LLM call (`toHaveBeenCalledTimes(1)` across two invocations), `cache: null` disables caching (two LLM calls), failed rerank does NOT poison the cache (next run still calls LLM).
- `src/auto-map/rerank.ts` — exposes `Reranker.model` as `public readonly` so the orchestrator can derive the cache key from it.
- `scripts/auto-map.ts` — constructs a default `RerankCache()` whenever the reranker is on (cache always on when re-rank is on).

## How to test

1. `git fetch origin && git checkout ralph/73-rerank-cache`
2. `npm install`
3. `npm test` — 294 tests green, including 12 new `rerank-cache` tests and 3 new orchestrator cache tests.
4. `npm run typecheck` — clean.
5. Optional manual smoke: with `ANTHROPIC_API_KEY` exported, run `npx tsx scripts/auto-map.ts block-metadata --config config/gutenberg-block-api.json` twice. The first run should show "AI re-rank…" output and produce a JSON file under `tmp/auto-map-rerank-cache/<16-hex>.json`; the second run should reproduce identical stdout output without any new LLM activity.
6. Confirm `tmp/auto-map-rerank-cache/` is gitignored: `git check-ignore tmp/auto-map-rerank-cache/anything.json` should print the path (covered by the existing `tmp/` rule in `.gitignore`).

Expected outcome: tests + typecheck both green; the second auto-map invocation on identical inputs is a cache hit (no LLM call) and produces bit-identical output.

## Out of scope

- The `--no-cache` flag (PRD/issue intentionally omits it — cache is always on when re-rank is on).
- Audit file (`mappings/<site>.audit.json`) — that is slice C (#74).
- `--explain` / `--review` flags — slices C (#74) and D (#75).
- `Mapping` / `CodeTiers` / `CodeFile` schemas in `src/types/` remain locked and untouched.
