### PR TITLE
RALPH: audit output + --explain flag for auto-map (#74)

### DIFF
--- a/scripts/auto-map.ts
+++ b/scripts/auto-map.ts
@@ -3,7 +3,7 @@
  * (optional) AI re-ranker.
  *
  * Usage:
- *   npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank]
+ *   npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank] [--explain]
  *
  * Builds a symbol index of all configured repos (cached by commit SHA),
  * cross-references the symbols named in the doc, and proposes a CodeTiers
@@ -14,8 +14,9 @@
  *
  * Flags:
  *   --config <path>   Config file (default: config/gutenberg-block-api.json)
- *   --write           Write result directly into the project mapping file
- *   --no-rerank       Skip the AI re-ranker (lexical-only output)
+ *   --write           Write the canonical mapping AND the audit file (when re-rank ran)
+ *   --no-rerank       Skip the AI re-ranker (lexical-only output, no audit)
+ *   --explain         Print rationale per kept file and reason per dropped file to stdout
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
@@ -32,19 +33,22 @@ import {
 } from '../src/indexer/symbol-index.js';
 import { Reranker } from '../src/auto-map/rerank.js';
 import { RerankCache } from '../src/auto-map/rerank-cache.js';
-import { buildTiersForSlug } from '../src/auto-map/orchestrator.js';
+import { buildTiersForSlug, auditPathFor } from '../src/auto-map/orchestrator.js';
+import { AuditWriter } from '../src/auto-map/audit-writer.js';
 
 function parseArgs(argv: string[]): {
   slug: string;
   configPath: string;
   write: boolean;
   rerank: boolean;
+  explain: boolean;
 } {
   const args = argv.slice(2);
   let slug = '';
   let configPath = resolve('config/gutenberg-block-api.json');
   let write = false;
   let rerank = true;
+  let explain = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--config' && args[i + 1]) {
@@ -54,21 +58,23 @@ function parseArgs(argv: string[]): {
       write = true;
     } else if (args[i] === '--no-rerank') {
       rerank = false;
+    } else if (args[i] === '--explain') {
+      explain = true;
     } else if (!slug && !args[i].startsWith('--')) {
       slug = args[i];
     }
   }
 
   if (!slug) {
-    console.error('Usage: npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank]');
+    console.error('Usage: npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank] [--explain]');
     process.exit(1);
   }
 
-  return { slug, configPath, write, rerank };
+  return { slug, configPath, write, rerank, explain };
 }
 
 async function main() {
-  const { slug, configPath, write, rerank } = parseArgs(process.argv);
+  const { slug, configPath, write, rerank, explain } = parseArgs(process.argv);
   const config = await loadConfig(configPath);
 
   // 1. Fetch manifest and locate the entry for this slug
@@ -170,7 +176,7 @@ async function main() {
   // negligible and identical re-runs should be free + bit-identical).
   const cache = reranker ? new RerankCache() : null;
 
-  const tiers = await buildTiersForSlug({
+  const { tiers, rerankResult } = await buildTiersForSlug({
     docContent,
     slug,
     scored,
@@ -182,6 +188,21 @@ async function main() {
   // 6. Output as JSON
   const output = { [slug]: tiers };
   console.log(JSON.stringify(output, null, 2));
+
+  // 7. --explain: render rationale per kept file and reason per dropped file.
+  // Has no effect under --no-rerank or when the AI step failed (no audit
+  // material). The Reranker has already emitted a stderr warning in those
+  // cases.
+  const auditWriter = new AuditWriter();
+  if (explain) {
+    if (rerankResult) {
+      console.log('\n' + auditWriter.formatExplain(rerankResult));
+    } else {
+      console.error(
+        '\n--explain: no rationale to print (re-rank was skipped or failed).',
+      );
+    }
+  }
 
   if (write) {
     let existing: Record<string, unknown> = {};
@@ -198,6 +219,15 @@ async function main() {
     const merged = { ...existing, ...output };
     writeFileSync(config.mappingPath, JSON.stringify(merged, null, 2) + '\n');
     console.error(`\nWrote mapping for "${slug}" to ${config.mappingPath}`);
+
+    // Audit is the side channel of the AI re-ranker. It is written iff
+    // re-rank ran AND succeeded (rerankResult !== null). --no-rerank leaves
+    // any existing audit untouched.
+    if (rerankResult) {
+      const auditPath = auditPathFor(config.mappingPath);
+      auditWriter.writeAudit(auditPath, slug, rerankResult);
+      console.error(`Wrote audit for "${slug}" to ${auditPath}`);
+    }
   } else {
     console.error(
       `\nReview the above and merge into ${config.mappingPath}, or re-run with --write`,

--- a/src/auto-map/__tests__/audit-writer.test.ts
+++ b/src/auto-map/__tests__/audit-writer.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, readFileSync, writeFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { AuditWriter, MappingAuditSchema, AUDIT_WARNING } from '../audit-writer.js';
+import type { RerankResult } from '../rerank.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tmpAuditPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'audit-writer-test-'));
+  return join(dir, 'sample-site.audit.json');
+}
+
+const RESULT_A: RerankResult = {
+  primary: [
+    { repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js', rationale: 'canonical impl', confidence: 0.95 },
+  ],
+  secondary: [
+    { repo: 'gutenberg', path: 'packages/blocks/src/api/parser.js', rationale: 'parser', confidence: 0.85 },
+  ],
+  context: [
+    { repo: 'gutenberg', path: 'packages/blocks/src/api/utils.ts', rationale: 'helpers', confidence: 0.75 },
+  ],
+  dropped: [
+    { repo: 'gutenberg', path: 'packages/deprecated/src/index.ts', reason: 'unrelated logger named `deprecated`' },
+    { repo: 'gutenberg', path: 'schemas/json/theme.json',          reason: 'cross-schema property collision (`name`)' },
+  ],
+};
+
+const RESULT_B: RerankResult = {
+  primary: [
+    { repo: 'gutenberg', path: 'packages/blocks/src/api/serializer.js', rationale: 'serializer entry', confidence: 0.9 },
+  ],
+  secondary: [],
+  context: [],
+  dropped: [],
+};
+
+// ---------------------------------------------------------------------------
+// MappingAuditSchema round-trip
+// ---------------------------------------------------------------------------
+
+describe('MappingAuditSchema', () => {
+  it('round-trips through writeAudit + read + parse', () => {
+    const writer = new AuditWriter();
+    const path = tmpAuditPath();
+
+    writer.writeAudit(path, 'block-metadata', RESULT_A);
+
+    const raw = JSON.parse(readFileSync(path, 'utf-8'));
+    const parsed = MappingAuditSchema.safeParse(raw);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.audits['block-metadata']).toEqual(RESULT_A);
+    }
+  });
+
+  it('rejects an envelope missing the version field', () => {
+    const bad = MappingAuditSchema.safeParse({ audits: { x: RESULT_A } });
+    expect(bad.success).toBe(false);
+  });
+
+  it('rejects audit entries that fail RerankResultSchema (e.g. confidence > 1)', () => {
+    const bad = MappingAuditSchema.safeParse({
+      version: 1,
+      audits: {
+        x: {
+          primary: [{ repo: 'r', path: 'p', rationale: 'r', confidence: 1.5 }],
+          secondary: [], context: [], dropped: [],
+        },
+      },
+    });
+    expect(bad.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeAudit — file format + warning header
+// ---------------------------------------------------------------------------
+
+describe('AuditWriter.writeAudit', () => {
+  it('writes a file with a top-level _comment warning against hand-editing', () => {
+    const writer = new AuditWriter();
+    const path = tmpAuditPath();
+    writer.writeAudit(path, 'block-metadata', RESULT_A);
+
+    const raw = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(typeof raw._comment).toBe('string');
+    expect(raw._comment).toBe(AUDIT_WARNING);
+    expect(raw._comment).toMatch(/do not (hand-)?edit/i);
+  });
+
+  it('writes the version field and the slug-keyed audits map', () => {
+    const writer = new AuditWriter();
+    const path = tmpAuditPath();
+    writer.writeAudit(path, 'block-metadata', RESULT_A);
+
+    const raw = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(raw.version).toBe(1);
+    expect(raw.audits).toBeDefined();
+    expect(raw.audits['block-metadata']).toEqual(RESULT_A);
+  });
+
+  it('preserves prior slug entries when writing a different slug (merge, not overwrite)', () => {
+    const writer = new AuditWriter();
+    const path = tmpAuditPath();
+
+    writer.writeAudit(path, 'slug-a', RESULT_A);
+    writer.writeAudit(path, 'slug-b', RESULT_B);
+
+    const parsed = MappingAuditSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
+    expect(parsed.audits['slug-a']).toEqual(RESULT_A);
+    expect(parsed.audits['slug-b']).toEqual(RESULT_B);
+  });
+
+  it('overwrites the same slug if rewritten', () => {
+    const writer = new AuditWriter();
+    const path = tmpAuditPath();
+
+    writer.writeAudit(path, 'slug-a', RESULT_A);
+    writer.writeAudit(path, 'slug-a', RESULT_B);
+
+    const parsed = MappingAuditSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
+    expect(parsed.audits['slug-a']).toEqual(RESULT_B);
+    expect(Object.keys(parsed.audits)).toEqual(['slug-a']);
+  });
+
+  it('emits slug keys in deterministic (sorted) order', () => {
+    const writer = new AuditWriter();
+    const path = tmpAuditPath();
+
+    writer.writeAudit(path, 'zeta',  RESULT_B);
+    writer.writeAudit(path, 'alpha', RESULT_A);
+    writer.writeAudit(path, 'mu',    RESULT_B);
+
+    const text = readFileSync(path, 'utf-8');
+    const idxAlpha = text.indexOf('"alpha"');
+    const idxMu    = text.indexOf('"mu"');
+    const idxZeta  = text.indexOf('"zeta"');
+    expect(idxAlpha).toBeGreaterThan(0);
+    expect(idxMu).toBeGreaterThan(idxAlpha);
+    expect(idxZeta).toBeGreaterThan(idxMu);
+  });
+
+  it('treats a malformed existing audit file as empty (does not throw, fresh write replaces it)', () => {
+    const writer = new AuditWriter();
+    const path = tmpAuditPath();
+    writeFileSync(path, '{ this is not valid json');
+
+    expect(() => writer.writeAudit(path, 'slug-a', RESULT_A)).not.toThrow();
+    const parsed = MappingAuditSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
+    expect(parsed.audits['slug-a']).toEqual(RESULT_A);
+  });
+
+  it('creates the parent directory if it does not yet exist', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'audit-mkdir-'));
+    const path = join(dir, 'nested', 'sub', 'site.audit.json');
+    const writer = new AuditWriter();
+    writer.writeAudit(path, 'slug-a', RESULT_A);
+    expect(existsSync(path)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatExplain — stdout renderer
+// ---------------------------------------------------------------------------
+
+describe('AuditWriter.formatExplain', () => {
+  it('includes rationale per kept file and reason per dropped file', () => {
+    const writer = new AuditWriter();
+    const out = writer.formatExplain(RESULT_A);
+
+    // Rationales (kept files)
+    expect(out).toContain('canonical impl');
+    expect(out).toContain('parser');
+    expect(out).toContain('helpers');
+    // Reasons (dropped files)
+    expect(out).toContain('unrelated logger named `deprecated`');
+    expect(out).toContain('cross-schema property collision (`name`)');
+  });
+
+  it('labels each kept file with its tier and confidence', () => {
+    const writer = new AuditWriter();
+    const out = writer.formatExplain(RESULT_A);
+
+    expect(out).toMatch(/primary/i);
+    expect(out).toMatch(/secondary/i);
+    expect(out).toMatch(/context/i);
+    expect(out).toContain('0.95');
+    expect(out).toContain('0.85');
+    expect(out).toContain('0.75');
+  });
+
+  it('renders kept files in fixed (primary → secondary → context) order', () => {
+    const writer = new AuditWriter();
+    const out = writer.formatExplain(RESULT_A);
+
+    const idxPrimary   = out.indexOf('canonical impl');
+    const idxSecondary = out.indexOf('parser');
+    const idxContext   = out.indexOf('helpers');
+    expect(idxPrimary).toBeGreaterThan(-1);
+    expect(idxSecondary).toBeGreaterThan(idxPrimary);
+    expect(idxContext).toBeGreaterThan(idxSecondary);
+  });
+
+  it('produces identical output for identical input (deterministic)', () => {
+    const writer = new AuditWriter();
+    const a = writer.formatExplain(RESULT_A);
+    const b = writer.formatExplain(RESULT_A);
+    expect(a).toBe(b);
+  });
+
+  it('omits the dropped-files block when no files were dropped', () => {
+    const writer = new AuditWriter();
+    const out = writer.formatExplain(RESULT_B);
+    expect(out).not.toMatch(/dropped/i);
+  });
+});

--- a/src/auto-map/__tests__/orchestrator.test.ts
+++ b/src/auto-map/__tests__/orchestrator.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
-import { mkdtempSync } from 'fs';
+import { mkdtempSync, existsSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import type Anthropic from '@anthropic-ai/sdk';
 
-import { buildTiersForSlug } from '../orchestrator.js';
+import { buildTiersForSlug, auditPathFor } from '../orchestrator.js';
 import { Reranker } from '../rerank.js';
 import { RerankCache } from '../rerank-cache.js';
+import { AuditWriter, MappingAuditSchema } from '../audit-writer.js';
 import type { ScoredFile } from '../../indexer/symbol-index.js';
 
 // ---------------------------------------------------------------------------
@@ -71,7 +72,7 @@ const ALL_FILES: Record<string, string[]> = {
 
 describe('orchestrator — --no-rerank (lexical-only)', () => {
   it('produces tiers from pickNext + tree heuristic when reranker is null', async () => {
-    const tiers = await buildTiersForSlug({
+    const { tiers, rerankResult } = await buildTiersForSlug({
       docContent:     '# block-metadata',
       slug:           'block-metadata',
       scored:         SCORED,
@@ -91,6 +92,9 @@ describe('orchestrator — --no-rerank (lexical-only)', () => {
     // context populated by tree heuristic (slug-keyword match on `block-metadata`)
     expect(tiers.context.length).toBeGreaterThan(0);
     expect(tiers.context.map(f => f.path)).toContain('packages/blocks/src/api/block-metadata.ts');
+
+    // No rerank ran -> no audit material is exposed.
+    expect(rerankResult).toBeNull();
   });
 });
 
@@ -119,7 +123,7 @@ describe('orchestrator — rerank on, mocked LLM', () => {
     const client = makeAnthropicClient([makeToolUseResponse(toolInput)]);
     const reranker = new Reranker('claude-sonnet-4-6', client);
 
-    const tiers = await buildTiersForSlug({
+    const { tiers, rerankResult } = await buildTiersForSlug({
       docContent:     '# block-metadata',
       slug:           'block-metadata',
       scored:         SCORED,
@@ -133,6 +137,11 @@ describe('orchestrator — rerank on, mocked LLM', () => {
     expect(tiers.context).toEqual([{ repo: 'gutenberg', path: 'packages/blocks/src/api/utils.ts' }]);
     // Diagnosed FP is no longer in primary
     expect(tiers.primary.map(f => f.path)).not.toContain('packages/deprecated/src/index.ts');
+
+    // The rerank result is exposed alongside tiers so the script can write
+    // the audit file and render --explain.
+    expect(rerankResult).not.toBeNull();
+    expect(rerankResult?.dropped.map(f => f.path)).toContain('packages/deprecated/src/index.ts');
   });
 });
 
@@ -169,7 +178,9 @@ describe('orchestrator — cache hit skips the LLM call', () => {
     expect(createSpy).toHaveBeenCalledTimes(1);
     // Both invocations produce the same tiers projected from the cached result.
     expect(t2).toEqual(t1);
-    expect(t1.primary).toEqual([{ repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js' }]);
+    expect(t1.tiers.primary).toEqual([{ repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js' }]);
+    // The cached path also surfaces the underlying RerankResult.
+    expect(t1.rerankResult).not.toBeNull();
   });
 
   it('produces a fresh LLM call when the cache is null (caching disabled)', async () => {
@@ -245,7 +256,7 @@ describe('orchestrator — rerank on but LLM fails', () => {
     const reranker = new Reranker('claude-sonnet-4-6', client);
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    const tiers = await buildTiersForSlug({
+    const { tiers, rerankResult } = await buildTiersForSlug({
       docContent:     '# block-metadata',
       slug:           'block-metadata',
       scored:         SCORED,
@@ -256,10 +267,122 @@ describe('orchestrator — rerank on but LLM fails', () => {
     // Same as the --no-rerank path
     expect(tiers.primary.map(f => f.path)).toContain('packages/blocks/src/api/registration.js');
     expect(tiers.context.map(f => f.path)).toContain('packages/blocks/src/api/block-metadata.ts');
+    // No audit material on rerank failure — caller skips writing the audit.
+    expect(rerankResult).toBeNull();
     // The Reranker emitted the user-visible warning before falling back.
     const allCalls = errSpy.mock.calls.map(c => c.join(' ')).join('\n');
     expect(allCalls).toMatch(/AI re-rank failed/);
 
     errSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Smoke: audit + --explain — gating logic between rerank result and audit write
+// ---------------------------------------------------------------------------
+
+describe('orchestrator + AuditWriter wiring (smoke)', () => {
+  const TOOL_INPUT = {
+    primary: [
+      { repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js', rationale: 'canonical impl', confidence: 0.95 },
+    ],
+    secondary: [
+      { repo: 'gutenberg', path: 'packages/blocks/src/api/parser.js', rationale: 'parses the block', confidence: 0.85 },
+    ],
+    context: [
+      { repo: 'gutenberg', path: 'packages/blocks/src/api/utils.ts', rationale: 'helpers', confidence: 0.75 },
+    ],
+    dropped: [
+      { repo: 'gutenberg', path: 'packages/deprecated/src/index.ts', reason: 'unrelated logger named `deprecated`' },
+    ],
+  };
+
+  it('writes the audit file when re-rank ran successfully and --write was set', async () => {
+    const client = makeAnthropicClient([makeToolUseResponse(TOOL_INPUT)]);
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+
+    const { rerankResult } = await buildTiersForSlug({
+      docContent:     '# block-metadata',
+      slug:           'block-metadata',
+      scored:         SCORED,
+      allFilesByRepo: ALL_FILES,
+      reranker,
+    });
+
+    // Caller guard: only write audit when rerank produced a non-null result.
+    expect(rerankResult).not.toBeNull();
+
+    const dir = mkdtempSync(join(tmpdir(), 'orch-smoke-'));
+    const auditPath = auditPathFor(join(dir, 'site.json'));
+    expect(auditPath).toBe(join(dir, 'site.audit.json'));
+
+    if (rerankResult) {
+      new AuditWriter().writeAudit(auditPath, 'block-metadata', rerankResult);
+    }
+
+    expect(existsSync(auditPath)).toBe(true);
+    const parsed = MappingAuditSchema.parse(JSON.parse(readFileSync(auditPath, 'utf-8')));
+    expect(parsed.audits['block-metadata']).toEqual(rerankResult);
+  });
+
+  it('does NOT produce audit material under --no-rerank (caller must skip writeAudit)', async () => {
+    const { rerankResult } = await buildTiersForSlug({
+      docContent:     '# block-metadata',
+      slug:           'block-metadata',
+      scored:         SCORED,
+      allFilesByRepo: ALL_FILES,
+      reranker:       null,
+    });
+
+    // No rerank means no audit material exists for the caller to write.
+    expect(rerankResult).toBeNull();
+  });
+
+  it('does NOT produce audit material when re-rank fails (caller must skip writeAudit)', async () => {
+    const client = makeAnthropicClient([new Error('SDK error')]);
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { rerankResult } = await buildTiersForSlug({
+      docContent:     '# block-metadata',
+      slug:           'block-metadata',
+      scored:         SCORED,
+      allFilesByRepo: ALL_FILES,
+      reranker,
+    });
+
+    expect(rerankResult).toBeNull();
+    errSpy.mockRestore();
+  });
+
+  it('--explain renders rationale per kept file and reason per dropped file', async () => {
+    const client = makeAnthropicClient([makeToolUseResponse(TOOL_INPUT)]);
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+
+    const { rerankResult } = await buildTiersForSlug({
+      docContent:     '# block-metadata',
+      slug:           'block-metadata',
+      scored:         SCORED,
+      allFilesByRepo: ALL_FILES,
+      reranker,
+    });
+
+    expect(rerankResult).not.toBeNull();
+    if (!rerankResult) return;
+
+    const out = new AuditWriter().formatExplain(rerankResult);
+    expect(out.length).toBeGreaterThan(0);
+    expect(out).toContain('canonical impl');
+    expect(out).toContain('parses the block');
+    expect(out).toContain('helpers');
+    expect(out).toContain('unrelated logger named `deprecated`');
+  });
+
+  it('auditPathFor derives `<mapping>.audit.json` from `<mapping>.json`', () => {
+    expect(auditPathFor('mappings/gutenberg-block-api.json')).toBe(
+      'mappings/gutenberg-block-api.audit.json',
+    );
+    // Falls back to suffix append for non-.json paths
+    expect(auditPathFor('mappings/site')).toBe('mappings/site.audit.json');
   });
 });

--- a/src/auto-map/audit-writer.ts
+++ b/src/auto-map/audit-writer.ts
@@ -1,0 +1,101 @@
+/**
+ * AuditWriter — persists the AI re-ranker's per-file rationale, confidence,
+ * and dropped-with-reason into a committed audit file alongside the canonical
+ * mapping, and renders the same information to stdout for `--explain`.
+ *
+ * The audit file lives at `mappings/<site>.audit.json` and is keyed by slug,
+ * mirroring the canonical mapping's structure. Each slug entry carries the
+ * full `RerankResult` (primary / secondary / context with rationale +
+ * confidence per kept file, plus a parallel `dropped` array with reason).
+ *
+ * The audit is treated as **generated** — a top-level `_comment` field on the
+ * file warns against hand-editing and directs readers to re-run auto-map.
+ *
+ * The canonical `Mapping` schema in `src/types/mapping.ts` stays locked. The
+ * audit is a side channel — runtime consumers (the validator pipeline) never
+ * read it. That is why `MappingAuditSchema` lives here, not in `src/types/`.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
+import { z } from 'zod';
+
+import { RerankResultSchema, type RerankResult } from './rerank.js';
+
+// Bump when the on-disk envelope or the contained RerankResult shape changes.
+export const AUDIT_FILE_VERSION = 1;
+
+export const AUDIT_WARNING =
+  'GENERATED FILE — do not hand-edit. Re-run scripts/auto-map.ts to regenerate.';
+
+export const MappingAuditSchema = z.object({
+  _comment: z.string().optional(),
+  version:  z.literal(AUDIT_FILE_VERSION),
+  audits:   z.record(z.string(), RerankResultSchema),
+});
+export type MappingAudit = z.infer<typeof MappingAuditSchema>;
+
+export class AuditWriter {
+  /**
+   * Merge `result` into the audit file at `siteAuditPath` under `slug`.
+   * Other slugs are preserved. A malformed or missing file is replaced with
+   * a fresh envelope rather than throwing.
+   */
+  writeAudit(siteAuditPath: string, slug: string, result: RerankResult): void {
+    const existing = this.loadExisting(siteAuditPath);
+    existing[slug] = result;
+
+    // Sort slug keys for deterministic output (no Set/Map iteration leakage).
+    const sortedAudits: Record<string, RerankResult> = {};
+    for (const k of Object.keys(existing).sort()) {
+      sortedAudits[k] = existing[k];
+    }
+
+    const envelope: MappingAudit = {
+      _comment: AUDIT_WARNING,
+      version:  AUDIT_FILE_VERSION,
+      audits:   sortedAudits,
+    };
+
+    mkdirSync(dirname(siteAuditPath), { recursive: true });
+    writeFileSync(siteAuditPath, JSON.stringify(envelope, null, 2) + '\n');
+  }
+
+  /**
+   * Render rationale per kept file and reason per dropped file as a string
+   * for `--explain` stdout. Iteration order is fixed (primary → secondary →
+   * context → dropped) so output is stable across runs on identical input.
+   */
+  formatExplain(result: RerankResult): string {
+    const lines: string[] = [];
+    lines.push('Kept files:');
+    for (const tier of ['primary', 'secondary', 'context'] as const) {
+      for (const f of result[tier]) {
+        lines.push(`  [${tier}] ${f.repo}:${f.path} (confidence ${f.confidence.toFixed(2)})`);
+        lines.push(`    rationale: ${f.rationale}`);
+      }
+    }
+
+    if (result.dropped.length > 0) {
+      lines.push('');
+      lines.push('Dropped files:');
+      for (const f of result.dropped) {
+        lines.push(`  ${f.repo}:${f.path}`);
+        lines.push(`    reason: ${f.reason}`);
+      }
+    }
+
+    return lines.join('\n');
+  }
+
+  private loadExisting(path: string): Record<string, RerankResult> {
+    if (!existsSync(path)) return {};
+    let raw: unknown;
+    try {
+      raw = JSON.parse(readFileSync(path, 'utf-8'));
+    } catch {
+      return {};
+    }
+    const parsed = MappingAuditSchema.safeParse(raw);
+    return parsed.success ? { ...parsed.data.audits } : {};
+  }
+}

--- a/src/auto-map/orchestrator.ts
+++ b/src/auto-map/orchestrator.ts
@@ -14,6 +14,19 @@ import { findFilesByTreeHeuristic, type ScoredFile } from '../indexer/symbol-ind
 import type { Reranker, RerankResult } from './rerank.js';
 import type { RerankCache } from './rerank-cache.js';
 
+/**
+ * Derive the audit-file path from the canonical mapping path, e.g.
+ *   `mappings/gutenberg-block-api.json` → `mappings/gutenberg-block-api.audit.json`.
+ *
+ * Audit lives next to the mapping it audits and is committed alongside it.
+ */
+export function auditPathFor(mappingPath: string): string {
+  if (mappingPath.endsWith('.json')) {
+    return mappingPath.replace(/\.json$/, '.audit.json');
+  }
+  return `${mappingPath}.audit.json`;
+}
+
 export type BuildTiersInput = {
   docContent:     string;
   slug:           string;
@@ -28,14 +41,26 @@ export type BuildTiersInput = {
   cache?:         RerankCache | null;
 };
 
-export async function buildTiersForSlug(input: BuildTiersInput): Promise<CodeTiers> {
+export type BuildTiersResult = {
+  tiers: CodeTiers;
+  // null when --no-rerank was used or when rerank ran but failed (sentinel).
+  // Callers gate audit-file writing on this — no rerank, no rationale.
+  rerankResult: RerankResult | null;
+};
+
+export async function buildTiersForSlug(input: BuildTiersInput): Promise<BuildTiersResult> {
   if (input.reranker) {
     const result = await rerankWithCache(input.reranker, input.cache ?? null, input);
-    if (result) return rerankToCodeTiers(result);
+    if (result) {
+      return { tiers: rerankToCodeTiers(result), rerankResult: result };
+    }
     // null = sentinel; the Reranker has already emitted a stderr warning.
     // Fall through to the lexical-only path.
   }
-  return lexicalTiers(input.scored, input.allFilesByRepo, input.slug);
+  return {
+    tiers:        lexicalTiers(input.scored, input.allFilesByRepo, input.slug),
+    rerankResult: null,
+  };
 }
 
 // Cache key is derived from docContent + canonically-sorted candidates +


### PR DESCRIPTION
## Summary

Slice C of the auto-map AI re-ranker (PRD #71). Persists the re-ranker's
per-file rationale, confidence, and dropped-with-reason into a committed
audit file alongside the canonical mapping, and adds a `--explain` CLI
flag that renders the same information to stdout.

The audit file lives at `mappings/<site>.audit.json` — keyed by slug,
mirrors the canonical mapping's structure, and carries a top-level
`_comment` warning against hand-editing. `MappingAuditSchema` (Zod) is in
a new module (`src/auto-map/audit-writer.ts`), **not** in `src/types/`,
because the audit is a side channel — runtime consumers (the validator
pipeline) never read it. The locked `CodeFile` / `CodeTiers` / `Mapping`
schemas are unchanged.

The orchestrator now returns `{ tiers, rerankResult }` so the script can
gate audit-writing on "rerank ran AND succeeded": `--no-rerank` and
rerank-failure paths both leave any existing audit untouched.

Closes #74

## Changes

- `src/auto-map/audit-writer.ts` (new) — `MappingAuditSchema`,
  `AuditWriter.writeAudit` (merging by slug, sorted-key output,
  malformed-file tolerance, parent-dir mkdir), `AuditWriter.formatExplain`
  (deterministic primary→secondary→context→dropped order), `AUDIT_WARNING`
  + `AUDIT_FILE_VERSION` constants.
- `src/auto-map/orchestrator.ts` — `buildTiersForSlug` now returns
  `{ tiers, rerankResult }`; new `auditPathFor()` helper derives
  `<mapping>.audit.json` from the canonical mapping path.
- `scripts/auto-map.ts` — adds `--explain` flag; on `--write`, also writes
  the audit when `rerankResult` is non-null; on `--explain`, prints the
  formatted rationale to stdout below the JSON.
- `src/auto-map/__tests__/audit-writer.test.ts` (new) — 15 tests covering
  schema round-trip, file format / warning header, slug merge / overwrite,
  deterministic ordering, malformed-file tolerance, mkdir behaviour,
  `formatExplain` content + ordering + determinism.
- `src/auto-map/__tests__/orchestrator.test.ts` — updated to the new
  `{ tiers, rerankResult }` return shape; adds a smoke describe block that
  pins audit-write gating (rerank-success → audit material; `--no-rerank`
  / rerank-failure → no audit material) and verifies `auditPathFor`.

## How to test

1. `git fetch origin && git checkout ralph/74-audit-explain`
2. `npm install`
3. `npm test` — should be green; new tests pin the audit-writer behaviour
   (15 tests in `audit-writer.test.ts`, 5 new tests in the smoke block at
   the bottom of `orchestrator.test.ts`).
4. `npm run typecheck` — clean.
5. Inspect the new module:
   - `src/auto-map/audit-writer.ts` — confirm `MappingAuditSchema` lives
     here (not in `src/types/`), confirm `_comment` field carries
     `AUDIT_WARNING`, confirm `audits` are keyed by slug.
6. Inspect the orchestrator wiring:
   - `git log -p src/auto-map/orchestrator.ts` — confirm the return type
     change to `{ tiers, rerankResult }` and the new `auditPathFor` export.
   - `git log -p scripts/auto-map.ts` — confirm `--explain` flag, audit
     write is gated on `rerankResult` (so `--no-rerank` does NOT write),
     and explain output goes to stdout via `console.log`.
7. Confirm the locked-contracts rule is respected:
   - `git diff main..HEAD -- src/types/` should be empty.
   - `examples/results.schema.json` is untouched.

Expected outcome: tests pass, typecheck clean, the audit file format
matches the PRD shape (slug-keyed `RerankResult` envelope with version +
warning), and the script writes audit + canonical mapping together when
re-rank ran successfully under `--write`. Live `auto-map.ts` invocation
against the Gutenberg corpus is out of scope here (needs an Anthropic
API key + network) — slice E (#75 / acceptance smoke run) covers that.

## Out of scope

- Slice D (`--review` flag for flagged-subset stdout) — tracked in #75.
- Live network smoke run against the Gutenberg corpus.
- `src/types/` schema changes — locked contract; deliberately untouched.
- `examples/results.schema.json` regeneration — not needed; no Zod export
  in `src/types/` changed.
