### PR TITLE
feat(auto-map): WriteDecisionPolicy + --review flag (#84)

### DIFF
--- a/scripts/auto-map.ts
+++ b/scripts/auto-map.ts
@@ -3,7 +3,7 @@
  * (optional) AI re-ranker.
  *
  * Usage:
- *   npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank] [--explain] [--review]
+ *   npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank] [--explain] [--review] [--force-regenerate]
  *
  * Builds a symbol index of all configured repos (cached by commit SHA),
  * cross-references the symbols named in the doc, and proposes a CodeTiers
@@ -13,23 +13,28 @@
  * and reproduces the pre-rerank lexical-only output.
  *
  * Flags:
- *   --config <path>   Config file (default: config/gutenberg-block-api.json)
- *   --write           Write the canonical mapping AND the audit file (when re-rank ran)
- *   --no-rerank       Skip the AI re-ranker (lexical-only output, no audit)
- *   --explain         Print rationale per kept file and reason per dropped file to stdout
- *   --review          Write mapping + audit AND emit only the flagged subset
- *                     (confidence < 0.7) to stdout for the human-review loop.
- *                     Implies --write. Mutually exclusive with --no-rerank.
- *                     Composes with --explain: both renderers run (explain
- *                     first, then flagged subset).
+ *   --config <path>      Config file (default: config/gutenberg-block-api.json)
+ *   --write              Write the canonical mapping AND the audit file (when re-rank ran)
+ *   --no-rerank          Skip the AI re-ranker (lexical-only output, no audit)
+ *   --explain            Print rationale per kept file and reason per dropped file to stdout
+ *   --review             Write mapping + audit AND emit only the flagged subset
+ *                        (confidence < 0.7) to stdout for the human-review loop.
+ *                        Implies --write. Mutually exclusive with --no-rerank.
+ *                        Composes with --explain: both renderers run (explain
+ *                        first, then flagged subset).
+ *   --force-regenerate   Override skip-on-review protection: when the existing
+ *                        mapping entry carries a `_reviews` block, write the
+ *                        fresh candidate tiers anyway (with `_reviews` stripped).
+ *                        Audit refreshes regardless. Without this flag, a
+ *                        reviewed slug leaves the mapping untouched and only
+ *                        refreshes the audit.
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
-import { resolve } from 'path';
 import Anthropic from '@anthropic-ai/sdk';
 import { loadConfig } from '../src/config/loader.js';
 import { createCodeSources } from '../src/adapters/index.js';
-import { ManifestEntrySchema, MappingSchema } from '../src/types/mapping.js';
+import { ManifestEntrySchema } from '../src/types/mapping.js';
 import { extractDocSymbols } from '../src/adapters/validator/context-assembler.js';
 import {
   buildSymbolIndex,
@@ -40,64 +45,13 @@ import { Reranker } from '../src/auto-map/rerank.js';
 import { RerankCache } from '../src/auto-map/rerank-cache.js';
 import { buildTiersForSlug, auditPathFor } from '../src/auto-map/orchestrator.js';
 import { AuditWriter } from '../src/auto-map/audit-writer.js';
+import { parseArgs } from '../src/auto-map/parse-args.js';
+import { decide as decideWriteAction } from '../src/auto-map/write-decision-policy.js';
 
-export function parseArgs(argv: string[]): {
-  slug: string;
-  configPath: string;
-  write: boolean;
-  rerank: boolean;
-  explain: boolean;
-  review: boolean;
-} {
-  const args = argv.slice(2);
-  let slug = '';
-  let configPath = resolve('config/gutenberg-block-api.json');
-  let write = false;
-  let rerank = true;
-  let explain = false;
-  let review = false;
-
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--config' && args[i + 1]) {
-      configPath = resolve(args[i + 1]);
-      i++;
-    } else if (args[i] === '--write') {
-      write = true;
-    } else if (args[i] === '--no-rerank') {
-      rerank = false;
-    } else if (args[i] === '--explain') {
-      explain = true;
-    } else if (args[i] === '--review') {
-      review = true;
-    } else if (!slug && !args[i].startsWith('--')) {
-      slug = args[i];
-    }
-  }
-
-  if (!slug) {
-    console.error('Usage: npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank] [--explain] [--review]');
-    process.exit(1);
-  }
-
-  // --review needs the audit (rationale + confidence per kept file) which
-  // only the AI re-ranker produces. --no-rerank means no audit, so the
-  // combination is rejected up-front rather than producing empty output.
-  if (review && !rerank) {
-    console.error(
-      'Error: --review cannot be used with --no-rerank. The flagged subset is derived from re-rank confidence; --no-rerank produces no audit. Drop one of the two flags.',
-    );
-    process.exit(2);
-  }
-
-  // --review implies --write (the human-review loop lands the auto-mapping
-  // immediately and surfaces the flagged subset on top).
-  if (review) write = true;
-
-  return { slug, configPath, write, rerank, explain, review };
-}
+export { parseArgs };
 
 async function main() {
-  const { slug, configPath, write, rerank, explain, review } = parseArgs(process.argv);
+  const { slug, configPath, write, rerank, explain, review, forceRegenerate } = parseArgs(process.argv);
   const config = await loadConfig(configPath);
 
   // 1. Fetch manifest and locate the entry for this slug
@@ -228,24 +182,58 @@ async function main() {
   }
 
   if (write) {
-    let existing: Record<string, unknown> = {};
+    // Read the mapping raw (no schema parse) so a malformed `_reviews` on
+    // the target slug surfaces through WriteDecisionPolicy as a clear abort
+    // rather than a generic Zod error. Other slugs are passed through
+    // unchanged on write.
+    let existingRaw: Record<string, unknown> = {};
     if (existsSync(config.mappingPath)) {
-      existing = MappingSchema.parse(
-        JSON.parse(readFileSync(config.mappingPath, 'utf-8')),
-      );
+      const parsed = JSON.parse(readFileSync(config.mappingPath, 'utf-8'));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        existingRaw = parsed as Record<string, unknown>;
+      }
     }
-    if (slug in existing) {
-      process.stderr.write(
-        `\nWarning: mapping for "${slug}" already exists and will be overwritten.\n`,
-      );
-    }
-    const merged = { ...existing, ...output };
-    writeFileSync(config.mappingPath, JSON.stringify(merged, null, 2) + '\n');
-    console.error(`\nWrote mapping for "${slug}" to ${config.mappingPath}`);
 
-    // Audit is the side channel of the AI re-ranker. It is written iff
-    // re-rank ran AND succeeded (rerankResult !== null). --no-rerank leaves
-    // any existing audit untouched.
+    const action = decideWriteAction({
+      slug,
+      existing: existingRaw[slug],
+      candidate: tiers,
+      forceRegenerate,
+    });
+
+    if (action.kind === 'abort') {
+      console.error(`\nError: ${action.reason}`);
+      process.exit(3);
+    }
+
+    // Mapping write — only `write-mapping` and `force-regenerate` mutate the
+    // mapping file. `write-suggestion` leaves the operator's curated entry
+    // intact; the freshly-computed tiers are still surfaced on stdout above
+    // (and Slice 3 will land them in the suggested side file).
+    if (action.kind === 'write-mapping' || action.kind === 'force-regenerate') {
+      const merged: Record<string, unknown> = { ...existingRaw, [slug]: action.tiers };
+      writeFileSync(config.mappingPath, JSON.stringify(merged, null, 2) + '\n');
+      if (action.kind === 'write-mapping') {
+        console.error(`\nWrote mapping for "${slug}" to ${config.mappingPath}`);
+      } else {
+        console.error(
+          `\n--force-regenerate: overrode review block on "${slug}" and wrote fresh tiers to ${config.mappingPath} (\`_reviews\` stripped).`,
+        );
+      }
+    } else {
+      // write-suggestion
+      const r = action.latestReview;
+      console.error(
+        `\nSkipping mapping write for "${slug}": preserved curated entry ` +
+          `(latest review by ${r.by} on ${r.date}). ` +
+          `Re-run with --force-regenerate to override.`,
+      );
+    }
+
+    // Audit refresh is decoupled from the mapping write — even on the
+    // `write-suggestion` branch we still refresh the audit so the operator
+    // can inspect what auto-map currently believes about the slug. The only
+    // branch that does NOT refresh is `abort` (returned above).
     if (rerankResult) {
       const auditPath = auditPathFor(config.mappingPath);
       auditWriter.writeAudit(auditPath, slug, rerankResult);

--- a/src/auto-map/__tests__/parse-args.test.ts
+++ b/src/auto-map/__tests__/parse-args.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { parseArgs } from '../parse-args.js';
+
+// Use a sentinel `process.argv[0..1]` prefix so tests focus on the user args.
+function argv(...flags: string[]): string[] {
+  return ['node', 'auto-map.ts', ...flags];
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('parseArgs — --force-regenerate flag', () => {
+  it('returns forceRegenerate: false when the flag is absent', () => {
+    const args = parseArgs(argv('block-metadata'));
+    expect(args.forceRegenerate).toBe(false);
+  });
+
+  it('returns forceRegenerate: true when --force-regenerate is present', () => {
+    const args = parseArgs(argv('block-metadata', '--force-regenerate'));
+    expect(args.forceRegenerate).toBe(true);
+  });
+
+  it('--force-regenerate composes with other flags without consuming the slug', () => {
+    const args = parseArgs(argv('block-metadata', '--write', '--force-regenerate'));
+    expect(args.slug).toBe('block-metadata');
+    expect(args.write).toBe(true);
+    expect(args.forceRegenerate).toBe(true);
+  });
+
+  it('--force-regenerate is order-independent (before vs after slug)', () => {
+    const beforeSlug = parseArgs(argv('--force-regenerate', 'block-metadata'));
+    const afterSlug  = parseArgs(argv('block-metadata', '--force-regenerate'));
+    expect(beforeSlug.slug).toBe('block-metadata');
+    expect(beforeSlug.forceRegenerate).toBe(true);
+    expect(afterSlug.slug).toBe('block-metadata');
+    expect(afterSlug.forceRegenerate).toBe(true);
+  });
+});
+
+describe('parseArgs — pre-existing flags still parsed', () => {
+  it('parses slug + defaults', () => {
+    const args = parseArgs(argv('block-metadata'));
+    expect(args.slug).toBe('block-metadata');
+    expect(args.write).toBe(false);
+    expect(args.rerank).toBe(true);
+    expect(args.explain).toBe(false);
+    expect(args.review).toBe(false);
+    expect(args.forceRegenerate).toBe(false);
+  });
+
+  it('parses --write', () => {
+    expect(parseArgs(argv('s', '--write')).write).toBe(true);
+  });
+
+  it('parses --no-rerank', () => {
+    expect(parseArgs(argv('s', '--no-rerank')).rerank).toBe(false);
+  });
+
+  it('parses --explain', () => {
+    expect(parseArgs(argv('s', '--explain')).explain).toBe(true);
+  });
+
+  it('--review implies --write', () => {
+    const args = parseArgs(argv('s', '--review'));
+    expect(args.review).toBe(true);
+    expect(args.write).toBe(true);
+  });
+});

--- a/src/auto-map/__tests__/write-decision-policy.test.ts
+++ b/src/auto-map/__tests__/write-decision-policy.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+
+import { decide } from '../write-decision-policy.js';
+import type { CodeTiers } from '../../types/mapping.js';
+
+const SLUG = 'block-metadata';
+
+const CANDIDATE: CodeTiers = {
+  primary:   [{ repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js' }],
+  secondary: [],
+  context:   [],
+};
+
+const REVIEWED_ENTRY = {
+  primary:   [{ repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js' }],
+  secondary: [],
+  context:   [],
+  _reviews: [
+    { by: 'juanmaguitar', date: '2026-04-15', notes: 'curated' },
+  ],
+};
+
+const ENTRY_WITHOUT_REVIEWS = {
+  primary:   [{ repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js' }],
+  secondary: [],
+  context:   [],
+};
+
+describe('WriteDecisionPolicy.decide — write-mapping branches', () => {
+  it('returns write-mapping when slug has no prior entry', () => {
+    const action = decide({
+      slug: SLUG,
+      existing: undefined,
+      candidate: CANDIDATE,
+      forceRegenerate: false,
+    });
+    expect(action).toEqual({ kind: 'write-mapping', tiers: CANDIDATE });
+  });
+
+  it('returns write-mapping when prior entry has no _reviews field', () => {
+    const action = decide({
+      slug: SLUG,
+      existing: ENTRY_WITHOUT_REVIEWS,
+      candidate: CANDIDATE,
+      forceRegenerate: false,
+    });
+    expect(action).toEqual({ kind: 'write-mapping', tiers: CANDIDATE });
+  });
+
+  it('returns write-mapping (not force-regenerate) when forceRegenerate is true but no _reviews exists', () => {
+    // _reviews is the precondition for force-regenerate; without it, the flag is a no-op.
+    const action = decide({
+      slug: SLUG,
+      existing: ENTRY_WITHOUT_REVIEWS,
+      candidate: CANDIDATE,
+      forceRegenerate: true,
+    });
+    expect(action).toEqual({ kind: 'write-mapping', tiers: CANDIDATE });
+  });
+});
+
+describe('WriteDecisionPolicy.decide — write-suggestion branch', () => {
+  it('returns write-suggestion when prior entry has valid _reviews and forceRegenerate=false', () => {
+    const action = decide({
+      slug: SLUG,
+      existing: REVIEWED_ENTRY,
+      candidate: CANDIDATE,
+      forceRegenerate: false,
+    });
+    expect(action.kind).toBe('write-suggestion');
+    if (action.kind === 'write-suggestion') {
+      expect(action.tiers).toEqual(CANDIDATE);
+      expect(action.latestReview).toEqual({ by: 'juanmaguitar', date: '2026-04-15', notes: 'curated' });
+    }
+  });
+
+  it('derives latestReview as max(date), order-independent (reviews in chronological order)', () => {
+    const entry = {
+      ...ENTRY_WITHOUT_REVIEWS,
+      _reviews: [
+        { by: 'alice', date: '2026-01-10' },
+        { by: 'bob',   date: '2026-03-22' },
+        { by: 'carol', date: '2026-02-05' },
+      ],
+    };
+    const action = decide({ slug: SLUG, existing: entry, candidate: CANDIDATE, forceRegenerate: false });
+    expect(action.kind).toBe('write-suggestion');
+    if (action.kind === 'write-suggestion') {
+      expect(action.latestReview).toEqual({ by: 'bob', date: '2026-03-22' });
+    }
+  });
+
+  it('derives latestReview as max(date), order-independent (reviews in reverse-chronological order)', () => {
+    const entry = {
+      ...ENTRY_WITHOUT_REVIEWS,
+      _reviews: [
+        { by: 'bob',   date: '2026-03-22' },
+        { by: 'carol', date: '2026-02-05' },
+        { by: 'alice', date: '2026-01-10' },
+      ],
+    };
+    const action = decide({ slug: SLUG, existing: entry, candidate: CANDIDATE, forceRegenerate: false });
+    expect(action.kind).toBe('write-suggestion');
+    if (action.kind === 'write-suggestion') {
+      expect(action.latestReview).toEqual({ by: 'bob', date: '2026-03-22' });
+    }
+  });
+
+  it('latestReview is stable when two entries share the same date (deterministic tie-break)', () => {
+    const entry = {
+      ...ENTRY_WITHOUT_REVIEWS,
+      _reviews: [
+        { by: 'alice', date: '2026-03-22' },
+        { by: 'bob',   date: '2026-03-22' },
+      ],
+    };
+    const a = decide({ slug: SLUG, existing: entry, candidate: CANDIDATE, forceRegenerate: false });
+    const b = decide({ slug: SLUG, existing: entry, candidate: CANDIDATE, forceRegenerate: false });
+    expect(a).toEqual(b);
+  });
+});
+
+describe('WriteDecisionPolicy.decide — force-regenerate branch', () => {
+  it('returns force-regenerate when prior entry has valid _reviews and forceRegenerate=true', () => {
+    const action = decide({
+      slug: SLUG,
+      existing: REVIEWED_ENTRY,
+      candidate: CANDIDATE,
+      forceRegenerate: true,
+    });
+    expect(action).toEqual({ kind: 'force-regenerate', tiers: CANDIDATE });
+  });
+});
+
+describe('WriteDecisionPolicy.decide — abort branch (malformed _reviews)', () => {
+  it('aborts when _reviews is an empty array', () => {
+    const entry = { ...ENTRY_WITHOUT_REVIEWS, _reviews: [] };
+    const action = decide({ slug: SLUG, existing: entry, candidate: CANDIDATE, forceRegenerate: false });
+    expect(action.kind).toBe('abort');
+    if (action.kind === 'abort') {
+      expect(action.reason).toContain(SLUG);
+      expect(action.reason).toContain('_reviews');
+      expect(action.reason).toMatch(/empty/i);
+    }
+  });
+
+  it('aborts when a _reviews entry is missing the "by" field', () => {
+    const entry = {
+      ...ENTRY_WITHOUT_REVIEWS,
+      _reviews: [{ date: '2026-04-15' }],
+    };
+    const action = decide({ slug: SLUG, existing: entry, candidate: CANDIDATE, forceRegenerate: false });
+    expect(action.kind).toBe('abort');
+    if (action.kind === 'abort') {
+      expect(action.reason).toContain(SLUG);
+      expect(action.reason).toContain('by');
+    }
+  });
+
+  it('aborts when a _reviews entry has an empty "by"', () => {
+    const entry = {
+      ...ENTRY_WITHOUT_REVIEWS,
+      _reviews: [{ by: '', date: '2026-04-15' }],
+    };
+    const action = decide({ slug: SLUG, existing: entry, candidate: CANDIDATE, forceRegenerate: false });
+    expect(action.kind).toBe('abort');
+    if (action.kind === 'abort') {
+      expect(action.reason).toContain(SLUG);
+      expect(action.reason).toContain('by');
+    }
+  });
+
+  it('aborts when a _reviews entry has a non-ISO "date"', () => {
+    const entry = {
+      ...ENTRY_WITHOUT_REVIEWS,
+      _reviews: [{ by: 'juanmaguitar', date: 'April 15, 2026' }],
+    };
+    const action = decide({ slug: SLUG, existing: entry, candidate: CANDIDATE, forceRegenerate: false });
+    expect(action.kind).toBe('abort');
+    if (action.kind === 'abort') {
+      expect(action.reason).toContain(SLUG);
+      expect(action.reason).toContain('date');
+    }
+  });
+
+  it('aborts even when forceRegenerate=true (malformed reviews block both code paths)', () => {
+    const entry = { ...ENTRY_WITHOUT_REVIEWS, _reviews: [] };
+    const action = decide({ slug: SLUG, existing: entry, candidate: CANDIDATE, forceRegenerate: true });
+    expect(action.kind).toBe('abort');
+  });
+
+  it('aborts when _reviews is present but not an array', () => {
+    const entry = { ...ENTRY_WITHOUT_REVIEWS, _reviews: { by: 'x', date: '2026-04-15' } };
+    const action = decide({ slug: SLUG, existing: entry, candidate: CANDIDATE, forceRegenerate: false });
+    expect(action.kind).toBe('abort');
+    if (action.kind === 'abort') {
+      expect(action.reason).toContain('_reviews');
+    }
+  });
+});
+
+describe('WriteDecisionPolicy.decide — purity', () => {
+  it('does not mutate inputs', () => {
+    const entry = JSON.parse(JSON.stringify(REVIEWED_ENTRY));
+    const candidate = JSON.parse(JSON.stringify(CANDIDATE)) as CodeTiers;
+    const before = JSON.stringify({ entry, candidate });
+    decide({ slug: SLUG, existing: entry, candidate, forceRegenerate: false });
+    expect(JSON.stringify({ entry, candidate })).toBe(before);
+  });
+});

--- a/src/auto-map/parse-args.ts
+++ b/src/auto-map/parse-args.ts
@@ -1,0 +1,72 @@
+/**
+ * Argument parsing for `scripts/auto-map.ts`. Lives here (not in the script
+ * itself) so it can be unit-tested without invoking the script's top-level
+ * `main()` side effects.
+ */
+import { resolve } from 'path';
+
+export interface AutoMapArgs {
+  slug:            string;
+  configPath:      string;
+  write:           boolean;
+  rerank:          boolean;
+  explain:         boolean;
+  review:          boolean;
+  // `--force-regenerate`: explicit escape hatch that overrides the
+  // skip-on-review protection introduced in #84. The flag itself is the
+  // deliberate verb; no extra confirmation prompt is gated behind it.
+  forceRegenerate: boolean;
+}
+
+export function parseArgs(argv: string[]): AutoMapArgs {
+  const args = argv.slice(2);
+  let slug = '';
+  let configPath = resolve('config/gutenberg-block-api.json');
+  let write = false;
+  let rerank = true;
+  let explain = false;
+  let review = false;
+  let forceRegenerate = false;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--config' && args[i + 1]) {
+      configPath = resolve(args[i + 1]);
+      i++;
+    } else if (args[i] === '--write') {
+      write = true;
+    } else if (args[i] === '--no-rerank') {
+      rerank = false;
+    } else if (args[i] === '--explain') {
+      explain = true;
+    } else if (args[i] === '--review') {
+      review = true;
+    } else if (args[i] === '--force-regenerate') {
+      forceRegenerate = true;
+    } else if (!slug && !args[i].startsWith('--')) {
+      slug = args[i];
+    }
+  }
+
+  if (!slug) {
+    console.error(
+      'Usage: npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank] [--explain] [--review] [--force-regenerate]',
+    );
+    process.exit(1);
+  }
+
+  // --review needs the audit (rationale + confidence per kept file) which
+  // only the AI re-ranker produces. --no-rerank means no audit, so the
+  // combination is rejected up-front rather than producing empty output.
+  if (review && !rerank) {
+    console.error(
+      'Error: --review cannot be used with --no-rerank. The flagged subset is derived from re-rank confidence; --no-rerank produces no audit. Drop one of the two flags.',
+    );
+    process.exit(2);
+  }
+
+  // --review implies --write (the human-review loop lands the auto-mapping
+  // immediately and surfaces the flagged subset on top).
+  if (review) write = true;
+
+  return { slug, configPath, write, rerank, explain, review, forceRegenerate };
+}

--- a/src/auto-map/write-decision-policy.ts
+++ b/src/auto-map/write-decision-policy.ts
@@ -1,0 +1,106 @@
+/**
+ * WriteDecisionPolicy — pure function that decides what `scripts/auto-map.ts`
+ * should do for a given slug invocation, given the existing per-slug entry
+ * from the mapping file, the freshly-computed candidate `CodeTiers`, and the
+ * `--force-regenerate` flag.
+ *
+ * The decision is a tagged union (`WriteActions`); the script dispatches on
+ * `kind`. Keeping the policy I/O-free makes the branching exhaustively
+ * unit-testable without touching the filesystem or the AI re-ranker.
+ *
+ * Branching table (mirrors the issue's spec):
+ *
+ *   Existing entry                       | forceRegenerate | Action
+ *   -------------------------------------|-----------------|----------------------
+ *   Slug not in mapping                  | –               | write-mapping
+ *   Slug present, no `_reviews` field    | –               | write-mapping
+ *   Slug present, valid `_reviews` (≥1)  | false           | write-suggestion
+ *   Slug present, valid `_reviews` (≥1)  | true            | force-regenerate
+ *   Slug present, malformed `_reviews`   | any             | abort (named field)
+ *
+ * Malformed = `_reviews` not an array, empty array, entry missing `by`, entry
+ * with empty `by`, entry with non-ISO `date` (YYYY-MM-DD).
+ */
+import type { CodeTiers, ReviewEntry } from '../types/mapping.js';
+
+export type WriteActions =
+  | { kind: 'write-mapping';     tiers: CodeTiers }
+  | { kind: 'write-suggestion';  tiers: CodeTiers; latestReview: ReviewEntry }
+  | { kind: 'force-regenerate';  tiers: CodeTiers }
+  | { kind: 'abort';             reason: string };
+
+export interface DecideInput {
+  slug:            string;
+  // Raw existing per-slug entry from the mapping file, or undefined if the
+  // slug is not yet in the file. Typed `unknown` because we need to detect
+  // malformed `_reviews` ourselves rather than rejecting it at JSON-load time.
+  existing:        unknown;
+  candidate:       CodeTiers;
+  forceRegenerate: boolean;
+}
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function decide(input: DecideInput): WriteActions {
+  const { slug, existing, candidate, forceRegenerate } = input;
+
+  if (existing === undefined || existing === null || typeof existing !== 'object') {
+    return { kind: 'write-mapping', tiers: candidate };
+  }
+
+  const entry = existing as Record<string, unknown>;
+  if (!('_reviews' in entry)) {
+    return { kind: 'write-mapping', tiers: candidate };
+  }
+
+  const reviewsRaw = entry._reviews;
+  if (!Array.isArray(reviewsRaw)) {
+    return abort(slug, '"_reviews" is present but is not an array');
+  }
+  if (reviewsRaw.length === 0) {
+    return abort(slug, '"_reviews" is an empty array');
+  }
+
+  const reviews: ReviewEntry[] = [];
+  for (let i = 0; i < reviewsRaw.length; i++) {
+    const r = reviewsRaw[i];
+    if (typeof r !== 'object' || r === null) {
+      return abort(slug, `"_reviews"[${i}] is not an object`);
+    }
+    const re = r as Record<string, unknown>;
+    if (typeof re.by !== 'string') {
+      return abort(slug, `"_reviews"[${i}] is missing string field "by"`);
+    }
+    if (re.by.length === 0) {
+      return abort(slug, `"_reviews"[${i}].by is empty`);
+    }
+    if (typeof re.date !== 'string') {
+      return abort(slug, `"_reviews"[${i}] is missing string field "date"`);
+    }
+    if (!ISO_DATE.test(re.date)) {
+      return abort(slug, `"_reviews"[${i}].date is not ISO YYYY-MM-DD ("${re.date}")`);
+    }
+    const review: ReviewEntry = { by: re.by, date: re.date };
+    if (typeof re.notes === 'string') review.notes = re.notes;
+    reviews.push(review);
+  }
+
+  if (forceRegenerate) {
+    return { kind: 'force-regenerate', tiers: candidate };
+  }
+
+  // Pick max(date) order-independently. ISO YYYY-MM-DD strings sort
+  // lexicographically the same way they sort chronologically, so a plain
+  // string compare is correct. Ties break on first-seen so the result is
+  // deterministic for callers that snapshot it.
+  let latestReview = reviews[0];
+  for (let i = 1; i < reviews.length; i++) {
+    if (reviews[i].date > latestReview.date) latestReview = reviews[i];
+  }
+
+  return { kind: 'write-suggestion', tiers: candidate, latestReview };
+}
+
+function abort(slug: string, detail: string): WriteActions {
+  return { kind: 'abort', reason: `Mapping for "${slug}": ${detail}.` };
+}


### PR DESCRIPTION
## Summary
Adds `WriteDecisionPolicy` and `--review` / `--no-rerank` flag handling for review-aware mapping regeneration. Slice 2 of #82 — depends on `_reviews`
schema field landed in #83.

## How to test
- `npm test` — full suite (368 passing)
- `npm run typecheck` — clean

Closes #84