### PR TITLE
RALPH: surface Pass 1 failure as critical, not silent healthy (#49)

### DIFF
--- a/src/adapters/validator/__tests__/claude.test.ts
+++ b/src/adapters/validator/__tests__/claude.test.ts
@@ -997,3 +997,75 @@ describe('ClaudeValidator — N-sample Pass 1', () => {
     ).toThrow(/samples must be an integer >= 1/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// ClaudeValidator — Pass 1 failure must downgrade status to 'critical' (issue #49)
+//
+// When the validator cannot complete Pass 1 (missing API key, network error,
+// rate-limit, malformed response, or — in multi-sample mode — every sample
+// throwing), the resulting DocResult must reflect analytic failure rather
+// than defaulting to `healthy/100` from `scoreDoc([])`. A clean doc (Pass 1
+// succeeded with zero issues) must still be `healthy/100` — the fix
+// distinguishes "no issues found" from "could not look".
+// ---------------------------------------------------------------------------
+
+describe('ClaudeValidator — Pass 1 failure status (issue #49)', () => {
+  it('marks the doc critical with healthScore 0 when single-sample Pass 1 throws', async () => {
+    const client = {
+      messages: {
+        create: vi.fn(async () => {
+          throw new Error('Anthropic API error: invalid x-api-key');
+        }),
+      },
+    } as unknown as Anthropic;
+
+    const validator = new ClaudeValidator('claude-sonnet-4-6', 'claude-sonnet-4-6', client);
+    const result = await validator.validateDoc(makeDoc(), makeCodeTiers(), makeCodeSources());
+
+    expect(result.status).toBe('critical');
+    expect(result.healthScore).toBe(0);
+    expect(result.issues).toHaveLength(0);
+    expect(result.diagnostics.some(d => /Pass 1 failed/.test(d))).toBe(true);
+    expect(result.diagnostics.some(d => /invalid x-api-key/.test(d))).toBe(true);
+  });
+
+  it('marks the doc critical when every Pass-1 sample throws (multi-sample mode)', async () => {
+    const client = {
+      messages: {
+        create: vi.fn(async () => {
+          throw new Error('rate limited');
+        }),
+      },
+    } as unknown as Anthropic;
+
+    const validator = new ClaudeValidator(
+      'claude-sonnet-4-6',
+      'claude-sonnet-4-6',
+      client,
+      undefined,
+      { samples: 3 },
+    );
+    const result = await validator.validateDoc(makeDoc(), makeCodeTiers(), makeCodeSources());
+
+    expect(result.status).toBe('critical');
+    expect(result.healthScore).toBe(0);
+    expect(result.issues).toHaveLength(0);
+    // Per-sample failure entries should remain in diagnostics so the cause is surfaced.
+    expect(result.diagnostics.filter(d => /Pass 1 sample \d+\/3 failed/.test(d))).toHaveLength(3);
+  });
+
+  it('preserves healthy/100 for a clean doc where Pass 1 succeeds with zero issues', async () => {
+    // The empty-findings → healthy/100 contract on `scoreDoc` MUST remain
+    // intact. Only analytic failure (above) downgrades to critical.
+    const pass1Empty = makeReportFindingsResponse([], ['Documentation accurately describes the API']);
+    const client = makeAnthropicClient([pass1Empty]);
+
+    const validator = new ClaudeValidator('claude-sonnet-4-6', 'claude-sonnet-4-6', client);
+    const result = await validator.validateDoc(makeDoc(), makeCodeTiers(), makeCodeSources());
+
+    expect(result.status).toBe('healthy');
+    expect(result.healthScore).toBe(100);
+    expect(result.issues).toHaveLength(0);
+    expect(result.diagnostics.some(d => /Pass 1 failed/.test(d))).toBe(false);
+  });
+});

--- a/src/adapters/validator/claude.ts
+++ b/src/adapters/validator/claude.ts
@@ -370,8 +370,11 @@ export class ClaudeValidator implements Validator {
         pass1Issues = pass1Result.issues;
         positives = pass1Result.positives.slice(0, 3);
       } catch (err) {
+        // Pass 1 produced no signal — the doc's health is unknown.
+        // Surface that as `critical` rather than letting `scoreDoc([])`
+        // default to healthy/100 (issue #49).
         diagnostics.push(`Pass 1 failed: ${String(err)}`);
-        return this.buildDocResult(doc, [], positives, assembled.relatedCode, diagnostics, commitSha);
+        return this.buildFailureDocResult(doc, positives, assembled.relatedCode, diagnostics, commitSha);
       }
     } else {
       const seenFingerprints = new Set<string>();
@@ -403,7 +406,8 @@ export class ClaudeValidator implements Validator {
         }
       }
       if (succeededSamples === 0) {
-        return this.buildDocResult(doc, [], [], assembled.relatedCode, diagnostics, commitSha);
+        // Every sample failed — same situation as a single-sample throw.
+        return this.buildFailureDocResult(doc, [], assembled.relatedCode, diagnostics, commitSha);
       }
       positives = aggregatedPositives.slice(0, 3);
     }
@@ -493,6 +497,35 @@ export class ClaudeValidator implements Validator {
       healthScore,
       status,
       issues,
+      positives,
+      relatedCode,
+      diagnostics,
+      commitSha,
+      analyzedAt:  new Date().toISOString(),
+    };
+  }
+
+  // Build a DocResult for the case where Pass 1 produced no signal at all
+  // (single-sample throw, or every sample failing in multi-sample mode).
+  // Bypasses `scoreDoc` deliberately: an empty issue array there would
+  // collapse to healthy/100, masking analytic failure as a clean doc
+  // (issue #49). The clean-doc path (Pass 1 succeeded with zero issues)
+  // still flows through `buildDocResult` and remains healthy/100.
+  private buildFailureDocResult(
+    doc: Doc,
+    positives: string[],
+    relatedCode: DocResult['relatedCode'],
+    diagnostics: string[],
+    commitSha: string,
+  ): DocResult {
+    return {
+      slug:        doc.slug,
+      title:       doc.title,
+      parent:      doc.parent,
+      sourceUrl:   doc.sourceUrl,
+      healthScore: 0,
+      status:      'critical',
+      issues:      [],
       positives,
       relatedCode,
       diagnostics,


### PR DESCRIPTION
## Summary

When the validator's Pass 1 LLM call fails (missing/invalid API key, network error, rate-limit, malformed response, or — in multi-sample mode — every sample throwing), the resulting `DocResult` was defaulting to `status: 'healthy'` / `healthScore: 100` because `scoreDoc([])` deterministically returns healthy for an empty issue array. The dashboard then rendered all-green despite zero successful LLM calls.

This PR introduces a dedicated `buildFailureDocResult` helper that bypasses `scoreDoc` for the analytic-failure path and forces `status: 'critical'` with `healthScore: 0`, while preserving the existing `diagnostics` entries that surface the failure cause. The clean-doc path (Pass 1 succeeded with zero issues) still flows through `buildDocResult` and remains `healthy/100`, so `scoreDoc`'s `[] → healthy/100` contract is unchanged.

Closes #49

## Changes

- `src/adapters/validator/claude.ts` — new `buildFailureDocResult` helper; the single-sample Pass-1 catch and the multi-sample "every sample failed" branch both call it instead of `buildDocResult`.
- `src/adapters/validator/__tests__/claude.test.ts` — three new tests pinning the contract: single-sample throw → critical/0; every multi-sample throw → critical/0 with per-sample diagnostics; clean doc with zero issues stays healthy/100.

## How to test

1. `git fetch origin && git checkout ralph/49-validator-pass1-fail-critical`
2. `npm install`
3. `npm test` — should be green; the three new tests under `ClaudeValidator — Pass 1 failure status (issue #49)` pin the new behaviour.
4. `npm run typecheck` — clean.
5. Sanity-check the diff scope:
   - `git log -p -1 src/adapters/validator/claude.ts` — confirm only the two catch-paths now call `buildFailureDocResult`, and the new helper is the only addition.
   - `git diff main..HEAD -- src/health-scorer.ts src/types/` — should be empty (the `scoreDoc` contract and locked schemas are untouched).
6. Optional manual check: temporarily set `ANTHROPIC_API_KEY` to an obviously invalid value and run `npm run analyze -- ...` against any config — every doc should report `status: 'critical'` with a `Pass 1 failed: ...` diagnostic, instead of the previous all-green output. (Skip if you don't have a sandbox config wired up; the new tests are the load-bearing verification.)

Expected outcome: `npm test` and `npm run typecheck` both pass, the new tests are visible in the test output, and a forced Pass-1 failure no longer silently scores docs as healthy.

## Out of scope

The reviewer should confirm these were NOT touched by this PR:

- `src/health-scorer.ts` — the empty-issues → healthy/100 contract on `scoreDoc` is preserved; the analytic-failure logic lives in the validator, upstream of `scoreDoc`.
- `src/types/` — locked Zod contracts; `DocResult.status` already permits `'critical'`, no schema change required.
- Pass 2 partial-failure handling — already correct (drops a single unverifiable candidate when Pass 1 succeeded).
- Dashboard UI changes — surfacing diagnostics-as-status-downgrade in the frontend is a separate concern; this PR fixes the upstream `DocResult` shape so any existing `status: 'critical'` rendering will now light up correctly.
- Retry-on-transient-failure logic — explicit failure is a strict improvement over silent green; retry can be a follow-up.

## Path-gate note

This PR touches `src/adapters/validator/claude.ts`, which is outside the Ralph path-gate allowlist in `.github/workflows/path-gate.yml`. The path-gate check is **expected to fail** for this branch — that is the by-design routing for validator-core changes, and the Agent Brief on issue #49 explicitly calls this out. Please admin-merge once `ci` is green and the diff has been reviewed; do not widen `ALLOWLIST_PATTERN` to land this.
