### PR TITLE
RALPH: SuggestedMappingWriter side file (#85)

### DIFF
--- a/scripts/auto-map.ts
+++ b/scripts/auto-map.ts
@@ -43,8 +43,9 @@ import {
 } from '../src/indexer/symbol-index.js';
 import { Reranker } from '../src/auto-map/rerank.js';
 import { RerankCache } from '../src/auto-map/rerank-cache.js';
-import { buildTiersForSlug, auditPathFor } from '../src/auto-map/orchestrator.js';
+import { buildTiersForSlug, auditPathFor, suggestedPathFor } from '../src/auto-map/orchestrator.js';
 import { AuditWriter } from '../src/auto-map/audit-writer.js';
+import { SuggestedMappingWriter } from '../src/auto-map/suggested-mapping-writer.js';
 import { parseArgs } from '../src/auto-map/parse-args.js';
 import { decide as decideWriteAction } from '../src/auto-map/write-decision-policy.js';
 
@@ -208,8 +209,11 @@ async function main() {
 
     // Mapping write — only `write-mapping` and `force-regenerate` mutate the
     // mapping file. `write-suggestion` leaves the operator's curated entry
-    // intact; the freshly-computed tiers are still surfaced on stdout above
-    // (and Slice 3 will land them in the suggested side file).
+    // intact; the freshly-computed tiers are landed in the suggested side
+    // file below for the operator's annual review.
+    const suggestedWriter = new SuggestedMappingWriter();
+    const suggestedPath = suggestedPathFor(config.mappingPath);
+
     if (action.kind === 'write-mapping' || action.kind === 'force-regenerate') {
       const merged: Record<string, unknown> = { ...existingRaw, [slug]: action.tiers };
       writeFileSync(config.mappingPath, JSON.stringify(merged, null, 2) + '\n');
@@ -220,14 +224,23 @@ async function main() {
           `\n--force-regenerate: overrode review block on "${slug}" and wrote fresh tiers to ${config.mappingPath} (\`_reviews\` stripped).`,
         );
       }
+      // Both branches return the slug to "auto-map land" — no curated
+      // candidate to surface in the side file. `remove` is a no-op when the
+      // slug is absent, so this also handles the `write-mapping` case where
+      // the operator manually deleted `_reviews` and a stale suggestion
+      // entry might linger from an earlier review cycle.
+      suggestedWriter.remove(suggestedPath, slug);
     } else {
-      // write-suggestion
+      // write-suggestion: preserve the curated mapping; land the candidate
+      // in the side file as the annual review prompt.
       const r = action.latestReview;
       console.error(
         `\nSkipping mapping write for "${slug}": preserved curated entry ` +
           `(latest review by ${r.by} on ${r.date}). ` +
           `Re-run with --force-regenerate to override.`,
       );
+      suggestedWriter.upsert(suggestedPath, slug, action.tiers);
+      console.error(`Wrote suggested tiers for "${slug}" to ${suggestedPath}`);
     }
 
     // Audit refresh is decoupled from the mapping write — even on the

--- a/src/auto-map/__tests__/orchestrator.test.ts
+++ b/src/auto-map/__tests__/orchestrator.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import type Anthropic from '@anthropic-ai/sdk';
 
-import { buildTiersForSlug, auditPathFor } from '../orchestrator.js';
+import { buildTiersForSlug, auditPathFor, suggestedPathFor } from '../orchestrator.js';
 import { Reranker } from '../rerank.js';
 import { RerankCache } from '../rerank-cache.js';
 import { AuditWriter, MappingAuditSchema, NO_FLAGGED_SENTINEL } from '../audit-writer.js';
@@ -443,6 +443,14 @@ describe('orchestrator + AuditWriter wiring (smoke)', () => {
     );
     // Falls back to suffix append for non-.json paths
     expect(auditPathFor('mappings/site')).toBe('mappings/site.audit.json');
+  });
+
+  it('suggestedPathFor derives `<mapping>.suggested.json` from `<mapping>.json`', () => {
+    expect(suggestedPathFor('mappings/gutenberg-block-api.json')).toBe(
+      'mappings/gutenberg-block-api.suggested.json',
+    );
+    // Falls back to suffix append for non-.json paths
+    expect(suggestedPathFor('mappings/site')).toBe('mappings/site.suggested.json');
   });
 });
 

--- a/src/auto-map/__tests__/suggested-mapping-writer.test.ts
+++ b/src/auto-map/__tests__/suggested-mapping-writer.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, readFileSync, writeFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { SuggestedMappingWriter } from '../suggested-mapping-writer.js';
+import type { CodeTiers } from '../../types/mapping.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tmpSuggestedPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'suggested-writer-test-'));
+  return join(dir, 'sample-site.suggested.json');
+}
+
+const TIERS_A: CodeTiers = {
+  primary:   [{ repo: 'gutenberg', path: 'packages/blocks/src/api/registration.js' }],
+  secondary: [{ repo: 'gutenberg', path: 'packages/blocks/src/api/parser.js' }],
+  context:   [{ repo: 'gutenberg', path: 'packages/blocks/src/api/utils.ts' }],
+};
+
+const TIERS_B: CodeTiers = {
+  primary:   [{ repo: 'gutenberg', path: 'packages/blocks/src/api/serializer.js' }],
+  secondary: [],
+  context:   [],
+};
+
+const TIERS_C: CodeTiers = {
+  primary:   [{ repo: 'gutenberg', path: 'packages/blocks/src/api/factory.js' }],
+  secondary: [],
+  context:   [],
+};
+
+// ---------------------------------------------------------------------------
+// read
+// ---------------------------------------------------------------------------
+
+describe('SuggestedMappingWriter.read', () => {
+  it('returns empty object when file is missing', () => {
+    const writer = new SuggestedMappingWriter();
+    const path = tmpSuggestedPath();
+    expect(writer.read(path)).toEqual({});
+  });
+
+  it('returns empty object when file is malformed JSON', () => {
+    const writer = new SuggestedMappingWriter();
+    const path = tmpSuggestedPath();
+    writeFileSync(path, '{ this is not valid json');
+    expect(writer.read(path)).toEqual({});
+  });
+
+  it('returns the parsed slug→tiers map when file exists', () => {
+    const writer = new SuggestedMappingWriter();
+    const path = tmpSuggestedPath();
+    writer.upsert(path, 'slug-a', TIERS_A);
+    expect(writer.read(path)).toEqual({ 'slug-a': TIERS_A });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsert
+// ---------------------------------------------------------------------------
+
+describe('SuggestedMappingWriter.upsert', () => {
+  it('creates the file with one entry when it does not exist', () => {
+    const writer = new SuggestedMappingWriter();
+    const path = tmpSuggestedPath();
+    writer.upsert(path, 'slug-a', TIERS_A);
+
+    expect(existsSync(path)).toBe(true);
+    const raw = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(raw).toEqual({ 'slug-a': TIERS_A });
+  });
+
+  it('creates the parent directory if it does not yet exist', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'suggested-mkdir-'));
+    const path = join(dir, 'nested', 'sub', 'site.suggested.json');
+    const writer = new SuggestedMappingWriter();
+    writer.upsert(path, 'slug-a', TIERS_A);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it('preserves other slug entries when upserting a new slug', () => {
+    const writer = new SuggestedMappingWriter();
+    const path = tmpSuggestedPath();
+    writer.upsert(path, 'slug-a', TIERS_A);
+    writer.upsert(path, 'slug-b', TIERS_B);
+
+    const raw = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(raw).toEqual({ 'slug-a': TIERS_A, 'slug-b': TIERS_B });
+  });
+
+  it('replaces the target slug (no append semantics; latest view wins)', () => {
+    const writer = new SuggestedMappingWriter();
+    const path = tmpSuggestedPath();
+    writer.upsert(path, 'slug-a', TIERS_A);
+    writer.upsert(path, 'slug-a', TIERS_B);
+
+    const raw = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(raw).toEqual({ 'slug-a': TIERS_B });
+    expect(Object.keys(raw)).toEqual(['slug-a']);
+  });
+
+  it('emits slug keys in deterministic (sorted) order', () => {
+    const writer = new SuggestedMappingWriter();
+    const path = tmpSuggestedPath();
+    writer.upsert(path, 'zeta',  TIERS_B);
+    writer.upsert(path, 'alpha', TIERS_A);
+    writer.upsert(path, 'mu',    TIERS_C);
+
+    const text = readFileSync(path, 'utf-8');
+    const idxAlpha = text.indexOf('"alpha"');
+    const idxMu    = text.indexOf('"mu"');
+    const idxZeta  = text.indexOf('"zeta"');
+    expect(idxAlpha).toBeGreaterThan(0);
+    expect(idxMu).toBeGreaterThan(idxAlpha);
+    expect(idxZeta).toBeGreaterThan(idxMu);
+  });
+
+  it('treats a malformed existing file as empty (does not throw)', () => {
+    const writer = new SuggestedMappingWriter();
+    const path = tmpSuggestedPath();
+    writeFileSync(path, '{ broken json');
+    expect(() => writer.upsert(path, 'slug-a', TIERS_A)).not.toThrow();
+    const raw = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(raw).toEqual({ 'slug-a': TIERS_A });
+  });
+
+  it('writes file ending in a trailing newline', () => {
+    const writer = new SuggestedMappingWriter();
+    const path = tmpSuggestedPath();
+    writer.upsert(path, 'slug-a', TIERS_A);
+    const text = readFileSync(path, 'utf-8');
+    expect(text.endsWith('\n')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// remove
+// ---------------------------------------------------------------------------
+
+describe('SuggestedMappingWriter.remove', () => {
+  it('deletes the target slug entry', () => {
+    const writer = new SuggestedMappingWriter();
+    const path = tmpSuggestedPath();
+    writer.upsert(path, 'slug-a', TIERS_A);
+    writer.upsert(path, 'slug-b', TIERS_B);
+
+    writer.remove(path, 'slug-a');
+
+    const raw = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(raw).toEqual({ 'slug-b': TIERS_B });
+  });
+
+  it('is a no-op when the slug is absent (other slugs untouched)', () => {
+    const writer = new SuggestedMappingWriter();
+    const path = tmpSuggestedPath();
+    writer.upsert(path, 'slug-b', TIERS_B);
+
+    writer.remove(path, 'slug-a');
+
+    const raw = JSON.parse(readFileSync(path, 'utf-8'));
+    expect(raw).toEqual({ 'slug-b': TIERS_B });
+  });
+
+  it('is a no-op when the file does not exist (does not create it, does not throw)', () => {
+    const writer = new SuggestedMappingWriter();
+    const path = tmpSuggestedPath();
+    expect(() => writer.remove(path, 'slug-a')).not.toThrow();
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it('leaves `{}\\n` rather than deleting the file when the last slug is removed', () => {
+    const writer = new SuggestedMappingWriter();
+    const path = tmpSuggestedPath();
+    writer.upsert(path, 'slug-a', TIERS_A);
+
+    writer.remove(path, 'slug-a');
+
+    expect(existsSync(path)).toBe(true);
+    const text = readFileSync(path, 'utf-8');
+    expect(text).toBe('{}\n');
+  });
+});

--- a/src/auto-map/orchestrator.ts
+++ b/src/auto-map/orchestrator.ts
@@ -44,6 +44,20 @@ export function auditPathFor(mappingPath: string): string {
   return `${mappingPath}.audit.json`;
 }
 
+/**
+ * Derive the suggested-mapping side-file path from the canonical mapping
+ * path, e.g. `mappings/gutenberg-block-api.json` →
+ * `mappings/gutenberg-block-api.suggested.json`. Mirrors `auditPathFor`'s
+ * shape; the side file lives next to the canonical mapping and is committed
+ * alongside it.
+ */
+export function suggestedPathFor(mappingPath: string): string {
+  if (mappingPath.endsWith('.json')) {
+    return mappingPath.replace(/\.json$/, '.suggested.json');
+  }
+  return `${mappingPath}.suggested.json`;
+}
+
 export type BuildTiersInput = {
   docContent:     string;
   slug:           string;

--- a/src/auto-map/suggested-mapping-writer.ts
+++ b/src/auto-map/suggested-mapping-writer.ts
@@ -1,0 +1,69 @@
+/**
+ * SuggestedMappingWriter — persists auto-map's would-be CodeTiers output for
+ * reviewed slugs into a committed side file at `mappings/<site>.suggested.json`.
+ *
+ * Auto-map runs are infrequent (quarterly to annually); the side file is an
+ * annual review prompt for the operator — "here is what auto-map currently
+ * believes for slugs you previously hand-curated" — not a weekly delta. The
+ * canonical `Mapping` in `mappings/<site>.json` is unchanged on a reviewed
+ * slug; the side file carries the candidate.
+ *
+ * File format is intentionally minimal: a flat `Record<string, CodeTiers>`
+ * keyed by slug, fully overwritten on every write. No envelope, no version —
+ * the .suggested.json suffix and the .json side-by-side with the canonical
+ * mapping convey provenance.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
+
+import type { CodeTiers } from '../types/mapping.js';
+
+export class SuggestedMappingWriter {
+  /**
+   * Read the slug→tiers map from `path`. Missing or malformed files are
+   * treated as empty rather than throwing.
+   */
+  read(path: string): Record<string, CodeTiers> {
+    if (!existsSync(path)) return {};
+    let raw: unknown;
+    try {
+      raw = JSON.parse(readFileSync(path, 'utf-8'));
+    } catch {
+      return {};
+    }
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return {};
+    return raw as Record<string, CodeTiers>;
+  }
+
+  /**
+   * Replace `slug`'s entry with `tiers`. Other slugs are preserved. Creates
+   * the file (and parent directory) when absent.
+   */
+  upsert(path: string, slug: string, tiers: CodeTiers): void {
+    const existing = this.read(path);
+    existing[slug] = tiers;
+    this.writeSorted(path, existing);
+  }
+
+  /**
+   * Delete `slug`'s entry. No-op when the slug is absent or the file is
+   * missing. When removing the last slug, the file is left as `{}\n` rather
+   * than deleted — keeps diffs stable when a reviewed slug is regenerated.
+   */
+  remove(path: string, slug: string): void {
+    if (!existsSync(path)) return;
+    const existing = this.read(path);
+    if (!(slug in existing)) return;
+    delete existing[slug];
+    this.writeSorted(path, existing);
+  }
+
+  private writeSorted(path: string, entries: Record<string, CodeTiers>): void {
+    const sorted: Record<string, CodeTiers> = {};
+    for (const k of Object.keys(entries).sort()) {
+      sorted[k] = entries[k];
+    }
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(sorted, null, 2) + '\n');
+  }
+}


### PR DESCRIPTION
## Summary

Adds the `mappings/<site>.suggested.json` side file that carries auto-map's would-be CodeTiers for reviewed slugs. Auto-map runs are infrequent (quarterly to annually); this side file becomes the operator's **annual review prompt** to revisit hand-curated mappings — not a weekly delta. The validator pipeline never reads it, so behaviour is unchanged.

A new `SuggestedMappingWriter` exposes `read` / `upsert` / `remove`. Wired into the `WriteDecisionPolicy` dispatch in `scripts/auto-map.ts`:

- `write-suggestion` → `upsert` (curated mapping preserved; candidate lands in side file).
- `force-regenerate` → `remove` (slug returns cleanly to "auto-map land"; mapping write strips `_reviews`, side file should not retain a stale candidate).
- `write-mapping` → `remove` (idempotent cleanup; covers the case where the operator manually deleted `_reviews` from a previously-reviewed slug, leaving a stale entry in the side file).
- `abort` → no side-file mutation.

A new `suggestedPathFor(mappingPath)` helper sits alongside `auditPathFor` in `src/auto-map/orchestrator.ts`.

Closes #85

## Changes

- `src/auto-map/suggested-mapping-writer.ts` — new module with `read` / `upsert` / `remove`. Sorted-key writes for stable diffs; treats malformed JSON as empty (no throw); leaves `{}\n` rather than deleting the file when the last slug is removed.
- `src/auto-map/__tests__/suggested-mapping-writer.test.ts` — covers every branch in the issue's acceptance criteria (missing-file read, empty-on-create upsert, multi-slug preservation, slug replacement, sorted ordering, malformed-input tolerance, no-op remove, empty-file `{}\n` post-condition).
- `src/auto-map/orchestrator.ts` — adds `suggestedPathFor` mirroring `auditPathFor`.
- `src/auto-map/__tests__/orchestrator.test.ts` — adds a unit test for `suggestedPathFor`.
- `scripts/auto-map.ts` — dispatches the writer based on the `WriteDecisionPolicy` action.

## How to test

1. `git fetch origin && git checkout ralph/85-suggested-mapping-writer`
2. `npm install`
3. `npm run typecheck` — should be clean.
4. `npm test` — should be green; new suite `src/auto-map/__tests__/suggested-mapping-writer.test.ts` (14 tests) and the new `suggestedPathFor` test in `orchestrator.test.ts` pin the writer's CRUD semantics and the path-derivation helper.
5. Inspect the new module: `cat src/auto-map/suggested-mapping-writer.ts` — confirm it has only `read` / `upsert` / `remove` (no extra surface), preserves keys via sorted iteration, and creates parent directories on first write.
6. Inspect the script integration: `git show HEAD -- scripts/auto-map.ts` — confirm the four dispatch branches in step 5 of the summary above.
7. (Optional, requires API key) Run `npx tsx scripts/auto-map.ts <slug-with-_reviews> --config config/gutenberg-block-api.json --write` and confirm:
   - The canonical mapping is unchanged.
   - `mappings/gutenberg-block-api.suggested.json` is created (or updated) with an entry for that slug.
   - Re-running with `--force-regenerate` removes the slug from the side file.

Expected outcome: a passing build with the new tests green, and the side file written/removed as the dispatch table specifies.

## Out of scope

- No changes to `src/types/` (locked contracts).
- No changes to `examples/results.schema.json` (generated artifact).
- No `.gitignore` change — the side file is committed alongside the canonical mapping, same convention as the audit file.
- Validator pipeline behaviour is unaffected; the side file is never read by the analyzer.
