### PR TITLE
RALPH: --review flag for flagged-subset rendering (#75)

### DIFF
--- a/scripts/auto-map.ts
+++ b/scripts/auto-map.ts
@@ -3,7 +3,7 @@
  * (optional) AI re-ranker.
  *
  * Usage:
- *   npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank] [--explain]
+ *   npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank] [--explain] [--review]
  *
  * Builds a symbol index of all configured repos (cached by commit SHA),
  * cross-references the symbols named in the doc, and proposes a CodeTiers
@@ -17,6 +17,11 @@
  *   --write           Write the canonical mapping AND the audit file (when re-rank ran)
  *   --no-rerank       Skip the AI re-ranker (lexical-only output, no audit)
  *   --explain         Print rationale per kept file and reason per dropped file to stdout
+ *   --review          Write mapping + audit AND emit only the flagged subset
+ *                     (confidence < 0.7) to stdout for the human-review loop.
+ *                     Implies --write. Mutually exclusive with --no-rerank.
+ *                     Composes with --explain: both renderers run (explain
+ *                     first, then flagged subset).
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
@@ -36,12 +41,13 @@ import { RerankCache } from '../src/auto-map/rerank-cache.js';
 import { buildTiersForSlug, auditPathFor } from '../src/auto-map/orchestrator.js';
 import { AuditWriter } from '../src/auto-map/audit-writer.js';
 
-function parseArgs(argv: string[]): {
+export function parseArgs(argv: string[]): {
   slug: string;
   configPath: string;
   write: boolean;
   rerank: boolean;
   explain: boolean;
+  review: boolean;
 } {
   const args = argv.slice(2);
   let slug = '';
@@ -49,6 +55,7 @@ function parseArgs(argv: string[]): {
   let write = false;
   let rerank = true;
   let explain = false;
+  let review = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--config' && args[i + 1]) {
@@ -60,21 +67,37 @@ function parseArgs(argv: string[]): {
       rerank = false;
     } else if (args[i] === '--explain') {
       explain = true;
+    } else if (args[i] === '--review') {
+      review = true;
     } else if (!slug && !args[i].startsWith('--')) {
       slug = args[i];
     }
   }
 
   if (!slug) {
-    console.error('Usage: npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank] [--explain]');
+    console.error('Usage: npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank] [--explain] [--review]');
     process.exit(1);
   }
 
-  return { slug, configPath, write, rerank, explain };
+  // --review needs the audit (rationale + confidence per kept file) which
+  // only the AI re-ranker produces. --no-rerank means no audit, so the
+  // combination is rejected up-front rather than producing empty output.
+  if (review && !rerank) {
+    console.error(
+      'Error: --review cannot be used with --no-rerank. The flagged subset is derived from re-rank confidence; --no-rerank produces no audit. Drop one of the two flags.',
+    );
+    process.exit(2);
+  }
+
+  // --review implies --write (the human-review loop lands the auto-mapping
+  // immediately and surfaces the flagged subset on top).
+  if (review) write = true;
+
+  return { slug, configPath, write, rerank, explain, review };
 }
 
 async function main() {
-  const { slug, configPath, write, rerank, explain } = parseArgs(process.argv);
+  const { slug, configPath, write, rerank, explain, review } = parseArgs(process.argv);
   const config = await loadConfig(configPath);
 
   // 1. Fetch manifest and locate the entry for this slug
@@ -232,6 +255,22 @@ async function main() {
     console.error(
       `\nReview the above and merge into ${config.mappingPath}, or re-run with --write`,
     );
+  }
+
+  // --review: surface the flagged subset (kept files with confidence < 0.7)
+  // on stdout for the human-review loop. Mapping + audit have already been
+  // written above (--review implies --write). If re-rank failed at runtime
+  // (rerankResult === null), the mapping write fell back to lexical-only
+  // and there is no audit material to flag — say so on stderr instead of
+  // printing an empty/confusing flagged section.
+  if (review) {
+    if (rerankResult) {
+      console.log('\n' + auditWriter.formatFlagged(rerankResult));
+    } else {
+      console.error(
+        '\n--review: no flagged subset to print (re-rank failed; mapping written from lexical-only fallback).',
+      );
+    }
   }
 }
 

--- a/src/auto-map/__tests__/audit-writer.test.ts
+++ b/src/auto-map/__tests__/audit-writer.test.ts
@@ -3,7 +3,13 @@ import { mkdtempSync, readFileSync, writeFileSync, existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-import { AuditWriter, MappingAuditSchema, AUDIT_WARNING } from '../audit-writer.js';
+import {
+  AuditWriter,
+  MappingAuditSchema,
+  AUDIT_WARNING,
+  FLAGGED_CONFIDENCE_THRESHOLD,
+  NO_FLAGGED_SENTINEL,
+} from '../audit-writer.js';
 import type { RerankResult } from '../rerank.js';
 
 // ---------------------------------------------------------------------------
@@ -218,5 +224,132 @@ describe('AuditWriter.formatExplain', () => {
     const writer = new AuditWriter();
     const out = writer.formatExplain(RESULT_B);
     expect(out).not.toMatch(/dropped/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatFlagged — flagged-subset stdout renderer (slice D, --review)
+// ---------------------------------------------------------------------------
+
+describe('AuditWriter.formatFlagged', () => {
+  // Pin the threshold value itself so a future refactor can't silently change
+  // the contract the CLI exposes via --review.
+  it('uses 0.7 as the flagged-confidence threshold', () => {
+    expect(FLAGGED_CONFIDENCE_THRESHOLD).toBe(0.7);
+  });
+
+  it('returns the literal sentinel string when no kept file is below the threshold', () => {
+    const writer = new AuditWriter();
+    // RESULT_A's confidences are 0.95, 0.85, 0.75 — all >= 0.7.
+    const out = writer.formatFlagged(RESULT_A);
+    expect(out).toBe(NO_FLAGGED_SENTINEL);
+    expect(out).toBe('(no flagged entries — confidence ≥ 0.7 across all kept files)');
+  });
+
+  it('includes only files with confidence < 0.7, with tier + confidence + rationale', () => {
+    const writer = new AuditWriter();
+    const result: RerankResult = {
+      primary: [
+        { repo: 'g', path: 'kept-high.js', rationale: 'canonical', confidence: 0.95 },
+      ],
+      secondary: [
+        { repo: 'g', path: 'flagged-low.js', rationale: 'maybe related', confidence: 0.55 },
+      ],
+      context: [
+        { repo: 'g', path: 'kept-mid.js', rationale: 'helpers', confidence: 0.8 },
+      ],
+      dropped: [],
+    };
+
+    const out = writer.formatFlagged(result);
+
+    // Flagged file is present with all three pieces of info
+    expect(out).toContain('flagged-low.js');
+    expect(out).toContain('secondary');
+    expect(out).toContain('0.55');
+    expect(out).toContain('maybe related');
+    expect(out).toContain('g:flagged-low.js');
+
+    // Non-flagged files are NOT printed
+    expect(out).not.toContain('kept-high.js');
+    expect(out).not.toContain('canonical');
+    expect(out).not.toContain('kept-mid.js');
+    expect(out).not.toContain('helpers');
+
+    // Not the sentinel
+    expect(out).not.toBe(NO_FLAGGED_SENTINEL);
+  });
+
+  it('treats confidence === 0.7 as NOT flagged (boundary: file at 0.7 is kept)', () => {
+    const writer = new AuditWriter();
+    const result: RerankResult = {
+      primary:   [{ repo: 'g', path: 'boundary.js', rationale: 'on-boundary', confidence: 0.7 }],
+      secondary: [],
+      context:   [],
+      dropped:   [],
+    };
+    const out = writer.formatFlagged(result);
+    expect(out).toBe(NO_FLAGGED_SENTINEL);
+    expect(out).not.toContain('boundary.js');
+  });
+
+  it('treats confidence === 0.69 as flagged (boundary: file just below 0.7 is flagged)', () => {
+    const writer = new AuditWriter();
+    const result: RerankResult = {
+      primary:   [{ repo: 'g', path: 'just-below.js', rationale: 'tip-the-scale', confidence: 0.69 }],
+      secondary: [],
+      context:   [],
+      dropped:   [],
+    };
+    const out = writer.formatFlagged(result);
+    expect(out).not.toBe(NO_FLAGGED_SENTINEL);
+    expect(out).toContain('just-below.js');
+    expect(out).toContain('0.69');
+    expect(out).toContain('tip-the-scale');
+  });
+
+  it('does NOT mention dropped files (dropped is not "kept and flagged")', () => {
+    const writer = new AuditWriter();
+    const result: RerankResult = {
+      primary:   [{ repo: 'g', path: 'flagged.js', rationale: 'flag me', confidence: 0.5 }],
+      secondary: [],
+      context:   [],
+      dropped:   [
+        { repo: 'g', path: 'noise.js', reason: 'English-word collision' },
+      ],
+    };
+    const out = writer.formatFlagged(result);
+    expect(out).toContain('flagged.js');
+    // Dropped files belong to formatExplain, not formatFlagged.
+    expect(out).not.toContain('noise.js');
+    expect(out).not.toContain('English-word collision');
+  });
+
+  it('renders flagged kept files in fixed (primary → secondary → context) order', () => {
+    const writer = new AuditWriter();
+    const result: RerankResult = {
+      primary:   [{ repo: 'g', path: 'p-flagged.js', rationale: 'pr',  confidence: 0.6 }],
+      secondary: [{ repo: 'g', path: 's-flagged.js', rationale: 'sr',  confidence: 0.6 }],
+      context:   [{ repo: 'g', path: 'c-flagged.js', rationale: 'cr',  confidence: 0.6 }],
+      dropped:   [],
+    };
+    const out = writer.formatFlagged(result);
+    const idxP = out.indexOf('p-flagged.js');
+    const idxS = out.indexOf('s-flagged.js');
+    const idxC = out.indexOf('c-flagged.js');
+    expect(idxP).toBeGreaterThan(-1);
+    expect(idxS).toBeGreaterThan(idxP);
+    expect(idxC).toBeGreaterThan(idxS);
+  });
+
+  it('produces identical output for identical input (deterministic)', () => {
+    const writer = new AuditWriter();
+    const result: RerankResult = {
+      primary:   [{ repo: 'g', path: 'a.js', rationale: 'r', confidence: 0.5 }],
+      secondary: [{ repo: 'g', path: 'b.js', rationale: 'r', confidence: 0.6 }],
+      context:   [],
+      dropped:   [],
+    };
+    expect(writer.formatFlagged(result)).toBe(writer.formatFlagged(result));
   });
 });

--- a/src/auto-map/__tests__/orchestrator.test.ts
+++ b/src/auto-map/__tests__/orchestrator.test.ts
@@ -7,7 +7,7 @@ import type Anthropic from '@anthropic-ai/sdk';
 import { buildTiersForSlug, auditPathFor } from '../orchestrator.js';
 import { Reranker } from '../rerank.js';
 import { RerankCache } from '../rerank-cache.js';
-import { AuditWriter, MappingAuditSchema } from '../audit-writer.js';
+import { AuditWriter, MappingAuditSchema, NO_FLAGGED_SENTINEL } from '../audit-writer.js';
 import type { ScoredFile } from '../../indexer/symbol-index.js';
 
 // ---------------------------------------------------------------------------
@@ -384,5 +384,93 @@ describe('orchestrator + AuditWriter wiring (smoke)', () => {
     );
     // Falls back to suffix append for non-.json paths
     expect(auditPathFor('mappings/site')).toBe('mappings/site.audit.json');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Smoke: --review wiring (slice D) — orchestrator + AuditWriter compose to
+// (a) write mapping + audit and (b) emit only the flagged subset to stdout.
+// ---------------------------------------------------------------------------
+
+describe('orchestrator + AuditWriter wiring (--review smoke)', () => {
+  // A canned mock LLM response containing exactly one flagged (confidence
+  // < 0.7) and one non-flagged (confidence >= 0.7) entry, plus one dropped
+  // file. Mirrors the acceptance-criterion fixture from the issue body.
+  const REVIEW_TOOL_INPUT = {
+    primary: [
+      { repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js', rationale: 'canonical impl', confidence: 0.95 },
+    ],
+    secondary: [
+      { repo: 'gutenberg', path: 'packages/blocks/src/api/parser.js', rationale: 'might be the parser, not 100% sure', confidence: 0.55 },
+    ],
+    context: [],
+    dropped: [
+      { repo: 'gutenberg', path: 'packages/deprecated/src/index.ts', reason: 'unrelated logger named `deprecated`' },
+    ],
+  };
+
+  it('writes both mapping + audit AND produces flagged-only stdout under --review', async () => {
+    const client = makeAnthropicClient([makeToolUseResponse(REVIEW_TOOL_INPUT)]);
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+
+    const { tiers, rerankResult } = await buildTiersForSlug({
+      docContent:     '# block-metadata',
+      slug:           'block-metadata',
+      scored:         SCORED,
+      allFilesByRepo: ALL_FILES,
+      reranker,
+    });
+
+    // Tiers were assembled from rerank — both kept files are present.
+    expect(tiers.primary).toEqual([{ repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js' }]);
+    expect(tiers.secondary).toEqual([{ repo: 'gutenberg', path: 'packages/blocks/src/api/parser.js' }]);
+
+    // Caller guard: rerank produced a non-null result, so the audit can be written.
+    expect(rerankResult).not.toBeNull();
+    if (!rerankResult) return;
+
+    // (1) Audit is written when --review implies --write and rerank ran.
+    const dir = mkdtempSync(join(tmpdir(), 'orch-review-'));
+    const auditPath = auditPathFor(join(dir, 'site.json'));
+    const writer = new AuditWriter();
+    writer.writeAudit(auditPath, 'block-metadata', rerankResult);
+    expect(existsSync(auditPath)).toBe(true);
+    const parsedAudit = MappingAuditSchema.parse(JSON.parse(readFileSync(auditPath, 'utf-8')));
+    expect(parsedAudit.audits['block-metadata']).toEqual(rerankResult);
+
+    // (2) formatFlagged emits ONLY the flagged subset (parser.js at 0.55).
+    const flagged = writer.formatFlagged(rerankResult);
+    expect(flagged).not.toBe(NO_FLAGGED_SENTINEL);
+    expect(flagged).toContain('parser.js');
+    expect(flagged).toContain('0.55');
+    expect(flagged).toContain('might be the parser');
+    // Non-flagged kept file (registration.js at 0.95) is NOT in flagged output.
+    expect(flagged).not.toContain('registration.js');
+    expect(flagged).not.toContain('canonical impl');
+    // Dropped files are not part of the flagged subset (they belong to --explain).
+    expect(flagged).not.toContain('packages/deprecated/src/index.ts');
+  });
+
+  it('emits the literal sentinel string when no kept file is below the threshold', async () => {
+    const allHighConfidence = {
+      primary:   [{ repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js', rationale: 'canonical', confidence: 0.95 }],
+      secondary: [{ repo: 'gutenberg', path: 'packages/blocks/src/api/parser.js',       rationale: 'parser',    confidence: 0.85 }],
+      context:   [{ repo: 'gutenberg', path: 'packages/blocks/src/api/utils.ts',        rationale: 'helpers',   confidence: 0.75 }],
+      dropped:   [],
+    };
+    const client = makeAnthropicClient([makeToolUseResponse(allHighConfidence)]);
+    const reranker = new Reranker('claude-sonnet-4-6', client);
+
+    const { rerankResult } = await buildTiersForSlug({
+      docContent:     '# block-metadata',
+      slug:           'block-metadata',
+      scored:         SCORED,
+      allFilesByRepo: ALL_FILES,
+      reranker,
+    });
+    expect(rerankResult).not.toBeNull();
+    if (!rerankResult) return;
+
+    expect(new AuditWriter().formatFlagged(rerankResult)).toBe(NO_FLAGGED_SENTINEL);
   });
 });

--- a/src/auto-map/audit-writer.ts
+++ b/src/auto-map/audit-writer.ts
@@ -27,6 +27,17 @@ export const AUDIT_FILE_VERSION = 1;
 export const AUDIT_WARNING =
   'GENERATED FILE — do not hand-edit. Re-run scripts/auto-map.ts to regenerate.';
 
+// Files with confidence STRICTLY BELOW this threshold are "flagged" — i.e.
+// surfaced by `--review` for the human to scrutinise first. A file with
+// confidence === 0.7 is NOT flagged. The PRD pins this value at 0.7.
+export const FLAGGED_CONFIDENCE_THRESHOLD = 0.7;
+
+// Sentinel string emitted by `formatFlagged` when nothing crosses the
+// threshold. Stable wording is part of the CLI contract — automation that
+// greps stdout under `--review` relies on it.
+export const NO_FLAGGED_SENTINEL =
+  '(no flagged entries — confidence ≥ 0.7 across all kept files)';
+
 export const MappingAuditSchema = z.object({
   _comment: z.string().optional(),
   version:  z.literal(AUDIT_FILE_VERSION),
@@ -85,6 +96,32 @@ export class AuditWriter {
     }
 
     return lines.join('\n');
+  }
+
+  /**
+   * Render the flagged-subset of kept files (confidence < 0.7) for `--review`
+   * stdout. Per flagged file, prints `<repo>:<path>` + tier + confidence +
+   * rationale. Files with `confidence >= 0.7` are not printed. When no kept
+   * file is below the threshold, returns `NO_FLAGGED_SENTINEL` verbatim —
+   * automation that greps stdout under `--review` depends on that exact
+   * string.
+   *
+   * Iteration order is fixed (primary → secondary → context) so output is
+   * stable across runs on identical input. Dropped files are NOT included —
+   * they belong to `formatExplain`.
+   */
+  formatFlagged(result: RerankResult): string {
+    const lines: string[] = [];
+    for (const tier of ['primary', 'secondary', 'context'] as const) {
+      for (const f of result[tier]) {
+        if (f.confidence < FLAGGED_CONFIDENCE_THRESHOLD) {
+          lines.push(`  [${tier}] ${f.repo}:${f.path} (confidence ${f.confidence.toFixed(2)})`);
+          lines.push(`    rationale: ${f.rationale}`);
+        }
+      }
+    }
+    if (lines.length === 0) return NO_FLAGGED_SENTINEL;
+    return ['Flagged entries (confidence < 0.7):', ...lines].join('\n');
   }
 
   private loadExisting(path: string): Record<string, RerankResult> {


### PR DESCRIPTION
## Summary

Slice D of the auto-map AI re-ranker (PRD #71). Adds a `--review` CLI flag
that writes the canonical mapping AND the audit, then emits ONLY the
kept-file subset with `confidence < 0.7` to stdout — the human-review loop
lands the auto-mapping immediately and surfaces the entries that need
scrutiny without making the human read the entire audit.

`--review` implies `--write`. `--no-rerank --review` is rejected up-front
with a clear stderr message and a non-zero exit (no audit means no
flagging). `--review` composes with `--explain`: both renderers run —
explain first, then the flagged subset.

The renderer is a new `AuditWriter.formatFlagged(result) → string`
method. Threshold is exactly 0.7 — a file at confidence 0.7 is NOT
flagged; a file at 0.69 IS flagged. When no kept file is below the
threshold, output is the literal sentinel string
`(no flagged entries — confidence ≥ 0.7 across all kept files)`. Stable
wording is part of the CLI contract — automation that greps stdout under
`--review` depends on that exact string.

The locked `CodeFile` / `CodeTiers` / `Mapping` schemas in `src/types/`
are unchanged. The audit / `MappingAuditSchema` (slice C) is unchanged.

> Note: issue #75 has no Agent Brief comment from the `/triage` skill —
> the contract here is the issue body. Future runs on a fresh
> `ready-for-agent` issue should still pick up the brief.

Closes #75

## Changes

- `src/auto-map/audit-writer.ts` — adds `FLAGGED_CONFIDENCE_THRESHOLD`
  (= 0.7) and `NO_FLAGGED_SENTINEL` constants, plus
  `AuditWriter.formatFlagged(result)`. Iteration order is fixed
  (primary → secondary → context); dropped files are intentionally NOT
  rendered (they belong to `formatExplain`).
- `src/auto-map/__tests__/audit-writer.test.ts` — 8 new tests for
  `formatFlagged`: threshold value pinning, sentinel-when-empty,
  flagged-subset rendering with `<repo>:<path>` + tier + confidence +
  rationale, both boundaries (0.7 NOT flagged, 0.69 IS flagged),
  dropped-files exclusion, fixed tier ordering, determinism.
- `scripts/auto-map.ts` — adds `--review` flag; up-front rejects
  `--review --no-rerank` (exit 2 + stderr); makes `--review` imply
  `--write`; renders the flagged subset to stdout after the audit is
  written; `parseArgs` exported (no behaviour change for the CLI entry,
  enables future test reuse).
- `src/auto-map/__tests__/orchestrator.test.ts` — 2 new smoke tests
  exercising the full `buildTiersForSlug` → `AuditWriter.writeAudit` →
  `AuditWriter.formatFlagged` pipeline on a canned mock LLM response
  containing one flagged + one non-flagged entry, and on an
  all-high-confidence response (sentinel path).

## How to test

1. `git fetch origin && git checkout ralph/75-review-flag`
2. `npm install`
3. `npm test` — should be green; 8 new tests in
   `audit-writer.test.ts` (the `AuditWriter.formatFlagged` describe
   block) and 2 new smoke tests in `orchestrator.test.ts` (the
   `--review smoke` describe block) pin the new behaviour. Total
   auto-map suite: 59 tests passing (rerank + rerank-cache +
   audit-writer + orchestrator).
4. `npm run typecheck` — clean.
5. Inspect the new module surface:
   - `src/auto-map/audit-writer.ts` — confirm `FLAGGED_CONFIDENCE_THRESHOLD`
     is exactly `0.7`, `NO_FLAGGED_SENTINEL` is the literal string
     `(no flagged entries — confidence ≥ 0.7 across all kept files)`,
     and `formatFlagged` short-circuits to the sentinel when no kept
     file is below threshold.
   - `git log -p scripts/auto-map.ts` — confirm `--review`+`--no-rerank`
     hits `process.exit(2)` with a clear stderr message, `--review`
     implies `--write`, and the flagged-subset render runs after the
     audit write.
6. Confirm the locked-contracts rule is respected:
   - `git diff main..HEAD -- src/types/` should be empty.
   - `examples/results.schema.json` is untouched.

Expected outcome: tests pass, typecheck clean, the `--review` flag is
wired end-to-end with deterministic stdout output. The stricter
acceptance items that need a live Anthropic API key + Gutenberg corpus
(slice E in PRD #71) — "at least one slug produces flagged: true",
"two consecutive runs are bit-identical via the cache" — are out of
scope for this PR; they're acceptance-smoke material handled with API
credentials, not CI material.

## Out of scope

- Live network smoke run against the Gutenberg corpus (PRD #71 slice E).
- Schema changes to `src/types/` — locked contract; deliberately untouched.
- `examples/results.schema.json` regeneration — not needed; no Zod
  export in `src/types/` changed.
- `MappingAuditSchema` shape changes (slice C is in main and stays as-is).
- Any change to the existing `--explain` renderer or
  `AuditWriter.writeAudit` (slice C); both untouched.
