### PR TITLE
RALPH: auto-map respects docSource.ignore + --all batch mode (#94)

### DIFF
--- a/scripts/auto-map.ts
+++ b/scripts/auto-map.ts
@@ -4,26 +4,37 @@
  *
  * Usage:
  *   npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank] [--explain]
+ *   npx tsx scripts/auto-map.ts --all  [--config <path>] [--no-rerank] [--force]
  *
- * Builds a symbol index of all configured repos (cached by commit SHA),
- * cross-references the symbols named in the doc, and proposes a CodeTiers
- * mapping ranked by symbol coverage. By default, the lexical top-N is then
- * passed to an AI re-ranker that re-orders the candidates by semantic
- * judgment and drops coincidental matches; `--no-rerank` skips this step
- * and reproduces the pre-rerank lexical-only output.
+ * Single-slug mode: maps one slug to a CodeTiers entry. Refuses ignored slugs
+ * (those matched by `config.docSource.ignore`) with a clear error — the
+ * validator would never consult such an entry at runtime, so creating one is
+ * dead weight.
+ *
+ * Batch mode (`--all`): iterates every in-scope, non-ignored manifest entry
+ * (same `parent === parentSlug` filter and `isIgnored` predicate the adapter
+ * uses at runtime), maps each to a CodeTiers entry, and writes them all to
+ * `config.mappingPath`. Resumable by default — slugs already keyed in the
+ * mapping file are skipped (use `--force` to re-map regardless).
  *
  * Flags:
  *   --config <path>      Config file (default: config/gutenberg-block-api.json)
  *   --write              Write the canonical mapping AND the audit file (when re-rank ran)
  *   --no-rerank          Skip the AI re-ranker (lexical-only output, no audit)
  *   --explain            Print rationale per kept file and reason per dropped file to stdout
+ *   --all                Batch mode (implicit --write)
+ *   --force              In --all mode, re-map every slug even if already in the mapping file
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import Anthropic from '@anthropic-ai/sdk';
 import { loadConfig } from '../src/config/loader.js';
 import { createCodeSources } from '../src/adapters/index.js';
-import { ManifestEntrySchema } from '../src/types/mapping.js';
+import {
+  ManifestEntrySchema,
+  type ManifestEntry,
+  type CodeTiers,
+} from '../src/types/mapping.js';
 import { extractDocSymbols } from '../src/adapters/validator/context-assembler.js';
 import {
   buildSymbolIndex,
@@ -35,22 +46,24 @@ import { RerankCache } from '../src/auto-map/rerank-cache.js';
 import { buildTiersForSlug, auditPathFor } from '../src/auto-map/orchestrator.js';
 import { AuditWriter } from '../src/auto-map/audit-writer.js';
 import { parseArgs } from '../src/auto-map/parse-args.js';
+import {
+  buildSlugToParent,
+  checkIgnored,
+  formatIgnoreRefusal,
+} from '../src/auto-map/ignore-filter.js';
+import { planBatch, type BatchPlanItem } from '../src/auto-map/batch.js';
+import type { Config } from '../src/config/schema.js';
 
 export { parseArgs };
 
-async function main() {
-  const { slug, configPath, write, rerank, explain } = parseArgs(process.argv);
-  const config = await loadConfig(configPath);
-
-  // 1. Fetch manifest and locate the entry for this slug
+async function fetchManifestEntries(config: Config): Promise<ManifestEntry[]> {
   const manifestRes = await fetch(config.docSource.manifestUrl);
   if (!manifestRes.ok) {
     console.error(`Failed to fetch manifest: HTTP ${manifestRes.status}`);
     process.exit(1);
   }
-
   const rawEntries = (await manifestRes.json()) as unknown[];
-  const resolvedEntries = rawEntries.flatMap((raw: unknown) => {
+  return rawEntries.flatMap((raw: unknown) => {
     if (typeof raw !== 'object' || raw === null) return [];
     const entry = raw as Record<string, unknown>;
     if (typeof entry.markdown_source === 'string') {
@@ -62,29 +75,12 @@ async function main() {
     const parsed = ManifestEntrySchema.safeParse(entry);
     return parsed.success ? [parsed.data] : [];
   });
+}
 
-  const entry = resolvedEntries.find(e => e.slug === slug);
-  if (!entry) {
-    console.error(
-      `Slug "${slug}" not found. Available: ${resolvedEntries.map(e => e.slug).join(', ')}`,
-    );
-    process.exit(1);
-  }
-
-  // 2. Fetch doc content and extract referenced symbols
-  const docRes = await fetch(entry.markdown_source);
-  if (!docRes.ok) {
-    console.error(`Failed to fetch doc: HTTP ${docRes.status}`);
-    process.exit(1);
-  }
-  const docContent = await docRes.text();
-  const docSymbols = extractDocSymbols(docContent);
-
-  console.error(
-    `Found ${docSymbols.length} symbols in doc: ${docSymbols.slice(0, 10).join(', ')}${docSymbols.length > 10 ? '...' : ''}`,
-  );
-
-  // 3. Build symbol indexes for all configured repos (cached by commit SHA)
+async function buildIndexes(config: Config): Promise<{
+  indexes:        Record<string, SymbolIndex>;
+  allFilesByRepo: Record<string, string[]>;
+}> {
   const codeSources = createCodeSources(config);
   const indexes: Record<string, SymbolIndex> = {};
   const allFilesByRepo: Record<string, string[]> = {};
@@ -106,8 +102,54 @@ async function main() {
     process.stderr.write('done\n');
     allFilesByRepo[repoId] = indexes[repoId].files;
   }
+  return { indexes, allFilesByRepo };
+}
 
-  // 4. Score all files by how many doc symbols they define or fire
+function readExistingMapping(mappingPath: string): Record<string, unknown> {
+  if (!existsSync(mappingPath)) return {};
+  const parsed = JSON.parse(readFileSync(mappingPath, 'utf-8'));
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    return parsed as Record<string, unknown>;
+  }
+  return {};
+}
+
+function writeMappingEntry(mappingPath: string, slug: string, tiers: CodeTiers): void {
+  const existing = readExistingMapping(mappingPath);
+  const merged: Record<string, unknown> = { ...existing, [slug]: tiers };
+  writeFileSync(mappingPath, JSON.stringify(merged, null, 2) + '\n');
+}
+
+type ProcessSlugOptions = {
+  entry:          ManifestEntry;
+  indexes:        Record<string, SymbolIndex>;
+  allFilesByRepo: Record<string, string[]>;
+  reranker:       Reranker | null;
+  cache:          RerankCache | null;
+  write:          boolean;
+  explain:        boolean;
+  mappingPath:    string;
+  auditWriter:    AuditWriter;
+  emitJson:       boolean;  // single-slug mode prints the JSON to stdout; batch mode does not
+};
+
+async function processSlug(opts: ProcessSlugOptions): Promise<void> {
+  const { entry, indexes, allFilesByRepo, reranker, cache, write, explain, mappingPath, auditWriter, emitJson } = opts;
+
+  // 1. Fetch doc content and extract referenced symbols
+  const docRes = await fetch(entry.markdown_source);
+  if (!docRes.ok) {
+    console.error(`Failed to fetch doc for "${entry.slug}": HTTP ${docRes.status}`);
+    return;
+  }
+  const docContent = await docRes.text();
+  const docSymbols = extractDocSymbols(docContent);
+
+  console.error(
+    `Found ${docSymbols.length} symbols in doc: ${docSymbols.slice(0, 10).join(', ')}${docSymbols.length > 10 ? '...' : ''}`,
+  );
+
+  // 2. Score all files by how many doc symbols they define or fire
   const scored = scoreFilesAcrossRepos(docSymbols, indexes);
 
   console.error('\nTop matches by symbol coverage (IDF-weighted, file-weighted):');
@@ -117,48 +159,24 @@ async function main() {
     ),
   );
 
-  // 5. Re-rank (optional) and assemble tiers.
-  //
-  // Default: AI re-ranker re-orders candidates by semantic judgment and
-  // drops coincidental matches (single-token English-word collisions,
-  // cross-schema property collisions). On API error / malformed output
-  // / missing API key, the Reranker emits a stderr warning and the
-  // orchestrator falls back to lexical-only output.
-  //
-  // `--no-rerank` skips the AI step entirely. Output is bit-identical to
-  // the pre-rerank lexical-only path.
-  let reranker: Reranker | null = null;
-  if (rerank) {
-    try {
-      reranker = new Reranker(config.validator.rerankModel ?? config.validator.pass1Model, new Anthropic());
-    } catch (err) {
-      console.error(`AI re-rank failed: ${err instanceof Error ? err.message : String(err)}`);
-      reranker = null;
-    }
-  }
-
-  // Cache is always on when re-rank is on (no `--no-cache` flag — cost is
-  // negligible and identical re-runs should be free + bit-identical).
-  const cache = reranker ? new RerankCache() : null;
-
+  // 3. Build tiers (with optional re-rank).
   const { tiers, rerankResult } = await buildTiersForSlug({
     docContent,
-    slug,
+    slug:    entry.slug,
     scored,
     allFilesByRepo,
     reranker,
     cache,
   });
 
-  // 6. Output as JSON
-  const output = { [slug]: tiers };
-  console.log(JSON.stringify(output, null, 2));
+  // 4. Output as JSON (single-slug mode; batch mode suppresses stdout JSON
+  // because the operator wants the mapping file, not 150 JSON blobs on stdout)
+  if (emitJson) {
+    const output = { [entry.slug]: tiers };
+    console.log(JSON.stringify(output, null, 2));
+  }
 
-  // 7. --explain: render rationale per kept file and reason per dropped file.
-  // Has no effect under --no-rerank or when the AI step failed (no audit
-  // material). The Reranker has already emitted a stderr warning in those
-  // cases.
-  const auditWriter = new AuditWriter();
+  // 5. --explain
   if (explain) {
     if (rerankResult) {
       console.log('\n' + auditWriter.formatExplain(rerankResult));
@@ -169,28 +187,176 @@ async function main() {
     }
   }
 
+  // 6. Write mapping + audit
   if (write) {
-    let existingRaw: Record<string, unknown> = {};
-    if (existsSync(config.mappingPath)) {
-      const parsed = JSON.parse(readFileSync(config.mappingPath, 'utf-8'));
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        existingRaw = parsed as Record<string, unknown>;
-      }
-    }
-
-    const merged: Record<string, unknown> = { ...existingRaw, [slug]: tiers };
-    writeFileSync(config.mappingPath, JSON.stringify(merged, null, 2) + '\n');
-    console.error(`\nWrote mapping for "${slug}" to ${config.mappingPath}`);
+    writeMappingEntry(mappingPath, entry.slug, tiers);
+    console.error(`Wrote mapping for "${entry.slug}" to ${mappingPath}`);
 
     if (rerankResult) {
-      const auditPath = auditPathFor(config.mappingPath);
-      auditWriter.writeAudit(auditPath, slug, rerankResult);
-      console.error(`Wrote audit for "${slug}" to ${auditPath}`);
+      const auditPath = auditPathFor(mappingPath);
+      auditWriter.writeAudit(auditPath, entry.slug, rerankResult);
+      console.error(`Wrote audit for "${entry.slug}" to ${auditPath}`);
     }
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const config = await loadConfig(args.configPath);
+
+  // 1. Fetch manifest once (shared by single-slug and batch).
+  const resolvedEntries = await fetchManifestEntries(config);
+  const slugToParent = buildSlugToParent(resolvedEntries);
+
+  // 2. Set up reranker + cache (shared across iterations in batch mode).
+  //
+  // Default: AI re-ranker re-orders candidates by semantic judgment and
+  // drops coincidental matches (single-token English-word collisions,
+  // cross-schema property collisions). On API error / malformed output
+  // / missing API key, the Reranker emits a stderr warning and the
+  // orchestrator falls back to lexical-only output.
+  let reranker: Reranker | null = null;
+  if (args.rerank) {
+    try {
+      reranker = new Reranker(config.validator.rerankModel ?? config.validator.pass1Model, new Anthropic());
+    } catch (err) {
+      console.error(`AI re-rank failed: ${err instanceof Error ? err.message : String(err)}`);
+      reranker = null;
+    }
+  }
+  const cache = reranker ? new RerankCache() : null;
+  const auditWriter = new AuditWriter();
+
+  if (args.all) {
+    await runBatch({ args, config, resolvedEntries, reranker, cache, auditWriter });
   } else {
+    await runSingleSlug({
+      args,
+      config,
+      resolvedEntries,
+      slugToParent,
+      reranker,
+      cache,
+      auditWriter,
+    });
+  }
+}
+
+async function runSingleSlug(opts: {
+  args:             ReturnType<typeof parseArgs>;
+  config:           Config;
+  resolvedEntries:  ManifestEntry[];
+  slugToParent:     Map<string, string | null>;
+  reranker:         Reranker | null;
+  cache:            RerankCache | null;
+  auditWriter:      AuditWriter;
+}): Promise<void> {
+  const { args, config, resolvedEntries, slugToParent, reranker, cache, auditWriter } = opts;
+
+  // Refuse ignored slugs early — the validator would never consult the entry
+  // we'd generate, so emitting one silently masks the operator's `ignore`
+  // declaration.
+  const ignoreMatch = checkIgnored(args.slug, slugToParent, config.docSource.ignore);
+  if (ignoreMatch.matched) {
+    console.error(formatIgnoreRefusal(args.slug, args.configPath, ignoreMatch));
+    process.exit(1);
+  }
+
+  const entry = resolvedEntries.find(e => e.slug === args.slug);
+  if (!entry) {
+    console.error(
+      `Slug "${args.slug}" not found. Available: ${resolvedEntries.map(e => e.slug).join(', ')}`,
+    );
+    process.exit(1);
+  }
+
+  const { indexes, allFilesByRepo } = await buildIndexes(config);
+
+  await processSlug({
+    entry,
+    indexes,
+    allFilesByRepo,
+    reranker,
+    cache,
+    write:       args.write,
+    explain:     args.explain,
+    mappingPath: config.mappingPath,
+    auditWriter,
+    emitJson:    true,
+  });
+
+  if (!args.write) {
     console.error(
       `\nReview the above and merge into ${config.mappingPath}, or re-run with --write`,
     );
+  }
+}
+
+async function runBatch(opts: {
+  args:            ReturnType<typeof parseArgs>;
+  config:          Config;
+  resolvedEntries: ManifestEntry[];
+  reranker:        Reranker | null;
+  cache:           RerankCache | null;
+  auditWriter:     AuditWriter;
+}): Promise<void> {
+  const { args, config, resolvedEntries, reranker, cache, auditWriter } = opts;
+
+  const existing = readExistingMapping(config.mappingPath);
+  const existingSlugs = new Set(Object.keys(existing));
+
+  const plan: BatchPlanItem[] = planBatch({
+    entries:       resolvedEntries,
+    parentSlug:    config.docSource.parentSlug,
+    ignore:        config.docSource.ignore,
+    existingSlugs,
+    force:         args.force,
+  });
+  const total = plan.length;
+
+  if (total === 0) {
+    console.error('No in-scope, non-ignored manifest entries to map.');
+    return;
+  }
+
+  console.error(`Found ${total} in-scope, non-ignored slug(s) to process.`);
+
+  // Build symbol indexes once — buildSymbolIndex caches by commit SHA, so
+  // multi-slug iteration reuses the index across calls.
+  const { indexes, allFilesByRepo } = await buildIndexes(config);
+
+  const byMappingSlug = new Map(resolvedEntries.map(e => [e.slug, e]));
+
+  let i = 0;
+  for (const item of plan) {
+    i++;
+    if (item.action === 'skip-already-mapped') {
+      process.stderr.write(
+        `[${i}/${total}] skipping "${item.slug}" (already mapped; use --force to re-map)\n`,
+      );
+      continue;
+    }
+    process.stderr.write(`[${i}/${total}] mapping "${item.slug}"...\n`);
+
+    const entry = byMappingSlug.get(item.slug);
+    if (!entry) {
+      // Should not happen — planBatch derives from resolvedEntries.
+      console.error(`  internal error: slug "${item.slug}" not found in manifest`);
+      continue;
+    }
+
+    await processSlug({
+      entry,
+      indexes,
+      allFilesByRepo,
+      reranker,
+      cache,
+      write:       true,  // --all implies --write
+      explain:     args.explain,
+      mappingPath: config.mappingPath,
+      auditWriter,
+      emitJson:    false,
+    });
   }
 }
 

--- a/src/auto-map/__tests__/batch.test.ts
+++ b/src/auto-map/__tests__/batch.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+
+import { planBatch } from '../batch.js';
+import { buildSlugToParent, checkIgnored } from '../ignore-filter.js';
+import type { ManifestEntry } from '../../types/mapping.js';
+
+// Compact constructor so test bodies focus on slug/parent semantics.
+function entries(...rows: Array<[slug: string, parent: string | null]>): ManifestEntry[] {
+  return rows.map(([slug, parent]) => ({
+    slug,
+    title:           slug,
+    markdown_source: `https://example.com/${slug}.md`,
+    parent,
+  }));
+}
+
+describe('planBatch — drives `auto-map.ts --all` iteration', () => {
+  const MANIFEST = entries(
+    ['block-api',        null],
+    ['block-attributes', 'block-api'],
+    ['block-bindings',   'block-api'],
+    ['block-metadata',   'block-api'],
+    // Out-of-scope: not under parentSlug
+    ['some-other-area',  null],
+    ['inner-other',      'some-other-area'],
+    // Under parentSlug but explicitly ignored
+    ['contributors',     'block-api'],
+    // Under a subtree root — both root and descendant should be excluded under subtrees
+    ['packages',         'block-api'],
+    ['packages-blocks',  'packages'],
+  );
+
+  it('iterates only in-scope (parent === parentSlug), non-ignored entries — preserves manifest order', () => {
+    const plan = planBatch({
+      entries:    MANIFEST,
+      parentSlug: 'block-api',
+      ignore:     { slugs: ['contributors'], subtrees: ['packages'] },
+      existingSlugs: new Set(),
+      force:      false,
+    });
+    // Out-of-scope `some-other-area` and `inner-other` excluded.
+    // Ignored `contributors`, `packages`, and the descendant `packages-blocks` excluded.
+    expect(plan.map(p => p.slug)).toEqual([
+      'block-attributes',
+      'block-bindings',
+      'block-metadata',
+    ]);
+    // `packages-blocks` has parent `packages` (not `block-api`) so it was never
+    // in scope anyway — but pin the principle: ignore.subtrees excludes the
+    // root AND the descendant chain even when a descendant *would* otherwise
+    // be eligible.
+    const planNoIgnore = planBatch({
+      entries:    MANIFEST,
+      parentSlug: 'packages',
+      ignore:     { subtrees: ['packages'] },
+      existingSlugs: new Set(),
+      force:      false,
+    });
+    expect(planNoIgnore.map(p => p.slug)).toEqual([]); // packages-blocks excluded
+  });
+
+  it('skips slugs already in the mapping file by default', () => {
+    const plan = planBatch({
+      entries:    MANIFEST,
+      parentSlug: 'block-api',
+      ignore:     { slugs: ['contributors'], subtrees: ['packages'] },
+      existingSlugs: new Set(['block-attributes']),
+      force:      false,
+    });
+    const byAction = (a: string) => plan.filter(p => p.action === a).map(p => p.slug);
+    expect(byAction('map')).toEqual(['block-bindings', 'block-metadata']);
+    expect(byAction('skip-already-mapped')).toEqual(['block-attributes']);
+  });
+
+  it('with --force re-maps every in-scope, non-ignored slug regardless of existing entries', () => {
+    const plan = planBatch({
+      entries:    MANIFEST,
+      parentSlug: 'block-api',
+      ignore:     { slugs: ['contributors'], subtrees: ['packages'] },
+      existingSlugs: new Set(['block-attributes', 'block-bindings', 'block-metadata']),
+      force:      true,
+    });
+    // Every plan item is `map` — none skipped.
+    expect(plan.every(p => p.action === 'map')).toBe(true);
+    expect(plan.map(p => p.slug)).toEqual([
+      'block-attributes',
+      'block-bindings',
+      'block-metadata',
+    ]);
+  });
+
+  it('plan length reflects total in-scope non-ignored slugs (the `[N/total]` denominator)', () => {
+    // PRD: progress counter [N/total] reflects total in-scope, non-ignored slugs
+    // (not raw manifest length). plan.length is what the script uses.
+    const plan = planBatch({
+      entries:    MANIFEST,
+      parentSlug: 'block-api',
+      ignore:     { slugs: ['contributors'], subtrees: ['packages'] },
+      existingSlugs: new Set(['block-attributes']),
+      force:      false,
+    });
+    // total = 3 (in-scope non-ignored), NOT 9 (raw manifest), NOT 4 (raw in-scope before ignore).
+    expect(plan.length).toBe(3);
+    expect(plan.length).not.toBe(MANIFEST.length);
+  });
+
+  it('contrast: same ignored slug → batch silently filters, single-slug would refuse', () => {
+    // PRD #94 specifically calls for a test pinning this asymmetry so a future
+    // refactor cannot accidentally collapse the two paths into one behavior.
+    // - Batch mode: ignored slugs vanish from the plan with no error (the
+    //   operator wants to iterate everything that's still in scope; the
+    //   ignored entries are simply not in scope).
+    // - Single-slug mode: ignored slug → checkIgnored returns matched=true,
+    //   which the script translates into an exit-1 refusal so the operator
+    //   notices they asked for something out of scope.
+    const planResult = planBatch({
+      entries:       MANIFEST,
+      parentSlug:    'block-api',
+      ignore:        { slugs: ['contributors'] },
+      existingSlugs: new Set(),
+      force:         false,
+    });
+    expect(planResult.map(p => p.slug)).not.toContain('contributors'); // silent in batch
+
+    const slugToParent = buildSlugToParent(MANIFEST);
+    const singleSlugCheck = checkIgnored('contributors', slugToParent, { slugs: ['contributors'] });
+    expect(singleSlugCheck).toEqual({                                  // refusal in single-slug
+      matched:   true,
+      rule:      'slugs',
+      matchedAt: 'contributors',
+    });
+  });
+
+  it('omitted ignore yields all in-scope entries (predicate is opt-in)', () => {
+    const plan = planBatch({
+      entries:    MANIFEST,
+      parentSlug: 'block-api',
+      existingSlugs: new Set(),
+      force:      false,
+    });
+    // Every direct child of block-api is mapped — contributors and packages too.
+    expect(plan.map(p => p.slug)).toEqual([
+      'block-attributes',
+      'block-bindings',
+      'block-metadata',
+      'contributors',
+      'packages',
+    ]);
+  });
+});

--- a/src/auto-map/__tests__/ignore-filter.test.ts
+++ b/src/auto-map/__tests__/ignore-filter.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  buildSlugToParent,
+  checkIgnored,
+  formatIgnoreRefusal,
+  isIgnored,
+} from '../ignore-filter.js';
+import type { ManifestEntry } from '../../types/mapping.js';
+
+// Mirrors the shape (slug → parent) the adapter constructs, so the predicate
+// here is tested against the same data the adapter sees at runtime.
+function entries(...rows: Array<[slug: string, parent: string | null]>): ManifestEntry[] {
+  return rows.map(([slug, parent]) => ({
+    slug,
+    title:           slug,
+    markdown_source: `https://example.com/${slug}.md`,
+    parent,
+  }));
+}
+
+describe('isIgnored', () => {
+  it('returns false when no ignore config is provided (predicate is opt-in)', () => {
+    const m = buildSlugToParent(entries(['block-api', null], ['block-attributes', 'block-api']));
+    expect(isIgnored('block-attributes', m)).toBe(false);
+  });
+
+  it('returns false when ignore is provided but empty', () => {
+    const m = buildSlugToParent(entries(['block-api', null], ['block-attributes', 'block-api']));
+    expect(isIgnored('block-attributes', m, { slugs: [], subtrees: [] })).toBe(false);
+  });
+
+  it('matches a slug listed in ignore.slugs (and only that slug, not descendants)', () => {
+    const m = buildSlugToParent(entries(
+      ['reference-guides', null],
+      ['packages',         'reference-guides'],
+      ['packages-blocks',  'packages'],   // descendant of packages
+    ));
+    // packages itself: matched
+    expect(isIgnored('packages', m, { slugs: ['packages'] })).toBe(true);
+    // descendant: NOT matched under `slugs` (only `subtrees` is transitive)
+    expect(isIgnored('packages-blocks', m, { slugs: ['packages'] })).toBe(false);
+  });
+
+  it('matches the named root AND all transitive descendants under ignore.subtrees', () => {
+    const m = buildSlugToParent(entries(
+      ['reference-guides', null],
+      ['packages',         'reference-guides'],
+      ['packages-blocks',  'packages'],
+      ['packages-blocks-api-registration', 'packages-blocks'],
+      ['unrelated',        'reference-guides'],
+    ));
+    expect(isIgnored('packages',                          m, { subtrees: ['packages'] })).toBe(true);
+    expect(isIgnored('packages-blocks',                   m, { subtrees: ['packages'] })).toBe(true);
+    expect(isIgnored('packages-blocks-api-registration',  m, { subtrees: ['packages'] })).toBe(true);
+    expect(isIgnored('reference-guides',                  m, { subtrees: ['packages'] })).toBe(false);
+    expect(isIgnored('unrelated',                         m, { subtrees: ['packages'] })).toBe(false);
+  });
+
+  it('terminates on a cycle in the parent map (cycle guard)', () => {
+    // a → b → c → a (synthetic; should never occur in real manifests).
+    const m = new Map<string, string | null>([
+      ['a', 'b'],
+      ['b', 'c'],
+      ['c', 'a'],
+    ]);
+    // None of a/b/c are ignore roots — predicate must return false, not loop forever.
+    expect(isIgnored('a', m, { subtrees: ['z'] })).toBe(false);
+    expect(isIgnored('b', m, { subtrees: ['z'] })).toBe(false);
+    // But a root anywhere in the cycle is still detected.
+    expect(isIgnored('a', m, { subtrees: ['c'] })).toBe(true);
+  });
+
+  it('walks ancestors only via the parent map; orphan slugs (unknown parent) are not ignored unless directly matched', () => {
+    const m = buildSlugToParent(entries(['orphan', null]));
+    expect(isIgnored('orphan',   m, { subtrees: ['ghost-root'] })).toBe(false);
+    expect(isIgnored('orphan',   m, { slugs:    ['orphan']     })).toBe(true);
+  });
+});
+
+describe('checkIgnored — reports which rule matched (used by the refusal message)', () => {
+  it('reports the matched slug-list rule', () => {
+    const m = buildSlugToParent(entries(['x', null]));
+    expect(checkIgnored('x', m, { slugs: ['x'] })).toEqual({
+      matched:   true,
+      rule:      'slugs',
+      matchedAt: 'x',
+    });
+  });
+
+  it('reports the matched subtree root (not the slug being checked)', () => {
+    const m = buildSlugToParent(entries(
+      ['root',  null],
+      ['child', 'root'],
+      ['grand', 'child'],
+    ));
+    expect(checkIgnored('grand', m, { subtrees: ['root'] })).toEqual({
+      matched:   true,
+      rule:      'subtrees',
+      matchedAt: 'root',
+    });
+  });
+
+  it('returns matched=false when no rule fires', () => {
+    const m = buildSlugToParent(entries(['x', null]));
+    expect(checkIgnored('x', m, { slugs: ['y'], subtrees: ['z'] })).toEqual({ matched: false });
+  });
+});
+
+describe('formatIgnoreRefusal — human-readable error for single-slug mode', () => {
+  it('names the rule and the matched slug/subtree', () => {
+    const out = formatIgnoreRefusal('packages-blocks', '/cfg/site.json', {
+      matched:   true,
+      rule:      'subtrees',
+      matchedAt: 'packages',
+    });
+    expect(out).toContain('packages-blocks');
+    expect(out).toContain('ignore.subtrees');
+    expect(out).toContain('"packages"');
+    expect(out).toContain('/cfg/site.json');
+    expect(out).toMatch(/Refusing to generate a mapping/i);
+  });
+
+  it('distinguishes the slugs rule from the subtrees rule in the message', () => {
+    const slugRule    = formatIgnoreRefusal('x', '/cfg.json', { matched: true, rule: 'slugs',    matchedAt: 'x' });
+    const subtreeRule = formatIgnoreRefusal('x', '/cfg.json', { matched: true, rule: 'subtrees', matchedAt: 'x' });
+    expect(slugRule).toContain('ignore.slugs');
+    expect(slugRule).not.toContain('ignore.subtrees:');
+    expect(subtreeRule).toContain('ignore.subtrees');
+    expect(subtreeRule).not.toContain('ignore.slugs:');
+  });
+});

--- a/src/auto-map/__tests__/parse-args.test.ts
+++ b/src/auto-map/__tests__/parse-args.test.ts
@@ -15,6 +15,8 @@ describe('parseArgs', () => {
   it('parses slug + defaults', () => {
     const args = parseArgs(argv('block-metadata'));
     expect(args.slug).toBe('block-metadata');
+    expect(args.all).toBe(false);
+    expect(args.force).toBe(false);
     expect(args.write).toBe(false);
     expect(args.rerank).toBe(true);
     expect(args.explain).toBe(false);
@@ -39,5 +41,56 @@ describe('parseArgs', () => {
     expect(beforeSlug.write).toBe(true);
     expect(afterSlug.slug).toBe('block-metadata');
     expect(afterSlug.write).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Batch mode (--all) — #94
+  // ---------------------------------------------------------------------------
+
+  it('parses --all and implies --write (opting out of write makes batch mode useless)', () => {
+    const args = parseArgs(argv('--all'));
+    expect(args.all).toBe(true);
+    expect(args.write).toBe(true);
+    expect(args.slug).toBe('');
+    expect(args.force).toBe(false);
+  });
+
+  it('parses --all --force', () => {
+    const args = parseArgs(argv('--all', '--force'));
+    expect(args.all).toBe(true);
+    expect(args.force).toBe(true);
+  });
+
+  it('--all + --no-rerank is a valid combination (cheap lexical-only batch)', () => {
+    const args = parseArgs(argv('--all', '--no-rerank'));
+    expect(args.all).toBe(true);
+    expect(args.rerank).toBe(false);
+    expect(args.write).toBe(true); // --all still implies --write
+  });
+
+  it('rejects combining <slug> with --all (mutually exclusive)', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => parseArgs(argv('block-metadata', '--all'))).toThrow(/exit:1/);
+    const allErr = errSpy.mock.calls.flat().join('\n');
+    expect(allErr).toMatch(/cannot combine|mutually exclusive|both/i);
+
+    exitSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it('rejects no slug and no --all (usage error)', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => parseArgs(argv())).toThrow(/exit:1/);
+
+    exitSpy.mockRestore();
+    errSpy.mockRestore();
   });
 });

--- a/src/auto-map/batch.ts
+++ b/src/auto-map/batch.ts
@@ -1,0 +1,49 @@
+/**
+ * Batch-mode planning for `auto-map.ts --all`.
+ *
+ * Pure logic — no I/O, no LLM calls. Given a manifest, the configured
+ * parentSlug, the ignore config, and the set of slugs already in the mapping
+ * file, returns an ordered plan saying which slugs to map and which to skip.
+ *
+ * The script consumes the plan to drive iteration, progress output, and the
+ * resume-by-default behaviour (skip-already-mapped unless --force).
+ */
+import type { ManifestEntry } from '../types/mapping.js';
+import { buildSlugToParent, isIgnored, type IgnoreConfig } from './ignore-filter.js';
+
+export interface BatchPlanItem {
+  slug:   string;
+  action: 'map' | 'skip-already-mapped';
+}
+
+export interface PlanBatchOptions {
+  entries:       ManifestEntry[];
+  parentSlug:    string;
+  ignore?:       IgnoreConfig;
+  existingSlugs: Set<string>;
+  force:         boolean;
+}
+
+/**
+ * Produce an ordered list of slugs to process in `--all` mode.
+ *
+ * Filtering applied (in order):
+ *  1. `parent === parentSlug` (same in-scope predicate the adapter uses).
+ *  2. Drop ignored entries via the shared `isIgnored` predicate.
+ *
+ * The returned length is the denominator of the `[N/total]` progress counter;
+ * the counter must NOT use the raw manifest length, otherwise out-of-scope
+ * entries inflate the total.
+ */
+export function planBatch(opts: PlanBatchOptions): BatchPlanItem[] {
+  const slugToParent = buildSlugToParent(opts.entries);
+  const inScope = opts.entries.filter(e =>
+    e.parent === opts.parentSlug && !isIgnored(e.slug, slugToParent, opts.ignore),
+  );
+  return inScope.map(e => ({
+    slug:   e.slug,
+    action: !opts.force && opts.existingSlugs.has(e.slug)
+      ? 'skip-already-mapped'
+      : 'map',
+  }));
+}

--- a/src/auto-map/ignore-filter.ts
+++ b/src/auto-map/ignore-filter.ts
@@ -1,0 +1,84 @@
+/**
+ * Manifest-entry ignore predicate.
+ *
+ * Mirrors `ManifestUrlDocSource.fetchDocs()`'s inline ignore logic so the
+ * auto-map bootstrap (`scripts/auto-map.ts`) refuses ignored slugs in
+ * single-slug mode and skips them in batch mode — keeping the mapping file
+ * aligned with what the validator runtime will actually consult.
+ *
+ * The adapter retains its own inline copy for now; deduplicating that is a
+ * follow-up that crosses the Ralph path-gate allowlist (see issue #94's
+ * Out of Scope).
+ */
+import type { ManifestEntry } from '../types/mapping.js';
+
+export interface IgnoreConfig {
+  slugs?:    string[];
+  subtrees?: string[];
+}
+
+export type IgnoreResult =
+  | { matched: true; rule: 'slugs' | 'subtrees'; matchedAt: string }
+  | { matched: false };
+
+export function buildSlugToParent(entries: ManifestEntry[]): Map<string, string | null> {
+  return new Map(entries.map(e => [e.slug, e.parent]));
+}
+
+/**
+ * Reports whether a slug should be dropped, and if so, which rule fired and
+ * which slug/subtree-root triggered the match.
+ *
+ * Semantics mirror the adapter exactly:
+ *  - Early O(1) exit on `ignoredSlugs.has(slug)`.
+ *  - Otherwise walk the ancestor chain starting at the slug itself (so
+ *    `subtrees: [X]` drops X too, not only its descendants).
+ *  - `seen` set guards against cyclic parent pointers.
+ *  - Walk halts on `null` parent (top-level entries).
+ */
+export function checkIgnored(
+  slug: string,
+  slugToParent: Map<string, string | null>,
+  ignore?: IgnoreConfig,
+): IgnoreResult {
+  const ignoredSlugs = new Set(ignore?.slugs    ?? []);
+  const ignoredRoots = new Set(ignore?.subtrees ?? []);
+  if (ignoredSlugs.has(slug)) return { matched: true, rule: 'slugs', matchedAt: slug };
+  let cursor: string | null = slug;
+  const seen = new Set<string>();
+  while (cursor !== null && !seen.has(cursor)) {
+    if (ignoredRoots.has(cursor)) {
+      return { matched: true, rule: 'subtrees', matchedAt: cursor };
+    }
+    seen.add(cursor);
+    cursor = slugToParent.get(cursor) ?? null;
+  }
+  return { matched: false };
+}
+
+export function isIgnored(
+  slug: string,
+  slugToParent: Map<string, string | null>,
+  ignore?: IgnoreConfig,
+): boolean {
+  return checkIgnored(slug, slugToParent, ignore).matched;
+}
+
+/**
+ * Render the user-facing refusal message for `auto-map.ts <slug>` when the
+ * requested slug is ignored. Names the matched rule (slugs vs subtrees) and
+ * the specific slug/root that triggered it, so the operator knows which
+ * entry to edit if the refusal is unintended.
+ */
+export function formatIgnoreRefusal(
+  slug: string,
+  configPath: string,
+  match: Extract<IgnoreResult, { matched: true }>,
+): string {
+  const ruleName = match.rule === 'slugs' ? 'ignore.slugs' : 'ignore.subtrees';
+  return [
+    `Slug "${slug}" is ignored by config (matched ${ruleName}: ["${match.matchedAt}"]).`,
+    'The validator will not see this doc. Refusing to generate a mapping.',
+    `Remove the slug from ignore.slugs / ignore.subtrees in ${configPath} if this is intentional.`,
+  ].join('\n');
+}

--- a/src/auto-map/parse-args.ts
+++ b/src/auto-map/parse-args.ts
@@ -6,16 +6,28 @@
 import { resolve } from 'path';
 
 export interface AutoMapArgs {
+  // Empty string when --all is set; populated otherwise.
   slug:       string;
+  // Batch mode: iterate every in-scope, non-ignored manifest entry.
+  all:        boolean;
+  // Batch mode: re-map every slug even if it's already in the mapping file.
+  force:      boolean;
   configPath: string;
   write:      boolean;
   rerank:     boolean;
   explain:    boolean;
 }
 
+const USAGE =
+  'Usage:\n' +
+  '  npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank] [--explain]\n' +
+  '  npx tsx scripts/auto-map.ts --all  [--config <path>] [--no-rerank] [--force]';
+
 export function parseArgs(argv: string[]): AutoMapArgs {
   const args = argv.slice(2);
   let slug = '';
+  let all = false;
+  let force = false;
   let configPath = resolve('config/gutenberg-block-api.json');
   let write = false;
   let rerank = true;
@@ -31,17 +43,28 @@ export function parseArgs(argv: string[]): AutoMapArgs {
       rerank = false;
     } else if (args[i] === '--explain') {
       explain = true;
+    } else if (args[i] === '--all') {
+      all = true;
+    } else if (args[i] === '--force') {
+      force = true;
     } else if (!slug && !args[i].startsWith('--')) {
       slug = args[i];
     }
   }
 
-  if (!slug) {
-    console.error(
-      'Usage: npx tsx scripts/auto-map.ts <slug> [--config <path>] [--write] [--no-rerank] [--explain]',
-    );
+  if (all && slug) {
+    console.error('Usage error: cannot combine <slug> with --all (mutually exclusive).');
+    console.error(USAGE);
+    process.exit(1);
+  }
+  if (!all && !slug) {
+    console.error(USAGE);
     process.exit(1);
   }
 
-  return { slug, configPath, write, rerank, explain };
+  // --all implies --write. Opting out of write makes batch mode useless;
+  // the operator's intent is unambiguous.
+  if (all) write = true;
+
+  return { slug, all, force, configPath, write, rerank, explain };
 }


### PR DESCRIPTION
## Summary

`scripts/auto-map.ts` now treats `config.docSource.ignore` as authoritative and supports batch generation of the full mapping file via `--all`.

- **Single-slug mode** refuses ignored slugs (matched by `ignore.slugs` or by an ancestor in `ignore.subtrees`) with an exit-1 error that names the matched rule and the offending slug/root — operators see *why* the script refused instead of silently producing dead mapping entries the validator runtime would ignore.
- **`--all` batch mode** iterates every in-scope (`parent === parentSlug`) non-ignored manifest entry through the existing single-slug orchestrator (symbol-index → score → re-rank → tiers). `--write` is implicit. Resumable by default — slugs already keyed in `config.mappingPath` are skipped (use `--force` to re-map). Progress goes to stderr as `[N/total] mapping "<slug>"...`, with `total` reflecting in-scope non-ignored slugs (not raw manifest length).
- Shared `isIgnored` predicate lives in `src/auto-map/ignore-filter.ts` so it's testable in isolation. The runtime adapter (`src/adapters/doc-source/manifest-url.ts`) keeps its inline copy unchanged — deduping crosses the path-gate allowlist and is flagged in the issue as an explicit follow-up.

Note: issue #94 carries no Agent Brief comment. This PR was driven directly from the issue body.

Closes #94

## Changes

- `src/auto-map/ignore-filter.ts` *(new)* — `checkIgnored` / `isIgnored` predicates mirroring the adapter's logic (early `slugs` exit, ancestor walk for `subtrees`, cycle guard). `formatIgnoreRefusal` renders the operator-facing single-slug error.
- `src/auto-map/batch.ts` *(new)* — pure `planBatch(...)` that returns the ordered `map` / `skip-already-mapped` plan. Drives the `[N/total]` counter and the resume-by-default behaviour.
- `src/auto-map/parse-args.ts` — adds `--all` and `--force`. `--all` implies `--write`. Slug + `--all` is a usage error; no slug and no `--all` is a usage error.
- `scripts/auto-map.ts` — factored into `runSingleSlug` / `runBatch`; shared `processSlug`, `buildIndexes`, `readExistingMapping`, `writeMappingEntry`, and `fetchManifestEntries` helpers. Symbol indexes are built once per run (the existing `buildSymbolIndex` SHA cache handles cross-slug reuse transparently). Reranker + cache are constructed once and shared across the batch loop.
- `src/auto-map/__tests__/ignore-filter.test.ts` *(new)* — table-driven tests of the predicate, including the cycle-guard and `slugs` vs `subtrees` rule distinction, plus the refusal-message formatter.
- `src/auto-map/__tests__/batch.test.ts` *(new)* — `planBatch` filters in-scope + non-ignored entries, skips already-mapped by default, re-maps under `--force`, exposes total as `plan.length`, and includes the PRD's contrast test pinning that batch silently filters where single-slug would refuse.
- `src/auto-map/__tests__/parse-args.test.ts` — adds `--all` / `--force` / mutual-exclusion / no-args tests; pins that `--all` implies `--write`.

## How to test

1. `git fetch origin && git checkout ralph/94-auto-map-ignore-and-all`
2. `npm install`
3. `npm test` — full suite (365 tests) passes, including the 22 new tests across `ignore-filter.test.ts`, `batch.test.ts`, and the additions to `parse-args.test.ts`.
4. `npm run typecheck` — clean.
5. Spot-check the targeted new tests:
   - `npx vitest run src/auto-map/__tests__/ignore-filter.test.ts`
   - `npx vitest run src/auto-map/__tests__/batch.test.ts`
   - `npx vitest run src/auto-map/__tests__/parse-args.test.ts`
6. Skim `scripts/auto-map.ts` and confirm:
   - `runSingleSlug` calls `checkIgnored(...)` before `find(...)` so a refusal beats a not-found error.
   - `runBatch` builds the plan via `planBatch(...)` (not by re-implementing the filter), constructs the reranker + cache once, and iterates with a `[i/total]` counter.
7. (Optional, network-dependent — needs `ANTHROPIC_API_KEY`.) Verify the CLI surface against the live Gutenberg manifest:
   - `npx tsx scripts/auto-map.ts contributors` → exit 1, stderr mentions `ignore.subtrees: ["contributors"]`.
   - `npx tsx scripts/auto-map.ts block-attributes --all` → usage error mentioning mutual exclusion.
   - `npx tsx scripts/auto-map.ts --all --no-rerank` → walks every in-scope non-ignored slug; entries already in `mappings/gutenberg-block-api.json` are skipped.

Expected outcome: the new tests document the contract; `npm test` + `npm run typecheck` green; the script gates ignored slugs and supports batch generation per the PRD.

## Out of scope

The PRD lists these explicitly; reviewer should confirm none are touched here:

- **Deduping the predicate.** `src/adapters/doc-source/manifest-url.ts` is untouched. The inline copy of the ignore logic remains; deduping requires a non-Ralph PR (the adapter path is outside the path-gate allowlist).
- **`parentSlug` descendant traversal.** Adapter still filters by direct parent only.
- **`--dry-run` for `--all`.** Not implemented; `--all` still implies `--write`.
- **Parallel slug processing in `--all`.** Loop is sequential.
- **Cost cap / `--cost-cap`.** Not implemented.
- **Pruning stale entries.** Slugs already in the mapping file that are now ignored stay in the file; this PR never deletes mapping entries.
